### PR TITLE
feat: run.sync_tensorboard()

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -24,6 +24,8 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Added support for gzip compression of filestream requests, reducing network traffic when logging metrics. It is currently opt-in and requires server support: set `x_file_stream_no_gzip=False` in `wandb.Settings` to enable it. Compression will become the default in a future release (@dmitryduev in https://github.com/wandb/wandb/pull/12262)
 - Added a `--term-timeout` flag to `wandb agent` (@nathancy-wandb in https://github.com/wandb/wandb/pull/12246)
 - Added `run.sync_dir` (@timoffex in https://github.com/wandb/wandb/pull/12319)
+- Added `run.sync_tensorboard()` (@timoffex in https://github.com/wandb/wandb/pull/12356)
+  - An alternative to `wandb.init(sync_tensorboard=True)` with more explicit behavior
 
 ## Changed
 

--- a/tests/system_tests/test_functional/test_tensorboard/test_run_sync_tensorboard.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_run_sync_tensorboard.py
@@ -1,0 +1,100 @@
+import pathlib
+
+import pytest
+import tensorflow as tf
+import wandb
+from tests.fixtures.wandb_backend_spy import WandbBackendSpy
+
+
+def test_syncing(wandb_backend_spy: WandbBackendSpy):
+    with wandb.init() as run:
+        # On Windows, this tests that forward slashes become backslashes
+        # or that forward slashes work fine.
+        run.sync_tensorboard("my/tb/logs", namespace="test", save_to=None)
+        with tf.summary.create_file_writer("my/tb/logs").as_default():
+            tf.summary.scalar("x", 0, step=0)
+            tf.summary.scalar("x", 1, step=1)
+
+    with wandb_backend_spy.freeze() as snapshot:
+        history = snapshot.history(run_id=run.id)
+        assert "test/x" in history[0] and history[0]["test/x"] == 0
+        assert "test/x" in history[1] and history[1]["test/x"] == 1
+
+
+def test_syncing_existing_files(wandb_backend_spy: WandbBackendSpy):
+    with tf.summary.create_file_writer("my/tb/logs").as_default():
+        tf.summary.scalar("x", 0, step=0)
+        tf.summary.scalar("x", 1, step=1)
+    with tf.summary.create_file_writer("my/tb/logs").as_default():
+        tf.summary.scalar("x", 2, step=2)
+        tf.summary.scalar("x", 3, step=3)
+
+    with wandb.init() as run:
+        run.sync_tensorboard("my/tb/logs", save_to="", existing_files=True)
+
+    with wandb_backend_spy.freeze() as snapshot:
+        # Check that all files were parsed.
+        history = snapshot.history(run_id=run.id)
+        for i in range(4):
+            assert "x" in history[i] and history[i]["x"] == i
+
+        # Check that all files were uploaded.
+        files = snapshot.uploaded_files(run_id=run.id)
+        assert len([f for f in files if "tfevents" in f]) == 2
+
+
+@pytest.mark.parametrize(
+    "save_to,expected",
+    (
+        pytest.param(None, None, id="none"),
+        pytest.param("", ".", id="empty"),
+        pytest.param("some/folder", "some/folder", id="relative"),
+        pytest.param("..weird", "..weird", id="..weird"),
+    ),
+)
+def test_syncing_save_to(
+    wandb_backend_spy: WandbBackendSpy,
+    save_to: str | None,
+    expected: str | None,
+):
+    with wandb.init() as run:
+        run.sync_tensorboard("my/tb/logs", save_to=save_to)
+        with tf.summary.create_file_writer("my/tb/logs").as_default():
+            tf.summary.scalar("x", 321, step=0)
+
+    with wandb_backend_spy.freeze() as snapshot:
+        files = snapshot.uploaded_files(run_id=run.id)
+
+        for file in files:
+            path = pathlib.PurePath(file)
+            if path.parent.as_posix() == expected and "tfevents" in path.name:
+                found = file
+                break
+        else:
+            found = None
+
+        assert bool(found) == bool(expected), files
+
+
+def test_syncing_save_to__absolute_path():
+    with wandb.init(mode="offline") as run:
+        with pytest.raises(
+            wandb.UsageError,
+            match="save_to must be relative",
+        ):
+            run.sync_tensorboard(
+                "my/tb/logs",
+                save_to=pathlib.Path(".").absolute(),
+            )
+
+
+def test_syncing_save_to__nonlocal_path():
+    with wandb.init(mode="offline") as run:
+        with pytest.raises(
+            wandb.UsageError,
+            match=r"save_to cannot use \.\.",
+        ):
+            run.sync_tensorboard(
+                "my/tb/logs",
+                save_to="valid/../still_ok/../../nevermind",
+            )

--- a/tests/unit_tests/test_library_public.py
+++ b/tests/unit_tests/test_library_public.py
@@ -207,6 +207,7 @@ SYMBOLS_RUN = {
     "settings",
     "status",
     "write_logs",
+    "sync_tensorboard",
 }
 
 # symbols having to do with resuming, we should clean this up

--- a/tests/unit_tests/test_wandb_run.py
+++ b/tests/unit_tests/test_wandb_run.py
@@ -52,6 +52,7 @@ REFERENCE_ATTRIBUTES = set(
         "sweep_id",
         "sweep_url",
         "sync_dir",
+        "sync_tensorboard",
         "tags",
         "to_html",
         "unwatch",

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -385,7 +385,8 @@ def init(
         tensorboard: Deprecated. Use `sync_tensorboard` instead.
         sync_tensorboard: Enables automatic syncing of W&B logs from TensorBoard
             or TensorBoardX, saving relevant event files for viewing in
-            the W&B UI.
+            the W&B UI. Consider using `run.sync_tensorboard()` instead for more
+            predictable behavior.
         monitor_gym: Enables automatic logging of videos of the environment when
             using OpenAI Gym.
         settings: Specifies a dictionary or `wandb.Settings` object with advanced

--- a/wandb/sdk/interface/interface.py
+++ b/wandb/sdk/interface/interface.py
@@ -656,11 +656,26 @@ class InterfaceBase(abc.ABC):
     def _publish_artifact(self, proto_artifact: pb.ArtifactRecord) -> None:
         raise NotImplementedError
 
-    def publish_tbdata(self, log_dir: str, save: bool, root_logdir: str = "") -> None:
+    def publish_tbdata(
+        self,
+        log_dir: str,
+        save: bool,
+        root_logdir: str = "",
+        *,
+        namespace: str | None = None,
+        save_path: str = "",
+        ignore_timestamp: bool = False,
+        ignore_hostname: bool = False,
+    ) -> None:
         tbrecord = pb.TBRecord()
         tbrecord.log_dir = log_dir
-        tbrecord.save = save
         tbrecord.root_dir = root_logdir
+        if namespace is not None:
+            tbrecord.namespace = namespace
+        tbrecord.save = save
+        tbrecord.save_path = save_path
+        tbrecord.ignore_timestamp = ignore_timestamp
+        tbrecord.ignore_hostname = ignore_hostname
         self._publish_tbdata(tbrecord)
 
     @abc.abstractmethod

--- a/wandb/sdk/lib/noop_run.py
+++ b/wandb/sdk/lib/noop_run.py
@@ -90,6 +90,7 @@ class NoopRun(wandb_run.Run):
         "mark_preempting",
         "restore",
         "status",
+        "sync_tensorboard",
         "watch",
         "write_logs",
         "unwatch",

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1369,7 +1369,8 @@ def init(  # noqa: C901
         tensorboard: Deprecated. Use `sync_tensorboard` instead.
         sync_tensorboard: Enables automatic syncing of W&B logs from TensorBoard
             or TensorBoardX, saving relevant event files for viewing in
-            the W&B UI.
+            the W&B UI. Consider using `run.sync_tensorboard()` instead for more
+            predictable behavior.
         monitor_gym: Enables automatic logging of videos of the environment when
             using OpenAI Gym.
         settings: Specifies a dictionary or `wandb.Settings` object with advanced

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3791,6 +3791,84 @@ class Run:
         if self._interface:
             self._interface.publish_preempting()
 
+    @_log_to_run
+    @_raise_if_finished
+    @_attach
+    def sync_tensorboard(
+        self,
+        path: str,
+        *,
+        save_to: StrPath | None,
+        namespace: str = "",
+        existing_files: bool = False,
+    ) -> None:
+        """Sync TensorBoard data in the given directory.
+
+        The run will process new tfevents files in the directory specified by
+        `path` and upload their data to W&B until `run.finish()` is called or
+        the script exits.
+
+        It is best to avoid using this together with `run.log()`, since the
+        tfevents data will produce additional steps at nondeterministic times.
+
+        Args:
+            path: Path to a TensorBoard logging directory containing tfevents
+                files. This can be a filesystem path, a cloud path for Amazon S3
+                (s3://bucket/some/file/name), GCS (gs://bucket/some/file/name)
+                or Microsoft Azure (az://account/bucket/some/file/name).
+            save_to: The path relative to the run's files directory where to
+                save tfevents files. Incompatible with tfevents files stored
+                in the cloud (S3, GCS, Azure). Setting this to None disables the
+                TensorBoard tab in the W&B UI. For example, setting this to
+                "tb/train" will save files in the tb/train/ folder in the run's
+                Files tab in the UI.
+            namespace: A prefix to add to all metric names. For example, you
+                may set this to "train" so that a metric logged as "epoch_loss"
+                in TensorBoard gets logged as "train/epoch_loss" in W&B.
+            existing_files: Whether to sync pre-existing tfevents files.
+                Normally, this only syncs data created after the run's start
+                time on the same machine (according to `HOSTNAME(1)`). Setting
+                this to true syncs all tfevents files.
+        """
+        assert self._interface
+
+        if not path.startswith(("s3://", "gs://", "az://")):
+            # In this case, it is a local filesystem path. If it is relative,
+            # we turn it into an absolute path because wandb-core may have
+            # a different working directory.
+            #
+            # We use str() to get the native representation (backslashes on
+            # Windows).
+            #
+            # We don't resolve the path, so that it can refer to a path that
+            # does not yet exist. Resolving with strict=False would allow this,
+            # but would result in inconsistent behavior for symlinks based on
+            # whether they existed at resolve time.
+            path = str(pathlib.Path(path).absolute())
+
+        match save_to:
+            case None:
+                save_path = ""
+            case "":
+                save_path = "."
+            case _:
+                save_to_path = pathlib.Path(save_to)
+                if save_to_path.is_absolute():
+                    raise UsageError(f"save_to must be relative, got {save_to}")
+                if ".." in pathlib.Path(os.path.normpath(save_to_path)).parts:
+                    raise UsageError(f"save_to cannot use .., got {save_to}")
+                save_path = str(save_to_path)  # convert to native format
+
+        self._interface.publish_tbdata(
+            path,
+            save=bool(save_path),
+            root_logdir=path,
+            namespace=namespace,
+            save_path=save_path,
+            ignore_timestamp=existing_files,
+            ignore_hostname=existing_files,
+        )
+
     @property
     @_log_to_run
     @_raise_if_finished


### PR DESCRIPTION
Creates the `run.sync_tensorboard()` method as an alternative way to enable the TB integration. Unlike `wandb.init(sync_tensorboard=True)`, this takes an explicit path instead of relying on monkeypatching tensorboard/tensorflow/torch, and it bypasses the "root directory" guessing logic.

This will be used for the `wandb sync --sync-tensorboard` replacement, pretty much as:

```python
with wandb.init() as run:
    run.sync_tensorboard(path, save_to=".", existing_files=True)
```

It can also be used directly, but it has a big caveat, which is that you probably don't want to use it with other logging methods, which is true of `wandb.init(sync_tensorboard=True)` as well.