### PR TITLE
fix: report failed check instead of crashing in wandb verify

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -43,3 +43,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - macOS x86_64 wheels now contain x86_64 builds of the `wandb-xpu` binary and the Rust parquet library, which previously shipped as arm64 and could not run or be loaded on Intel Macs (@dmitryduev in https://github.com/wandb/wandb/pull/12267)
 - `wandb.login(verify=True)` and `wandb login --verify` now verify federated identity (identity token) credentials, which were previously not verified (@dmitryduev in https://github.com/wandb/wandb/pull/12294)
 - `wandb login` and `wandb verify` no longer update the system host settings when failing to login (@jacobromero in https://github.com/wandb/wandb/pull/12332)
+- `wandb verify` now reports a failed check instead of crashing when an operation still fails after retries (@dmitryduev in https://github.com/wandb/wandb/pull/12360)

--- a/tests/unit_tests/test_wandb_verify.py
+++ b/tests/unit_tests/test_wandb_verify.py
@@ -1,5 +1,6 @@
 import unittest.mock
 
+import pytest
 import wandb
 import wandb.sdk.verify.verify as wandb_verify
 from wandb.proto import wandb_api_pb2 as apb
@@ -134,5 +135,5 @@ def test_retry_fn_times_out():
 
     with unittest.mock.patch("time.sleep", side_effect=sleep):
         with unittest.mock.patch("time.time", side_effect=time):
-            result = wandb_verify.retry_fn(fn)
-            assert result is None
+            with pytest.raises(Exception, match="test"):
+                wandb_verify.retry_fn(fn)

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -542,14 +542,12 @@ def check_sweeps(api: Api) -> bool:
 
 def retry_fn(fn: Callable) -> Any:
     ini_time = time.time()
-    res = None
     i = 0
-    while i < MIN_RETRYS or time.time() - ini_time < GET_RUN_MAX_TIME:
+    while True:
         i += 1
         try:
-            res = fn()
-            break
+            return fn()
         except Exception:
+            if i >= MIN_RETRYS and time.time() - ini_time >= GET_RUN_MAX_TIME:
+                raise
             time.sleep(1)
-            continue
-    return res


### PR DESCRIPTION
Description
-----------
Fixes WB-30075, WB-26806.

`retry_fn` in `verify.py` swallowed all exceptions and returned `None` once retries were exhausted, so a persistently failing operation crashed `wandb verify` with `AttributeError: 'NoneType' object has no attribute 'read'` instead of reaching the except blocks that report the failed check. Now it re-raises the last exception, and the existing handlers print their diagnostics.

