### PR TITLE
refactor(sweeps): move SweepNotFoundError to wandb.sdk.sweeps.errors

### DIFF
--- a/tests/system_tests/test_sweep/test_launch_scheduler.py
+++ b/tests/system_tests/test_sweep/test_launch_scheduler.py
@@ -7,7 +7,7 @@ import pytest
 import wandb
 from wandb.apis import internal, public
 from wandb.errors import CommError
-from wandb.sdk.launch.sweeps import SchedulerError, SweepNotFoundError, load_scheduler
+from wandb.sdk.launch.sweeps import SchedulerError, load_scheduler
 from wandb.sdk.launch.sweeps.scheduler import (
     RunState,
     Scheduler,
@@ -16,6 +16,7 @@ from wandb.sdk.launch.sweeps.scheduler import (
 )
 from wandb.sdk.launch.sweeps.scheduler_sweep import SweepScheduler
 from wandb.sdk.launch.sweeps.utils import construct_scheduler_args
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .test_wandb_sweep import SWEEP_CONFIG_RANDOM
 

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -27,9 +27,9 @@ from wandb.sdk.internal.internal_api import (
     _match_org_with_fetched_org_entities,
     _OrgNames,
 )
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib import retry, wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .test_retry import MockTime, mock_time  # noqa: F401
 

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -26,9 +26,9 @@ from wandb.sdk.internal.internal_api import (
     _match_org_with_fetched_org_entities,
     _OrgNames,
 )
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib import retry
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .test_retry import MockTime, mock_time  # noqa: F401
 

--- a/tests/unit_tests/test_wandb_agent/test_cli_agent.py
+++ b/tests/unit_tests/test_wandb_agent/test_cli_agent.py
@@ -10,8 +10,8 @@ from unittest import mock
 import pytest
 import yaml
 from wandb import env, wandb_agent
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 from wandb.wandb_agent import Agent
 
 from .conftest import (

--- a/tests/unit_tests/test_wandb_agent/test_cli_agent.py
+++ b/tests/unit_tests/test_wandb_agent/test_cli_agent.py
@@ -10,7 +10,7 @@ from unittest import mock
 import pytest
 import yaml
 from wandb import env, wandb_agent
-from wandb.sdk.launch.sweeps import SweepNotFoundError
+from wandb.sdk.sweeps import SweepNotFoundError
 from wandb.wandb_agent import Agent
 
 from .conftest import (

--- a/tests/unit_tests/test_wandb_agent/test_pyagent.py
+++ b/tests/unit_tests/test_wandb_agent/test_pyagent.py
@@ -8,8 +8,8 @@ import threading
 
 import pytest
 import wandb
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .conftest import (
     DEFAULT_ENTITY,

--- a/tests/unit_tests/test_wandb_agent/test_pyagent.py
+++ b/tests/unit_tests/test_wandb_agent/test_pyagent.py
@@ -7,7 +7,7 @@ import io
 import threading
 
 import wandb
-from wandb.sdk.launch.sweeps import SweepNotFoundError
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .conftest import (
     DEFAULT_ENTITY,

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -17,9 +17,9 @@ from typing import Any
 
 import wandb
 from wandb.apis import InternalApi
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.lib import config_util
+from wandb.sdk.sweeps import SweepNotFoundError
 
 logger = logging.getLogger(__name__)
 

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -44,6 +44,7 @@ from wandb.apis.paginator import SizedPaginator
 from wandb.errors import Error, UnsupportedError
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.lib import ipython
+from wandb.sdk.sweeps import SweepNotFoundError
 
 # Minimum W&B server release that supports filtering sweeps via the `filters`
 # argument on the `sweeps` field.
@@ -330,7 +331,7 @@ class Sweep(Attrs):
                     self.id,
                 )
             ):
-                raise ValueError(f"Could not find sweep {self!r}")
+                raise SweepNotFoundError(f"Could not find sweep {self!r}")
             self._attrs = sweep._attrs
             self.runs = sweep.runs
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -37,10 +37,10 @@ from wandb.sdk.internal.internal_api import Api as SDKInternalApi
 from wandb.sdk.launch import utils as launch_utils
 from wandb.sdk.launch._launch_add import _launch_add
 from wandb.sdk.launch.errors import ExecutionError, LaunchError
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.launch.sweeps.scheduler import Scheduler
 from wandb.sdk.lib import filesystem, settings_file
+from wandb.sdk.sweeps import SweepNotFoundError
 from wandb.sync import TFEVENT_SUBSTRING, SyncManager, get_runs
 
 from .beta import beta

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -36,10 +36,10 @@ from wandb.sdk.internal.internal_api import Api as SDKInternalApi
 from wandb.sdk.launch import utils as launch_utils
 from wandb.sdk.launch._launch_add import _launch_add
 from wandb.sdk.launch.errors import ExecutionError, LaunchError
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.launch.sweeps.scheduler import Scheduler
 from wandb.sdk.lib import filesystem, settings_file
+from wandb.sdk.sweeps import SweepNotFoundError
 from wandb.sync import TFEVENT_SUBSTRING, SyncManager, get_runs
 
 from .beta import beta

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2449,7 +2449,7 @@ class Api:
             SweepNotFoundError: If the server returns a 404, indicating the
                 sweep was likely deleted.
         """
-        from wandb.sdk.launch.sweeps import SweepNotFoundError
+        from wandb.sdk.sweeps import SweepNotFoundError
 
         mutation = """
         mutation Heartbeat(

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2429,7 +2429,7 @@ class Api:
             SweepNotFoundError: If the server returns a 404, indicating the
                 sweep was likely deleted.
         """
-        from wandb.sdk.launch.sweeps import SweepNotFoundError
+        from wandb.sdk.sweeps import SweepNotFoundError
 
         mutation = """
         mutation Heartbeat(

--- a/wandb/sdk/launch/sweeps/__init__.py
+++ b/wandb/sdk/launch/sweeps/__init__.py
@@ -2,15 +2,13 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from wandb.sdk.sweeps import SweepNotFoundError
+
 log = logging.getLogger(__name__)
 
 
 class SchedulerError(Exception):
     """Raised when a known error occurs with wandb sweep scheduler."""
-
-
-class SweepNotFoundError(Exception):
-    """Raised when a sweep is not found, typically because it was deleted."""
 
 
 def _import_sweep_scheduler() -> Any:

--- a/wandb/sdk/launch/sweeps/__init__.py
+++ b/wandb/sdk/launch/sweeps/__init__.py
@@ -2,7 +2,9 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from wandb.sdk.sweeps import SweepNotFoundError
+# SweepNotFoundError was moved from this file to sdk.sweeps.
+# Ensure backward-compatible re-export for legacy path.
+from wandb.sdk.sweeps import SweepNotFoundError as SweepNotFoundError
 
 log = logging.getLogger(__name__)
 

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -7,8 +7,8 @@ from pprint import pformat as pf
 from typing import Any
 
 import wandb
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps.scheduler import LOG_PREFIX, RunState, Scheduler, SweepRun
+from wandb.sdk.sweeps import SweepNotFoundError
 
 _logger = logging.getLogger(__name__)
 

--- a/wandb/sdk/sweeps/__init__.py
+++ b/wandb/sdk/sweeps/__init__.py
@@ -1,1 +1,2 @@
-from wandb.sdk.sweeps.run_state import RunState as RunState
+from wandb.sdk.sweeps.errors import SweepNotFoundError
+from wandb.sdk.sweeps.run_state import RunState

--- a/wandb/sdk/sweeps/__init__.py
+++ b/wandb/sdk/sweeps/__init__.py
@@ -1,2 +1,2 @@
-from wandb.sdk.sweeps.errors import SweepNotFoundError
-from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.errors import SweepNotFoundError as SweepNotFoundError
+from wandb.sdk.sweeps.run_state import RunState as RunState

--- a/wandb/sdk/sweeps/errors.py
+++ b/wandb/sdk/sweeps/errors.py
@@ -1,0 +1,2 @@
+class SweepNotFoundError(Exception):
+    """Raised when a sweep is not found, typically because it was deleted."""

--- a/wandb/sdk/sweeps/errors.py
+++ b/wandb/sdk/sweeps/errors.py
@@ -1,2 +1,5 @@
+"""Errors shared by the schedulers that drive sweeps."""
+
+
 class SweepNotFoundError(Exception):
     """Raised when a sweep is not found, typically because it was deleted."""

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -20,8 +20,8 @@ from typing import Any
 import wandb
 from wandb import util
 from wandb.sdk import wandb_login, wandb_setup
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib import config_util, ipython
+from wandb.sdk.sweeps import SweepNotFoundError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-38287

Centralize SweepNotFoundError by moving it from wandb.sdk.launch.sweeps to wandb.sdk.sweeps

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x]  CHANGELOG.unreleased.md N/A

## Testing

All of the CI still works

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->