### PR TITLE
feat(sweeps): add Scheduler base class for driving sweep runs

### DIFF
--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -1,19 +1,34 @@
 from __future__ import annotations
 
 import abc
+import contextlib
+import signal
+from collections.abc import Iterator, Sequence
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from wandb.apis.public import Sweep
+from wandb.apis.public import Sweep, SweepState
 from wandb.apis.public.service_api import ServiceApi
+from wandb.errors import CommError
+from wandb.proto.wandb_api_pb2 import ApiErrorResponse
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 from wandb.sdk.sweeps.run_state import RunState
 from wandb.sdk.sweeps.scheduler.optimizer import (
     Optimizer,
+    Run,
     RunConfig,
     RunSuggestion,
     RunWithMetrics,
+)
+from wandb.sdk.sweeps.scheduler.scheduler import (
+    _MAX_CONSECUTIVE_ERRORS,
+    Executor,
+    Scheduler,
+    _LoopControl,
+    _ShutdownMonitor,
 )
 
 SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
@@ -22,6 +37,7 @@ SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
     "early_terminate": {"type": "hyperband", "max_iter": 5, "eta": 2, "s": 2},
     "metric": {"name": "loss", "goal": "minimize"},
     "parameters": {"param1": {"values": [1, 2, 3]}},
+    "scheduler": {"engine": "wandb"},
 }
 
 
@@ -31,7 +47,7 @@ def make_scheduler_grid_sweep() -> Sweep:
     Passing `attrs` keeps the constructor from issuing a GraphQL load().
     """
     service_api = MagicMock(spec=ServiceApi)
-    return Sweep(
+    sweep = Sweep(
         service_api=service_api,
         entity="test_entity",
         project="test_project",
@@ -42,6 +58,8 @@ def make_scheduler_grid_sweep() -> Sweep:
             "config": yaml.dump(SCHEDULER_GRID_SWEEP_CONFIG),
         },
     )
+    sweep.finish = MagicMock()  # type: ignore[attr-defined]
+    return sweep
 
 
 def make_run(
@@ -50,14 +68,95 @@ def make_run(
     state: RunState,
     summary: dict[str, Any],
     history: list[dict[str, Any]] | None = None,
+    wandb_run_id: str = "wandb-run-id",
 ) -> RunWithMetrics:
     return RunWithMetrics(
         config=suggestion.config,
         state=state,
-        wandb_run_id="wandb-run-id",
+        wandb_run_id=wandb_run_id,
         summary_metrics=summary,
         history_metrics=history or [],
     )
+
+
+def api_error(status: int | None = None, message: str = "boom") -> WandbApiFailedError:
+    """A W&B API failure as wandb-core reports it.
+
+    Args:
+        status: The upstream HTTP status. None models a failure that never
+            reached an HTTP response.
+        message: The failure message.
+    """
+    if status is None:
+        return WandbApiFailedError(message)
+    return WandbApiFailedError(
+        message,
+        ApiErrorResponse(message=message, http_status=status),
+    )
+
+
+class StateSource:
+    """Serve a scripted sequence of sweep-state reads.
+
+    Each entry is a `SweepState` to return or an exception to raise. The last
+    entry repeats, so a test needn't predict how often the loop reads.
+    """
+
+    def __init__(self, *entries: SweepState | BaseException) -> None:
+        self.entries = entries
+        self.calls = 0
+
+    def __call__(self) -> SweepState:
+        self.calls += 1
+        entry = self.entries[min(self.calls - 1, len(self.entries) - 1)]
+        if isinstance(entry, BaseException):
+            raise entry
+        return entry
+
+
+def make_suggestions(n: int, prefix: str = "opt") -> list[RunSuggestion]:
+    return [
+        RunSuggestion(
+            config=RunConfig.from_values({"param1": i + 1}),
+            run_id=f"{prefix}-{i}",
+        )
+        for i in range(n)
+    ]
+
+
+class MockOptimizer(Optimizer):
+    """Minimal optimizer with mockable hooks for scheduler contract tests."""
+
+    def __init__(self, sweep: Sweep) -> None:
+        super().__init__(sweep)
+        self.ask_n_runs_mock = MagicMock(side_effect=lambda n: make_suggestions(n))
+        self.tell_run_mock = MagicMock()
+        self.tell_existing_finished_run_mock = MagicMock()
+        self.tell_existing_active_run_mock = MagicMock(
+            side_effect=lambda data: f"adopted-{data.wandb_run_id}"
+        )
+        self.prune_runs_mock = MagicMock(return_value=[])
+        self.should_terminate_sweep_mock = MagicMock(return_value=False)
+
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        return self.ask_n_runs_mock(n)
+
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
+        self.tell_run_mock(run_id, data)
+
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        self.tell_existing_finished_run_mock(data)
+
+    def tell_existing_active_run(self, data: Run) -> Any:
+        return self.tell_existing_active_run_mock(data)
+
+    def prune_runs(
+        self, run_ids: Sequence[str], runs: Sequence[RunWithMetrics]
+    ) -> Sequence[str]:
+        return self.prune_runs_mock(run_ids, runs)
+
+    def should_terminate_sweep(self) -> bool:
+        return self.should_terminate_sweep_mock()
 
 
 class OptimizerAcceptanceTests(abc.ABC):
@@ -156,3 +255,395 @@ class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
         from wandb.sdk.sweeps.scheduler.wandb import WandbOptimizer
 
         return WandbOptimizer(sweep=sweep)
+
+
+class LoopDriver:
+    """Drive `Scheduler.loop()` from the loop's own progress.
+
+    Stubbing `sweep_state` with a list of return values ties a test to how many
+    times the loop happens to read the state, and says nothing about *when* a
+    transition becomes visible. This driver serves whatever state the test last
+    set -- the loop may read it as often as it likes -- and only advances at a
+    real synchronization point: an iteration completing, or the test setting a
+    new state once it knows the loop reached the point under test.
+
+    `max_iterations` doubles as a hang guard: a loop that ignores its exit
+    conditions is pushed out with `exit_state` instead of spinning forever.
+    """
+
+    def __init__(
+        self,
+        scheduler: Scheduler,
+        state: SweepState = SweepState.RUNNING,
+        *,
+        max_iterations: int = 1,
+        exit_state: SweepState = SweepState.FINISHED,
+    ) -> None:
+        self._scheduler = scheduler
+        self._real_loop_iteration = scheduler._loop_iteration
+        self.state = state
+        self.max_iterations = max_iterations
+        self.exit_state = exit_state
+        self.iterations = 0
+
+    @contextlib.contextmanager
+    def driving(self) -> Iterator[LoopDriver]:
+        """Patch the scheduler so `scheduler.loop()` is driven by this driver."""
+        with (
+            patch.object(
+                self._scheduler, "sweep_state", side_effect=lambda: self.state
+            ),
+            patch.object(
+                self._scheduler, "_loop_iteration", side_effect=self._iteration
+            ),
+        ):
+            yield self
+
+    def _iteration(self) -> _LoopControl:
+        self.iterations += 1
+        try:
+            return self._real_loop_iteration()
+        finally:
+            if self.iterations >= self.max_iterations:
+                self.state = self.exit_state
+
+
+class SchedulerAcceptanceTests(abc.ABC):
+    """Contract tests every Scheduler implementation must satisfy."""
+
+    @pytest.fixture
+    def sweep(self) -> Sweep:
+        return make_scheduler_grid_sweep()
+
+    @pytest.fixture
+    def optimizer(self, sweep: Sweep) -> MockOptimizer:
+        return MockOptimizer(sweep=sweep)
+
+    @pytest.fixture
+    def batch_size(self) -> int:
+        return 2
+
+    @pytest.fixture
+    def executor(self) -> MagicMock:
+        executor = MagicMock(spec=Executor)
+        executor.schedule.side_effect = lambda suggestion: f"wandb-{suggestion.run_id}"
+        executor.reap.return_value = set()
+        return executor
+
+    @pytest.fixture
+    def sleeps(self, monkeypatch: pytest.MonkeyPatch) -> list[float]:
+        """Record the loop's poll waits instead of performing them.
+
+        Recording rather than zeroing keeps the slowdown observable.
+        """
+        recorded: list[float] = []
+        monkeypatch.setattr(
+            _ShutdownMonitor,
+            "wait",
+            lambda self, seconds: recorded.append(seconds),
+        )
+        return recorded
+
+    @abc.abstractmethod
+    @pytest.fixture
+    def scheduler(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        executor: MagicMock,
+        batch_size: int,
+    ) -> Scheduler: ...
+
+    def test_schedule_up_to_batch_size(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        batch_size: int,
+    ) -> None:
+        assert len(scheduler.in_flight_runs()) == 0
+        scheduler.push_in_flight_run("wandb-existing", "opt-existing")
+        with patch.object(scheduler, "sweep_state", return_value=SweepState.RUNNING):
+            scheduler._schedule_suggestions()
+
+        assert len(scheduler.in_flight_runs()) == batch_size
+        assert "wandb-existing" in scheduler.in_flight_runs()
+        assert "wandb-opt-0" in scheduler.in_flight_runs()
+        optimizer.ask_n_runs_mock.assert_called_once_with(batch_size - 1)
+
+    def test_loop_finishes_sweep_when_optimizer_is_exhausted(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        sweep: Sweep,
+        executor: MagicMock,
+        batch_size: int,
+    ) -> None:
+        # Nothing left to propose means the search space is exhausted.
+        optimizer.ask_n_runs_mock.side_effect = lambda n: []
+
+        # The sweep stays RUNNING for more iterations than the loop should take,
+        # so exhaustion -- not a state transition -- has to end it.
+        driver = LoopDriver(scheduler, SweepState.RUNNING, max_iterations=2)
+        with driver.driving():
+            scheduler.loop()
+
+        assert driver.iterations == 1
+        optimizer.ask_n_runs_mock.assert_called_once_with(batch_size)
+        sweep.finish.assert_called_once()  # type: ignore[attr-defined]
+        executor.schedule.assert_not_called()
+        assert len(scheduler.in_flight_runs()) == 0
+
+    def test_loop_exits_when_sweep_state_not_found(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+    ) -> None:
+        with patch.object(
+            scheduler,
+            "sweep_state",
+            side_effect=CommError("sweep not found"),
+        ):
+            with pytest.raises(CommError, match="sweep not found"):
+                scheduler.loop()
+
+        optimizer.ask_n_runs_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status",
+        [None, 0, 408, 500, 502, 503, 504],
+    )
+    def test_loop_keeps_polling_through_intermittent_api_error(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+        status: int | None,
+    ) -> None:
+        """A transient failure reading sweep state must not end the sweep."""
+        source = StateSource(
+            api_error(status),
+            SweepState.RUNNING,
+            SweepState.FINISHED,
+        )
+        iterations = 0
+
+        def iteration() -> _LoopControl:
+            nonlocal iterations
+            iterations += 1
+            return _LoopControl.CONTINUE
+
+        with (
+            patch.object(scheduler, "sweep_state", side_effect=source),
+            patch.object(scheduler, "_loop_iteration", side_effect=iteration),
+        ):
+            scheduler.loop()
+
+        # Absorbed rather than raised, so a real iteration still ran.
+        assert iterations == 1
+        assert sleeps == [1.0, 0.0]  # slowed down, then back to the poll rate
+
+    @pytest.mark.parametrize(
+        "status",
+        [400, 401, 403, 409, 410, 413, 422, 501],
+    )
+    def test_loop_exits_immediately_on_permanent_api_error(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        sleeps: list[float],
+        status: int,
+    ) -> None:
+        error = api_error(status)
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(WandbApiFailedError):
+                scheduler.loop()
+
+        assert sleeps == []  # exited without waiting
+        optimizer.ask_n_runs_mock.assert_not_called()
+
+    def test_loop_exits_immediately_when_sweep_is_gone(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """A 404 ends the loop rather than being retried."""
+        error = api_error(404)
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(WandbApiFailedError):
+                scheduler.loop()
+
+        assert sleeps == []
+
+    def test_loop_exits_immediately_when_sweep_query_returns_no_sweep(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """A deleted sweep raises `SweepNotFoundError`, not a 404."""
+        error = SweepNotFoundError("Could not find sweep <Sweep e/p/s>")
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(SweepNotFoundError, match="Could not find sweep"):
+                scheduler.loop()
+
+        assert sleeps == []
+
+    def test_loop_slows_down_while_rate_limited_without_giving_up(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """Throttling slows polling indefinitely; it never ends the sweep."""
+        throttled = [api_error(429)] * (_MAX_CONSECUTIVE_ERRORS + 5)
+        source = StateSource(*throttled, SweepState.FINISHED)
+
+        with patch.object(scheduler, "sweep_state", side_effect=source):
+            scheduler.loop()
+
+        assert len(sleeps) == len(throttled)
+        assert sleeps[:4] == [1.0, 2.0, 4.0, 8.0]  # doubles up to the cap
+        assert sleeps[-1] == 60.0
+        assert sleeps == sorted(sleeps)
+
+    def test_loop_gives_up_after_repeated_failed_polls(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """A backend that never recovers ends the loop instead of spinning."""
+        error = api_error(503)
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(WandbApiFailedError):
+                scheduler.loop()
+
+        assert len(sleeps) == _MAX_CONSECUTIVE_ERRORS
+
+    def test_loop_returns_to_normal_poll_rate_after_a_clean_iteration(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        source = StateSource(
+            api_error(503),
+            SweepState.RUNNING,
+            api_error(503),
+            SweepState.FINISHED,
+        )
+        with (
+            patch.object(scheduler, "sweep_state", side_effect=source),
+            patch.object(
+                scheduler,
+                "_loop_iteration",
+                return_value=_LoopControl.CONTINUE,
+            ),
+        ):
+            scheduler.loop()
+
+        assert sleeps == [1.0, 0.0, 1.0]  # without the reset, 2.0 at the end
+
+    def test_loop_reads_sweep_state_once_per_iteration(
+        self,
+        scheduler: Scheduler,
+    ) -> None:
+        """Each read is a full sweep query, so the loop makes one per pass."""
+        source = StateSource(
+            SweepState.RUNNING,
+            SweepState.RUNNING,
+            SweepState.FINISHED,
+        )
+        with (
+            patch.object(scheduler, "sweep_state", side_effect=source),
+            patch.object(
+                scheduler,
+                "_loop_iteration",
+                return_value=_LoopControl.CONTINUE,
+            ),
+        ):
+            scheduler.loop()
+
+        # Two iterations plus the read that ended the loop, none after.
+        assert source.calls == 3
+
+    def test_loop_finishes_iteration_on_shutdown_signal(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+    ) -> None:
+        call_order: list[str] = []
+
+        def poll_with_shutdown() -> list[RunWithMetrics]:
+            call_order.append("poll")
+            scheduler._shutdown.handle_signal(signal.SIGTERM, None)
+            return []
+
+        # The sweep stays RUNNING for more iterations than the loop should take:
+        # the shutdown request, not a state transition, has to end it after the
+        # iteration in flight completes.
+        driver = LoopDriver(scheduler, SweepState.RUNNING, max_iterations=2)
+
+        with (
+            driver.driving(),
+            patch.object(
+                scheduler, "_poll_active_runs", side_effect=poll_with_shutdown
+            ),
+            patch.object(
+                scheduler,
+                "_prune_active_runs",
+                side_effect=lambda *a, **kw: call_order.append("prune"),
+            ),
+            patch.object(
+                scheduler,
+                "_reap_dead_runs",
+                side_effect=lambda: call_order.append("reap"),
+            ),
+            patch.object(
+                scheduler,
+                "_schedule_suggestions",
+                side_effect=lambda: call_order.append("schedule"),
+            ),
+        ):
+            scheduler.loop()
+
+        assert driver.iterations == 1
+        assert call_order == ["poll", "prune", "reap", "schedule"]
+
+    def test_loop_finishes_iteration_on_keyboard_interrupt(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+    ) -> None:
+        call_order: list[str] = []
+
+        def poll_with_interrupt() -> list[RunWithMetrics]:
+            call_order.append("poll")
+            scheduler._shutdown.handle_signal(signal.SIGINT, None)
+            return []
+
+        # The sweep stays RUNNING for more iterations than the loop should take:
+        # the interrupt, not a state transition, has to end it after the
+        # iteration in flight completes.
+        driver = LoopDriver(scheduler, SweepState.RUNNING, max_iterations=2)
+
+        with (
+            driver.driving(),
+            patch.object(
+                scheduler, "_poll_active_runs", side_effect=poll_with_interrupt
+            ),
+            patch.object(
+                scheduler,
+                "_prune_active_runs",
+                side_effect=lambda *a, **kw: call_order.append("prune"),
+            ),
+            patch.object(
+                scheduler,
+                "_reap_dead_runs",
+                side_effect=lambda: call_order.append("reap"),
+            ),
+            patch.object(
+                scheduler,
+                "_schedule_suggestions",
+                side_effect=lambda: call_order.append("schedule"),
+            ),
+        ):
+            scheduler.loop()
+
+        assert driver.iterations == 1
+        assert call_order == ["poll", "prune", "reap", "schedule"]

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -393,6 +393,29 @@ class SchedulerAcceptanceTests(abc.ABC):
         executor.schedule.assert_not_called()
         assert len(scheduler.in_flight_runs()) == 0
 
+    def test_loop_keeps_polling_when_optimizer_declines_to_propose(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        sweep: Sweep,
+        executor: MagicMock,
+        batch_size: int,
+    ) -> None:
+        # None declines this round (e.g. the strategy is waiting on results);
+        # the loop must keep polling instead of finishing the sweep.
+        optimizer.ask_n_runs_mock.side_effect = lambda n: None
+
+        driver = LoopDriver(scheduler, SweepState.RUNNING, max_iterations=2)
+        with driver.driving():
+            scheduler.loop()
+
+        # Only the driver's state transition ends the loop.
+        assert driver.iterations == 2
+        assert optimizer.ask_n_runs_mock.call_count == 2
+        sweep.finish.assert_not_called()  # type: ignore[attr-defined]
+        executor.schedule.assert_not_called()
+        assert len(scheduler.in_flight_runs()) == 0
+
     def test_loop_exits_when_sweep_state_not_found(
         self,
         scheduler: Scheduler,

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -1,19 +1,33 @@
 from __future__ import annotations
 
 import abc
+import contextlib
+import signal
+from collections.abc import Iterator, Sequence
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from wandb.apis.public import Sweep
+from wandb.apis.public import Sweep, SweepState
 from wandb.apis.public.service_api import ServiceApi
+from wandb.errors import CommError
+from wandb.proto.wandb_api_pb2 import ApiErrorResponse
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 from wandb.sdk.sweeps.run_state import RunState
 from wandb.sdk.sweeps.scheduler.optimizer import (
     Optimizer,
+    Run,
     RunConfig,
     RunSuggestion,
     RunWithMetrics,
+)
+from wandb.sdk.sweeps.scheduler.scheduler import (
+    _MAX_CONSECUTIVE_ERRORS,
+    Executor,
+    Scheduler,
+    _ShutdownMonitor,
 )
 
 SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
@@ -22,6 +36,7 @@ SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
     "early_terminate": {"type": "hyperband", "max_iter": 5, "eta": 2, "s": 2},
     "metric": {"name": "loss", "goal": "minimize"},
     "parameters": {"param1": {"values": [1, 2, 3]}},
+    "scheduler": {"engine": "wandb"},
 }
 
 
@@ -31,7 +46,7 @@ def make_scheduler_grid_sweep() -> Sweep:
     Passing `attrs` keeps the constructor from issuing a GraphQL load().
     """
     service_api = MagicMock(spec=ServiceApi)
-    return Sweep(
+    sweep = Sweep(
         service_api=service_api,
         entity="test_entity",
         project="test_project",
@@ -42,6 +57,8 @@ def make_scheduler_grid_sweep() -> Sweep:
             "config": yaml.dump(SCHEDULER_GRID_SWEEP_CONFIG),
         },
     )
+    sweep.finish = MagicMock()  # type: ignore[attr-defined]
+    return sweep
 
 
 def make_run(
@@ -50,14 +67,93 @@ def make_run(
     state: RunState,
     summary: dict[str, Any],
     history: list[dict[str, Any]] | None = None,
+    wandb_run_id: str = "wandb-run-id",
 ) -> RunWithMetrics:
     return RunWithMetrics(
         config=suggestion.config,
         state=state,
-        wandb_run_id="wandb-run-id",
+        wandb_run_id=wandb_run_id,
         summary_metrics=summary,
         history_metrics=history or [],
     )
+
+
+def api_error(status: int | None = None, message: str = "boom") -> WandbApiFailedError:
+    """A W&B API failure as wandb-core reports it.
+
+    Args:
+        status: The upstream HTTP status. None models a failure that never
+            reached an HTTP response.
+        message: The failure message.
+    """
+    if status is None:
+        return WandbApiFailedError(message)
+    return WandbApiFailedError(
+        message,
+        ApiErrorResponse(message=message, http_status=status),
+    )
+
+
+class StateSource:
+    """Serve a scripted sequence of sweep-state reads.
+
+    Each entry is a `SweepState` to return or an exception to raise. The last
+    entry repeats, so a test needn't predict how often the loop reads.
+    """
+
+    def __init__(self, *entries: SweepState | BaseException) -> None:
+        self.entries = entries
+        self.calls = 0
+
+    def __call__(self) -> SweepState:
+        self.calls += 1
+        entry = self.entries[min(self.calls - 1, len(self.entries) - 1)]
+        if isinstance(entry, BaseException):
+            raise entry
+        return entry
+
+
+def make_suggestions(n: int, prefix: str = "opt") -> list[RunSuggestion]:
+    return [
+        RunSuggestion(
+            config=RunConfig.from_values({"param1": i + 1}),
+            run_id=f"{prefix}-{i}",
+        )
+        for i in range(n)
+    ]
+
+
+class MockOptimizer(Optimizer):
+    """Minimal optimizer with mockable hooks for scheduler contract tests."""
+
+    def __init__(self, sweep: Sweep) -> None:
+        super().__init__(sweep)
+        self.ask_n_runs_mock = MagicMock(side_effect=lambda n: make_suggestions(n))
+        self.tell_run_mock = MagicMock()
+        self.tell_existing_finished_run_mock = MagicMock()
+        self.tell_existing_active_run_mock = MagicMock(
+            side_effect=lambda data: f"adopted-{data.wandb_run_id}"
+        )
+        self.prune_run_mock = MagicMock(return_value=False)
+        self.should_terminate_sweep_mock = MagicMock(return_value=False)
+
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        return self.ask_n_runs_mock(n)
+
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
+        self.tell_run_mock(run_id, data)
+
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        self.tell_existing_finished_run_mock(data)
+
+    def tell_existing_active_run(self, data: Run) -> Any:
+        return self.tell_existing_active_run_mock(data)
+
+    def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
+        return self.prune_run_mock(run_id, data)
+
+    def should_terminate_sweep(self) -> bool:
+        return self.should_terminate_sweep_mock()
 
 
 class OptimizerAcceptanceTests(abc.ABC):
@@ -148,3 +244,387 @@ class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
         from wandb.sdk.sweeps.scheduler.wandb import WandbOptimizer
 
         return WandbOptimizer(sweep=sweep)
+
+
+class LoopDriver:
+    """Drive `Scheduler.loop()` from the loop's own progress.
+
+    Stubbing `sweep_state` with a list of return values ties a test to how many
+    times the loop happens to read the state, and says nothing about *when* a
+    transition becomes visible. This driver serves whatever state the test last
+    set -- the loop may read it as often as it likes -- and only advances at a
+    real synchronization point: an iteration completing, or the test setting a
+    new state once it knows the loop reached the point under test.
+
+    `max_iterations` doubles as a hang guard: a loop that ignores its exit
+    conditions is pushed out with `exit_state` instead of spinning forever.
+    """
+
+    def __init__(
+        self,
+        scheduler: Scheduler,
+        state: SweepState = SweepState.RUNNING,
+        *,
+        max_iterations: int = 1,
+        exit_state: SweepState = SweepState.FINISHED,
+    ) -> None:
+        self._scheduler = scheduler
+        self._real_loop_iteration = scheduler._loop_iteration
+        self.state = state
+        self.max_iterations = max_iterations
+        self.exit_state = exit_state
+        self.iterations = 0
+
+    @contextlib.contextmanager
+    def driving(self) -> Iterator[LoopDriver]:
+        """Patch the scheduler so `scheduler.loop()` is driven by this driver."""
+        with (
+            patch.object(
+                self._scheduler, "sweep_state", side_effect=lambda: self.state
+            ),
+            patch.object(
+                self._scheduler, "_loop_iteration", side_effect=self._iteration
+            ),
+        ):
+            yield self
+
+    def _iteration(self) -> bool:
+        self.iterations += 1
+        try:
+            return self._real_loop_iteration()
+        finally:
+            if self.iterations >= self.max_iterations:
+                self.state = self.exit_state
+
+
+class SchedulerAcceptanceTests(abc.ABC):
+    """Contract tests every Scheduler implementation must satisfy."""
+
+    @pytest.fixture
+    def sweep(self) -> Sweep:
+        return make_scheduler_grid_sweep()
+
+    @pytest.fixture
+    def optimizer(self, sweep: Sweep) -> MockOptimizer:
+        return MockOptimizer(sweep=sweep)
+
+    @pytest.fixture
+    def batch_size(self) -> int:
+        return 2
+
+    @pytest.fixture
+    def executor(self) -> MagicMock:
+        executor = MagicMock(spec=Executor)
+        executor.schedule.side_effect = lambda suggestion: f"wandb-{suggestion.run_id}"
+        executor.reap.return_value = set()
+        return executor
+
+    @pytest.fixture
+    def sleeps(self, monkeypatch: pytest.MonkeyPatch) -> list[float]:
+        """Record the loop's poll waits instead of performing them.
+
+        Recording rather than zeroing keeps the slowdown observable.
+        """
+        recorded: list[float] = []
+        monkeypatch.setattr(
+            _ShutdownMonitor,
+            "wait",
+            lambda self, seconds: recorded.append(seconds),
+        )
+        return recorded
+
+    @abc.abstractmethod
+    @pytest.fixture
+    def scheduler(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        executor: MagicMock,
+        batch_size: int,
+    ) -> Scheduler: ...
+
+    def test_schedule_up_to_batch_size(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        batch_size: int,
+    ) -> None:
+        assert len(scheduler.in_flight_runs()) == 0
+        scheduler.push_in_flight_run("wandb-existing", "opt-existing")
+        with patch.object(scheduler, "sweep_state", return_value=SweepState.RUNNING):
+            scheduler._schedule_suggestions()
+
+        assert len(scheduler.in_flight_runs()) == batch_size
+        assert "wandb-existing" in scheduler.in_flight_runs()
+        assert "wandb-opt-0" in scheduler.in_flight_runs()
+        optimizer.ask_n_runs_mock.assert_called_once_with(batch_size - 1)
+
+    def test_loop_finishes_sweep_when_optimizer_is_exhausted(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        sweep: Sweep,
+        executor: MagicMock,
+        batch_size: int,
+    ) -> None:
+        # Nothing left to propose means the search space is exhausted.
+        optimizer.ask_n_runs_mock.side_effect = lambda n: []
+
+        # The sweep stays RUNNING for more iterations than the loop should take,
+        # so exhaustion -- not a state transition -- has to end it.
+        driver = LoopDriver(scheduler, SweepState.RUNNING, max_iterations=2)
+        with driver.driving():
+            scheduler.loop()
+
+        assert driver.iterations == 1
+        optimizer.ask_n_runs_mock.assert_called_once_with(batch_size)
+        sweep.finish.assert_called_once()  # type: ignore[attr-defined]
+        executor.schedule.assert_not_called()
+        assert len(scheduler.in_flight_runs()) == 0
+
+    def test_loop_exits_when_sweep_state_not_found(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+    ) -> None:
+        with patch.object(
+            scheduler,
+            "sweep_state",
+            side_effect=CommError("sweep not found"),
+        ):
+            with pytest.raises(CommError, match="sweep not found"):
+                scheduler.loop()
+
+        optimizer.ask_n_runs_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status",
+        [None, 0, 408, 500, 502, 503, 504],
+    )
+    def test_loop_keeps_polling_through_intermittent_api_error(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+        status: int | None,
+    ) -> None:
+        """A transient failure reading sweep state must not end the sweep."""
+        source = StateSource(
+            api_error(status),
+            SweepState.RUNNING,
+            SweepState.FINISHED,
+        )
+        iterations = 0
+
+        def iteration() -> bool:
+            nonlocal iterations
+            iterations += 1
+            return False
+
+        with (
+            patch.object(scheduler, "sweep_state", side_effect=source),
+            patch.object(scheduler, "_loop_iteration", side_effect=iteration),
+        ):
+            scheduler.loop()
+
+        # Absorbed rather than raised, so a real iteration still ran.
+        assert iterations == 1
+        assert sleeps == [1.0, 0.0]  # slowed down, then back to the poll rate
+
+    @pytest.mark.parametrize(
+        "status",
+        [400, 401, 403, 409, 410, 413, 422, 501],
+    )
+    def test_loop_exits_immediately_on_permanent_api_error(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+        sleeps: list[float],
+        status: int,
+    ) -> None:
+        error = api_error(status)
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(WandbApiFailedError):
+                scheduler.loop()
+
+        assert sleeps == []  # exited without waiting
+        optimizer.ask_n_runs_mock.assert_not_called()
+
+    def test_loop_exits_immediately_when_sweep_is_gone(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """A 404 ends the loop rather than being retried."""
+        error = api_error(404)
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(WandbApiFailedError):
+                scheduler.loop()
+
+        assert sleeps == []
+
+    def test_loop_exits_immediately_when_sweep_query_returns_no_sweep(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """A deleted sweep raises `SweepNotFoundError`, not a 404."""
+        error = SweepNotFoundError("Could not find sweep <Sweep e/p/s>")
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(SweepNotFoundError, match="Could not find sweep"):
+                scheduler.loop()
+
+        assert sleeps == []
+
+    def test_loop_slows_down_while_rate_limited_without_giving_up(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """Throttling slows polling indefinitely; it never ends the sweep."""
+        throttled = [api_error(429)] * (_MAX_CONSECUTIVE_ERRORS + 5)
+        source = StateSource(*throttled, SweepState.FINISHED)
+
+        with patch.object(scheduler, "sweep_state", side_effect=source):
+            scheduler.loop()
+
+        assert len(sleeps) == len(throttled)
+        assert sleeps[:4] == [1.0, 2.0, 4.0, 8.0]  # doubles up to the cap
+        assert sleeps[-1] == 60.0
+        assert sleeps == sorted(sleeps)
+
+    def test_loop_gives_up_after_repeated_failed_polls(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        """A backend that never recovers ends the loop instead of spinning."""
+        error = api_error(503)
+        with patch.object(scheduler, "sweep_state", side_effect=StateSource(error)):
+            with pytest.raises(WandbApiFailedError):
+                scheduler.loop()
+
+        assert len(sleeps) == _MAX_CONSECUTIVE_ERRORS
+
+    def test_loop_returns_to_normal_poll_rate_after_a_clean_iteration(
+        self,
+        scheduler: Scheduler,
+        sleeps: list[float],
+    ) -> None:
+        source = StateSource(
+            api_error(503),
+            SweepState.RUNNING,
+            api_error(503),
+            SweepState.FINISHED,
+        )
+        with (
+            patch.object(scheduler, "sweep_state", side_effect=source),
+            patch.object(scheduler, "_loop_iteration", return_value=False),
+        ):
+            scheduler.loop()
+
+        assert sleeps == [1.0, 0.0, 1.0]  # without the reset, 2.0 at the end
+
+    def test_loop_reads_sweep_state_once_per_iteration(
+        self,
+        scheduler: Scheduler,
+    ) -> None:
+        """Each read is a full sweep query, so the loop makes one per pass."""
+        source = StateSource(
+            SweepState.RUNNING,
+            SweepState.RUNNING,
+            SweepState.FINISHED,
+        )
+        with (
+            patch.object(scheduler, "sweep_state", side_effect=source),
+            patch.object(scheduler, "_loop_iteration", return_value=False),
+        ):
+            scheduler.loop()
+
+        # Two iterations plus the read that ended the loop, none after.
+        assert source.calls == 3
+
+    def test_loop_finishes_iteration_on_shutdown_signal(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+    ) -> None:
+        call_order: list[str] = []
+
+        def poll_with_shutdown() -> list[RunWithMetrics]:
+            call_order.append("poll")
+            scheduler._shutdown.handle_signal(signal.SIGTERM, None)
+            return []
+
+        # The sweep stays RUNNING for more iterations than the loop should take:
+        # the shutdown request, not a state transition, has to end it after the
+        # iteration in flight completes.
+        driver = LoopDriver(scheduler, SweepState.RUNNING, max_iterations=2)
+
+        with (
+            driver.driving(),
+            patch.object(
+                scheduler, "_poll_active_runs", side_effect=poll_with_shutdown
+            ),
+            patch.object(
+                scheduler,
+                "_prune_active_runs",
+                side_effect=lambda *a, **kw: call_order.append("prune"),
+            ),
+            patch.object(
+                scheduler,
+                "_reap_dead_runs",
+                side_effect=lambda: call_order.append("reap"),
+            ),
+            patch.object(
+                scheduler,
+                "_schedule_suggestions",
+                side_effect=lambda: call_order.append("schedule"),
+            ),
+        ):
+            scheduler.loop()
+
+        assert driver.iterations == 1
+        assert call_order == ["poll", "prune", "reap", "schedule"]
+
+    def test_loop_finishes_iteration_on_keyboard_interrupt(
+        self,
+        scheduler: Scheduler,
+        optimizer: MockOptimizer,
+    ) -> None:
+        call_order: list[str] = []
+
+        def poll_with_interrupt() -> list[RunWithMetrics]:
+            call_order.append("poll")
+            scheduler._shutdown.handle_signal(signal.SIGINT, None)
+            return []
+
+        # The sweep stays RUNNING for more iterations than the loop should take:
+        # the interrupt, not a state transition, has to end it after the
+        # iteration in flight completes.
+        driver = LoopDriver(scheduler, SweepState.RUNNING, max_iterations=2)
+
+        with (
+            driver.driving(),
+            patch.object(
+                scheduler, "_poll_active_runs", side_effect=poll_with_interrupt
+            ),
+            patch.object(
+                scheduler,
+                "_prune_active_runs",
+                side_effect=lambda *a, **kw: call_order.append("prune"),
+            ),
+            patch.object(
+                scheduler,
+                "_reap_dead_runs",
+                side_effect=lambda: call_order.append("reap"),
+            ),
+            patch.object(
+                scheduler,
+                "_schedule_suggestions",
+                side_effect=lambda: call_order.append("schedule"),
+            ),
+        ):
+            scheduler.loop()
+
+        assert driver.iterations == 1
+        assert call_order == ["poll", "prune", "reap", "schedule"]

--- a/tests/unit_tests/test_sweep_scheduler_failure_policy.py
+++ b/tests/unit_tests/test_sweep_scheduler_failure_policy.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from wandb.errors import CommError
+from wandb.proto.wandb_api_pb2 import ApiErrorResponse
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
+from wandb.sdk.sweeps.scheduler.failure_policy import Disposition, classify, http_status
+
+
+def api_error(status: int | None = None, message: str = "boom") -> WandbApiFailedError:
+    """A W&B API failure as wandb-core reports it.
+
+    Args:
+        status: The upstream HTTP status. None models a failure that never
+            reached an HTTP response, which is how a transport error or a
+            service process that isn't running arrives.
+        message: The failure message.
+    """
+    if status is None:
+        return WandbApiFailedError(message)
+    return WandbApiFailedError(
+        message,
+        ApiErrorResponse(message=message, http_status=status),
+    )
+
+
+def wrapped(error: WandbApiFailedError) -> CommError:
+    """`error` as `normalize_exceptions` re-raises it."""
+    return CommError(error.args[0], error)
+
+
+PERMANENT_STATUSES = [
+    HTTPStatus.BAD_REQUEST,
+    HTTPStatus.UNAUTHORIZED,
+    HTTPStatus.FORBIDDEN,
+    HTTPStatus.CONFLICT,
+    HTTPStatus.GONE,
+    HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+    HTTPStatus.UNPROCESSABLE_ENTITY,
+    HTTPStatus.NOT_IMPLEMENTED,
+]
+
+TRANSIENT_STATUSES = [
+    HTTPStatus.REQUEST_TIMEOUT,
+    HTTPStatus.INTERNAL_SERVER_ERROR,
+    HTTPStatus.BAD_GATEWAY,
+    HTTPStatus.SERVICE_UNAVAILABLE,
+    HTTPStatus.GATEWAY_TIMEOUT,
+]
+
+
+@pytest.mark.parametrize("status", PERMANENT_STATUSES)
+def test_permanent_statuses_are_fatal(status: int) -> None:
+    assert classify(api_error(status)) is Disposition.FATAL
+    assert classify(wrapped(api_error(status))) is Disposition.FATAL
+
+
+@pytest.mark.parametrize("status", TRANSIENT_STATUSES)
+def test_transient_statuses_keep_the_loop_polling(status: int) -> None:
+    assert classify(api_error(status)) is Disposition.TRANSIENT
+    assert classify(wrapped(api_error(status))) is Disposition.TRANSIENT
+
+
+def test_not_found_is_reported_separately() -> None:
+    assert classify(api_error(HTTPStatus.NOT_FOUND)) is Disposition.NOT_FOUND
+    assert classify(wrapped(api_error(HTTPStatus.NOT_FOUND))) is Disposition.NOT_FOUND
+
+
+def test_too_many_requests_is_rate_limited() -> None:
+    error = api_error(HTTPStatus.TOO_MANY_REQUESTS)
+    assert classify(error) is Disposition.RATE_LIMITED
+    assert classify(wrapped(error)) is Disposition.RATE_LIMITED
+
+
+def test_failure_without_an_http_response_is_transient() -> None:
+    """A failure that never reached the server is a transport problem."""
+    # wandb-core reports no status at all when the service process is gone.
+    assert classify(api_error(None)) is Disposition.TRANSIENT
+    assert classify(wrapped(api_error(None))) is Disposition.TRANSIENT
+    # It reports 0 when the request itself had no HTTP response.
+    assert classify(api_error(0)) is Disposition.TRANSIENT
+
+
+def test_unrecognized_client_error_is_fatal() -> None:
+    assert classify(api_error(HTTPStatus.EXPECTATION_FAILED)) is Disposition.FATAL
+
+
+def test_non_api_error_is_fatal() -> None:
+    """An error that isn't a W&B API failure would just fail again."""
+    # A malformed run config reaches the scheduler as a bare CommError, because
+    # normalize_exceptions wraps every exception, not just network ones.
+    assert classify(CommError("Unable to convert 3 to a dict")) is Disposition.FATAL
+    assert classify(TypeError("not a dict")) is Disposition.FATAL
+
+
+def test_missing_sweep_is_not_found() -> None:
+    """A deleted sweep answers 200 with a null sweep, so `Sweep.load` raises."""
+    error = SweepNotFoundError("Could not find sweep <Sweep entity/project/sweep_id>")
+    assert classify(error) is Disposition.NOT_FOUND
+
+
+def test_unrelated_value_error_is_fatal() -> None:
+    assert classify(ValueError("Run r is already in flight")) is Disposition.FATAL
+
+
+def test_http_status_reads_requests_style_errors() -> None:
+    """Paths that talk HTTP directly still expose a status."""
+
+    class Response:
+        status_code = int(HTTPStatus.SERVICE_UNAVAILABLE)
+
+    class HttpError(Exception):
+        response = Response()
+
+    assert http_status(HttpError()) == HTTPStatus.SERVICE_UNAVAILABLE
+    assert classify(HttpError()) is Disposition.TRANSIENT
+
+
+def test_http_status_is_none_without_a_status() -> None:
+    assert http_status(api_error(None)) is None
+    assert http_status(api_error(0)) is None
+    assert http_status(CommError("no status here")) is None

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -37,6 +37,7 @@ __all__ = (
     "Runs",
     "AgentRuns",  # doc:exclude
     "Sweep",
+    "SweepState",
     "Member",
     "Team",
     "Organization",
@@ -85,7 +86,7 @@ from wandb.apis.public.runhistory.downloads import (
     DownloadHistoryResult,
     IncompleteRunHistoryError,
 )
-from wandb.apis.public.runs import RUN_FRAGMENT, AgentRuns, Run, RunNotFoundError, Runs
-from wandb.apis.public.sweeps import Sweep
+from wandb.apis.public.runs import RUN_FRAGMENT, AgentRuns, Run, Runs
+from wandb.apis.public.sweeps import Sweep, SweepState
 from wandb.apis.public.teams import Member, Team
 from wandb.apis.public.users import User

--- a/wandb/apis/public/__init__.py
+++ b/wandb/apis/public/__init__.py
@@ -86,7 +86,7 @@ from wandb.apis.public.runhistory.downloads import (
     DownloadHistoryResult,
     IncompleteRunHistoryError,
 )
-from wandb.apis.public.runs import RUN_FRAGMENT, AgentRuns, Run, Runs
+from wandb.apis.public.runs import RUN_FRAGMENT, AgentRuns, Run, RunNotFoundError, Runs
 from wandb.apis.public.sweeps import Sweep, SweepState
 from wandb.apis.public.teams import Member, Team
 from wandb.apis.public.users import User

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import urllib
 from collections.abc import Mapping
+from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from typing_extensions import override
@@ -55,6 +56,32 @@ if TYPE_CHECKING:
     from wandb.apis.public.api import Api
     from wandb.apis.public.runs import AgentRuns
     from wandb.apis.public.service_api import ServiceApi
+
+
+class SweepState(str, Enum):
+    """The state of a sweep as a `str` enum."""
+
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    PAUSED = "PAUSED"
+    FINISHED = "FINISHED"
+    CANCELED = "CANCELED"
+    FAILED = "FAILED"
+    CRASHED = "CRASHED"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def _missing_(cls, value: object) -> SweepState:
+        """Resolve values case-insensitively, falling back to `UNKNOWN`."""
+        if isinstance(value, str):
+            normalized = value.strip().upper()
+            for member in cls:
+                if member.value == normalized:
+                    return member
+            # The backend spells this with two L's in some places.
+            if normalized == "CANCELLED":
+                return cls.CANCELED
+        return cls.UNKNOWN
 
 
 class Sweeps(SizedPaginator["Sweep"]):
@@ -278,8 +305,7 @@ class Sweep(Attrs):
         id (str): Sweep ID
         project (str): The name of the project the sweep belongs to
         config (dict): Dictionary containing the sweep configuration
-        state (str): The state of the sweep. Can be "Finished", "Failed",
-            "Crashed", or "Running".
+        state (SweepState): The state of the sweep.
         expected_run_count (int): The number of expected runs for the sweep
     """
 
@@ -316,6 +342,12 @@ class Sweep(Attrs):
     def config(self):
         """The sweep configuration used for the sweep."""
         return util.load_yaml(self._attrs["config"])
+
+    def finish(self) -> None:
+        """Mark the sweep finished on the server so no new runs are started."""
+        from wandb.apis.internal import InternalApi
+
+        InternalApi().stop_sweep(self.id, entity=self.entity, project=self.project)
 
     def load(self, force: bool = False):
         """Fetch and update sweep data logged to the run from GraphQL database.

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -305,7 +305,7 @@ class Sweep(Attrs):
         id (str): Sweep ID
         project (str): The name of the project the sweep belongs to
         config (dict): Dictionary containing the sweep configuration
-        state (SweepState): The state of the sweep.
+        state (str): The state of the sweep, as reported by the server.
         expected_run_count (int): The number of expected runs for the sweep
     """
 

--- a/wandb/sdk/sweeps/scheduler/failure_policy.py
+++ b/wandb/sdk/sweeps/scheduler/failure_policy.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from enum import Enum
+from http import HTTPStatus
+
+from wandb.errors import CommError
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps.errors import SweepNotFoundError
+
+__all__ = ["Disposition", "classify", "http_status"]
+
+
+class Disposition(Enum):
+    """What the scheduler loop should do about a failed API call."""
+
+    FATAL = "fatal"
+    """The call will never succeed; end the loop."""
+
+    NOT_FOUND = "not_found"
+    """The sweep or run is gone; end the loop."""
+
+    TRANSIENT = "transient"
+    """May clear up on its own; keep polling, but less often."""
+
+    RATE_LIMITED = "rate_limited"
+    """The server is asking us to slow down; poll less often."""
+
+
+# A malformed query (400, 422), bad credentials (401, 403), a resource gone
+# or conflicted (409, 410), an oversized payload (413), or an unimplemented
+# operation (501). wandb-core retries none of these.
+_FATAL_STATUSES = frozenset(
+    {
+        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.FORBIDDEN,
+        HTTPStatus.CONFLICT,
+        HTTPStatus.GONE,
+        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+        HTTPStatus.UNPROCESSABLE_ENTITY,
+        HTTPStatus.NOT_IMPLEMENTED,
+    }
+)
+
+
+def _api_failure(exc: BaseException) -> WandbApiFailedError | None:
+    """Return the W&B API failure behind `exc`, if there is one.
+
+    `normalize_exceptions` wraps it in a `CommError`, except under
+    `WANDB_DEBUG`, which re-raises it untouched -- so both forms turn up.
+    """
+    if isinstance(exc, WandbApiFailedError):
+        return exc
+    if isinstance(exc, CommError) and isinstance(exc.exc, WandbApiFailedError):
+        return exc.exc
+    return None
+
+
+def http_status(exc: BaseException) -> int | None:
+    """The upstream HTTP status behind `exc`, or None if it carries none.
+
+    None means either that the failure never reached an HTTP response, or that
+    `exc` is not a W&B API failure at all; `classify` tells those apart.
+
+    Args:
+        exc: The exception to read a status off of.
+    """
+    if (api_failure := _api_failure(exc)) is not None:
+        if api_failure.response is None:
+            return None
+        # http_status is 0 when the failure had no HTTP response at all.
+        return api_failure.response.http_status or None
+
+    # Paths that talk HTTP directly raise `requests.HTTPError` instead. None
+    # of the scheduler's calls do today, but reading it keeps a future one from
+    # being misclassified silently.
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) and status else None
+
+
+def classify(exc: BaseException) -> Disposition:
+    """Decide what the scheduler loop should do about `exc`.
+
+    Args:
+        exc: The exception raised by a W&B API call.
+    """
+    # A deleted sweep answers 200 with a null sweep rather than 404, so this
+    # is the signal that it is gone.
+    if isinstance(exc, SweepNotFoundError):
+        return Disposition.NOT_FOUND
+
+    status = http_status(exc)
+    if status is None:
+        # No status on an API failure means a transport problem. Anything else
+        # never made a request -- a bug or a data error -- and the next poll
+        # would hit it again just as surely.
+        return Disposition.TRANSIENT if _api_failure(exc) else Disposition.FATAL
+
+    if status == HTTPStatus.NOT_FOUND:
+        return Disposition.NOT_FOUND
+    if status == HTTPStatus.TOO_MANY_REQUESTS:
+        return Disposition.RATE_LIMITED
+    if status in _FATAL_STATUSES:
+        return Disposition.FATAL
+    # 501 is fatal and already returned above.
+    if status == HTTPStatus.REQUEST_TIMEOUT or status >= 500:
+        return Disposition.TRANSIENT
+    # An unrecognized 4xx: assume our request is at fault and would fail again.
+    return Disposition.FATAL

--- a/wandb/sdk/sweeps/scheduler/failure_policy.py
+++ b/wandb/sdk/sweeps/scheduler/failure_policy.py
@@ -1,0 +1,123 @@
+"""Which W&B API failures the sweep scheduler's poll loop can survive.
+
+wandb-core has already retried the individual call by the time a failure gets
+here: it retries transport errors, 429s and most 5xxs up to 20 times with its
+own 2-60s backoff (`RetryMostFailures` in
+`core/internal/clients/retry_policy.go`). A status reaching Python either was
+never retried there or outlasted that whole budget, so re-issuing the call
+would just stack a second ladder on top of the first.
+
+This classifies a failure by what the *loop* should do next, not by whether the
+call is worth repeating. See `Scheduler.loop`.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from http import HTTPStatus
+
+from wandb.errors import CommError
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps.errors import SweepNotFoundError
+
+__all__ = ["Disposition", "classify", "http_status"]
+
+
+class Disposition(Enum):
+    """What the scheduler loop should do about a failed API call."""
+
+    FATAL = "fatal"
+    """The call will never succeed; end the loop."""
+
+    NOT_FOUND = "not_found"
+    """The sweep or run is gone; end the loop."""
+
+    TRANSIENT = "transient"
+    """May clear up on its own; keep polling, but less often."""
+
+    RATE_LIMITED = "rate_limited"
+    """The server is asking us to slow down; poll less often."""
+
+
+# A malformed query (400, 422), bad credentials (401, 403), a resource gone
+# or conflicted (409, 410), an oversized payload (413), or an unimplemented
+# operation (501). wandb-core retries none of these.
+_FATAL_STATUSES = frozenset(
+    {
+        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.FORBIDDEN,
+        HTTPStatus.CONFLICT,
+        HTTPStatus.GONE,
+        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+        HTTPStatus.UNPROCESSABLE_ENTITY,
+        HTTPStatus.NOT_IMPLEMENTED,
+    }
+)
+
+
+def _api_failure(exc: BaseException) -> WandbApiFailedError | None:
+    """Return the W&B API failure behind `exc`, if there is one.
+
+    `normalize_exceptions` wraps it in a `CommError`, except under
+    `WANDB_DEBUG`, which re-raises it untouched -- so both forms turn up.
+    """
+    if isinstance(exc, WandbApiFailedError):
+        return exc
+    if isinstance(exc, CommError) and isinstance(exc.exc, WandbApiFailedError):
+        return exc.exc
+    return None
+
+
+def http_status(exc: BaseException) -> int | None:
+    """The upstream HTTP status behind `exc`, or None if it carries none.
+
+    None means either that the failure never reached an HTTP response, or that
+    `exc` is not a W&B API failure at all; `classify` tells those apart.
+
+    Args:
+        exc: The exception to read a status off of.
+    """
+    if (api_failure := _api_failure(exc)) is not None:
+        if api_failure.response is None:
+            return None
+        # http_status is 0 when the failure had no HTTP response at all.
+        return api_failure.response.http_status or None
+
+    # Paths that talk HTTP directly raise `requests.HTTPError` instead. None
+    # of the scheduler's calls do today, but reading it keeps a future one from
+    # being misclassified silently.
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) and status else None
+
+
+def classify(exc: BaseException) -> Disposition:
+    """Decide what the scheduler loop should do about `exc`.
+
+    Args:
+        exc: The exception raised by a W&B API call.
+    """
+    # A deleted sweep answers 200 with a null sweep rather than 404, so this
+    # is the signal that it is gone.
+    if isinstance(exc, SweepNotFoundError):
+        return Disposition.NOT_FOUND
+
+    status = http_status(exc)
+    if status is None:
+        # No status on an API failure means a transport problem. Anything else
+        # never made a request -- a bug or a data error -- and the next poll
+        # would hit it again just as surely.
+        return Disposition.TRANSIENT if _api_failure(exc) else Disposition.FATAL
+
+    if status == HTTPStatus.NOT_FOUND:
+        return Disposition.NOT_FOUND
+    if status == HTTPStatus.TOO_MANY_REQUESTS:
+        return Disposition.RATE_LIMITED
+    if status in _FATAL_STATUSES:
+        return Disposition.FATAL
+    # 501 is fatal and already returned above.
+    if status == HTTPStatus.REQUEST_TIMEOUT or status >= 500:
+        return Disposition.TRANSIENT
+    # An unrecognized 4xx: assume our request is at fault and would fail again.
+    return Disposition.FATAL

--- a/wandb/sdk/sweeps/scheduler/scheduler.py
+++ b/wandb/sdk/sweeps/scheduler/scheduler.py
@@ -624,7 +624,8 @@ class Scheduler(ABC):
             return _LoopControl.CONTINUE
         suggestions = self._next_suggestions(n_to_enqueue)
         if suggestions is None:
-            # search was interrupted
+            # The search was interrupted or the optimizer declined to
+            # propose this round; try again next poll.
             return _LoopControl.CONTINUE
         if len(suggestions) == 0:
             # search space is exhausted
@@ -642,18 +643,20 @@ class Scheduler(ABC):
     def _next_suggestions(self, n: int) -> Sequence[RunSuggestion] | None:
         """Ask the optimizer for up to `n` runs, polling sweep state.
 
-        An optimizer that proposes nothing has exhausted its search space (grid
-        search, for one, stops proposing once every point has been handed out),
-        so there is nothing left to schedule and the sweep is finished here.
+        An optimizer that proposes an empty sequence has exhausted its search
+        space (grid search, for one, stops proposing once every point has
+        been handed out), so there is nothing left to schedule and the sweep
+        is finished here. An optimizer that returns None declines to propose
+        for now; it is asked again on a later poll.
 
         Returns:
             The runs to enqueue; an empty sequence once the search space is
-            exhausted and the sweep has been finished; or None when the sweep
-            leaves RUNNING/PENDING/PAUSED (or a shutdown is requested) before
-            the optimizer responds, so the loop can exit without enqueueing
-            new runs.
+            exhausted and the sweep has been finished; or None to enqueue
+            nothing this round -- because the optimizer declined to propose,
+            or because the sweep left RUNNING/PENDING/PAUSED (or a shutdown
+            was requested) before the optimizer responded.
         """
-        suggestions: list[RunSuggestion] | None = None
+        suggestions: Sequence[RunSuggestion] | None = None
         error: BaseException | None = None
         done = threading.Event()
 
@@ -662,7 +665,7 @@ class Scheduler(ABC):
             # A swallowed exception here would leave `done` unset and the
             # loop below polling forever, so capture it for re-raising.
             try:
-                suggestions = list(self._optimizer.ask_n_runs(n))
+                suggestions = self._optimizer.ask_n_runs(n)
             except BaseException as e:
                 error = e
             finally:
@@ -680,6 +683,10 @@ class Scheduler(ABC):
                 return None
         if error is not None:
             raise error
+        if suggestions is None:
+            # The optimizer declined to propose this round (e.g. waiting on
+            # in-flight results).
+            return None
         if not suggestions:
             termlog(
                 f"Optimizer for sweep {self._sweep.name} has no runs left to "
@@ -687,7 +694,7 @@ class Scheduler(ABC):
             )
             self._sweep.finish()
             return []
-        return suggestions
+        return list(suggestions)
 
     def _build_runs(
         self, runs: Iterable[Any], builder: Callable[[Any], _RunT]

--- a/wandb/sdk/sweeps/scheduler/scheduler.py
+++ b/wandb/sdk/sweeps/scheduler/scheduler.py
@@ -12,6 +12,8 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
+from typing_extensions import override
+
 from wandb import termerror, termlog, termwarn
 from wandb.apis.public import Sweep, SweepState
 from wandb.sdk.sweeps.run_state import RunState
@@ -75,8 +77,9 @@ class Executor(ABC):
     def reap(self, run_ids: Iterable[str]) -> set[str]:
         """Return the `run_ids` whose backend jobs are no longer alive.
 
-        Catches jobs that died before `wandb.init` ran (rejected,
-        preempted, crashed at startup) and left their W&B run stuck PENDING.
+        Override to catch jobs that died before `wandb.init` ran (rejected,
+        preempted, crashed at startup) and left their W&B run stuck PENDING;
+        the default reports none.
         """
         return set()
 
@@ -90,6 +93,7 @@ class WBAgentExecutor(Executor):
     def __init__(self, sweep: Sweep):
         self._sweep = sweep
 
+    @override
     def schedule(self, suggestion: RunSuggestion) -> str:
         """Enqueue the run in the sweep's queue; return its W&B run id."""
         return self._sweep.enqueue_run(suggestion.config.wire_dict())
@@ -218,8 +222,9 @@ class _ShutdownMonitor:
 class SchedulerOptions:
     """How a scheduler drives a sweep, independent of the search strategy.
 
-    `executor` is the backend that schedules runs; the default is the W&B run
-    queue.
+    `poll_interval_s` is how long the loop waits between polls, `batch_size`
+    is how many runs to keep in flight, and `executor` is the backend that
+    schedules runs; the default is the W&B run queue.
     """
 
     poll_interval_s: float = 5.0
@@ -291,7 +296,11 @@ class Scheduler(ABC):
 
     @abstractmethod
     def sweep_state(self) -> SweepState:
-        """The sweep's current state; the loop runs while RUNNING/PENDING."""
+        """The sweep's current state.
+
+        The loop keeps polling while it is active: RUNNING, PENDING or
+        PAUSED.
+        """
         ...
 
     def unreadable_run_ids(self) -> frozenset[str]:
@@ -319,7 +328,7 @@ class Scheduler(ABC):
         (ctrl-c) let the current loop iteration finish before exiting.
 
         Intermittent W&B API failures don't end the sweep: the loop keeps
-        polling, just further apart, until they clear or
+        polling, just further apart, until they clear or more than
         `_MAX_CONSECUTIVE_ERRORS` polls have failed in a row. Failures that
         won't resolve on their own end the loop immediately. See
         `failure_policy.classify`.
@@ -359,9 +368,12 @@ class Scheduler(ABC):
         # past the handling above.
         state = self._last_sweep_state
         if state is None:
-            termlog(f"Sweep {self._sweep.name} has exited")
+            termlog(f"Scheduler for sweep {self._sweep.name} exited.")
         else:
-            termlog(f"Sweep {self._sweep.name} has exited with state {state}")
+            termlog(
+                f"Scheduler for sweep {self._sweep.name} exited; "
+                f"sweep state is {state.value}."
+            )
 
     def _refresh_sweep_state(self) -> SweepState:
         """Read the sweep's state and cache it for the current iteration."""
@@ -442,7 +454,8 @@ class Scheduler(ABC):
         self._prune_active_runs(active)
         if self._optimizer.should_terminate_sweep():
             termlog(
-                f"Sweep {self._sweep.name} should be terminated;exiting scheduler loop."
+                f"Sweep {self._sweep.name} should be terminated; "
+                f"exiting scheduler loop."
             )
             self._sweep.finish()
             return _LoopControl.TERMINATE
@@ -490,8 +503,8 @@ class Scheduler(ABC):
                 and data.state == RunState.FINISHED
             ):
                 termwarn(
-                    f"Run {wandb_run_id} in sweep {self._sweep.name} "
-                    f"has no metric value"
+                    f"Run {wandb_run_id} in sweep {self._sweep.name} finished "
+                    f"without the sweep metric; marking it failed."
                 )
                 data.state = RunState.FAILED
 
@@ -641,12 +654,19 @@ class Scheduler(ABC):
             new runs.
         """
         suggestions: list[RunSuggestion] | None = None
+        error: BaseException | None = None
         done = threading.Event()
 
         def fetch() -> None:
-            nonlocal suggestions
-            suggestions = list(self._optimizer.ask_n_runs(n))
-            done.set()
+            nonlocal suggestions, error
+            # A swallowed exception here would leave `done` unset and the
+            # loop below polling forever, so capture it for re-raising.
+            try:
+                suggestions = list(self._optimizer.ask_n_runs(n))
+            except BaseException as e:
+                error = e
+            finally:
+                done.set()
 
         thread = threading.Thread(target=fetch, daemon=True)
         thread.start()
@@ -658,6 +678,8 @@ class Scheduler(ABC):
                 return None
             if self._refresh_sweep_state() not in _ACTIVE_SWEEP_STATES:
                 return None
+        if error is not None:
+            raise error
         if not suggestions:
             termlog(
                 f"Optimizer for sweep {self._sweep.name} has no runs left to "

--- a/wandb/sdk/sweeps/scheduler/scheduler.py
+++ b/wandb/sdk/sweeps/scheduler/scheduler.py
@@ -1,0 +1,686 @@
+from __future__ import annotations
+
+import contextlib
+import enum
+import select
+import signal
+import socket
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from wandb import termerror, termlog, termwarn
+from wandb.apis.public import Sweep, SweepState
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.failure_policy import Disposition, classify
+from wandb.sdk.sweeps.scheduler.optimizer import (
+    Optimizer,
+    Run,
+    RunConfig,
+    RunSuggestion,
+    RunWithMetrics,
+    is_terminal_state,
+)
+from wandb.wandb_agent import TERMINATING_SIGNALS, ShutdownSignal
+
+_RunT = TypeVar("_RunT", bound=Run)
+_T = TypeVar("_T")
+
+# Terminal states, derived from `is_terminal_state` so the two stay in sync.
+_TERMINAL_STATES = [s.value for s in RunState if is_terminal_state(s)]
+
+# Sweep states the loop keeps polling for. Anything else ends it.
+_ACTIVE_SWEEP_STATES = frozenset(
+    {
+        SweepState.RUNNING,
+        SweepState.PENDING,
+        SweepState.PAUSED,
+    }
+)
+
+# How much longer to wait between polls once W&B calls start failing. This
+# throttles the whole loop -- a failed call is never re-issued, since
+# wandb-core already retried it; the next poll just happens later, so an
+# unhealthy or throttling backend receives fewer requests per minute. The delay
+# is added to `poll_interval_s` (absolute, so a `poll_interval_s` of 0 still
+# slows down) and doubles per consecutive failed poll.
+_INITIAL_SLOWDOWN_S = 1.0
+_MAX_SLOWDOWN_S = 60.0
+
+# Consecutive failed polls to absorb before giving up on the sweep. Rate
+# limiting doesn't count toward this.
+_MAX_CONSECUTIVE_ERRORS = 10
+
+
+class _LoopControl(enum.Enum):
+    CONTINUE = enum.auto()
+    TERMINATE = enum.auto()
+
+
+class Executor(ABC):
+    """The backend that starts a suggested run and reports on it later.
+
+    Subclass this to schedule runs somewhere other than the W&B run queue, e.g.
+    directly onto SLURM or Volcano. See `WBAgentExecutor` for the default.
+    """
+
+    @abstractmethod
+    def schedule(self, suggestion: RunSuggestion) -> str:
+        """Start or queue a run for `suggestion`; return its W&B run id."""
+        ...
+
+    def reap(self, run_ids: Iterable[str]) -> set[str]:
+        """Return the `run_ids` whose backend jobs are no longer alive.
+
+        Catches jobs that died before `wandb.init` ran (rejected,
+        preempted, crashed at startup) and left their W&B run stuck PENDING.
+        """
+        return set()
+
+
+class WBAgentExecutor(Executor):
+    """Default executor: enqueue the run into the W&B sweep's run queue.
+
+    A W&B agent (`wandb agent <sweep>`) pulls the queued run and executes it.
+    """
+
+    def __init__(self, sweep: Sweep):
+        self._sweep = sweep
+
+    def schedule(self, suggestion: RunSuggestion) -> str:
+        """Enqueue the run in the sweep's queue; return its W&B run id."""
+        return self._sweep.enqueue_run(suggestion.config.wire_dict())
+
+
+class _ShutdownMonitor:
+    """Turn terminating signals into a graceful-shutdown request."""
+
+    def __init__(self) -> None:
+        self._requested = False
+        self._signum: int | None = None
+        self._announced = False
+        self._original_handlers: dict[int, Any] = {}
+        self._wakeup_recv: socket.socket | None = None
+        self._wakeup_send: socket.socket | None = None
+        # The wakeup fd this monitor replaced; None while not installed.
+        self._prev_wakeup_fd: int | None = None
+
+    @property
+    def requested(self) -> bool:
+        """Whether a shutdown has been requested (by signal or `request`).
+
+        A read that observes a signal's request also logs the one-time
+        acknowledgment, which the signal handler could not do safely.
+        """
+        if self._requested:
+            self._announce()
+        return self._requested
+
+    def request(self, signum: int) -> None:
+        """Record a shutdown request from normal (non-handler) code."""
+        self._signum = signum
+        self._requested = True
+        self._announce()
+
+    def handle_signal(self, signum: int, frame: Any) -> None:
+        """Record a shutdown request; installed as the signal handler.
+
+        Plain attribute writes only to prevent deadlocks
+        """
+        self._signum = signum
+        self._requested = True
+
+    def install(self) -> None:
+        """Install the signal handlers and wakeup fd, resetting any request.
+
+        Handlers and the wakeup fd can only be set on the main thread;
+        elsewhere they are skipped and `wait` degrades to a full sleep.
+        """
+        self._requested = False
+        self._signum = None
+        self._announced = False
+        # A socketpair rather than a pipe because on Windows the wakeup fd
+        # must be a socket. Non-blocking on both ends so signal delivery
+        # never blocks on a full buffer.
+        self._wakeup_recv, self._wakeup_send = socket.socketpair()
+        self._wakeup_recv.setblocking(False)
+        self._wakeup_send.setblocking(False)
+        try:
+            self._prev_wakeup_fd = signal.set_wakeup_fd(
+                self._wakeup_send.fileno(), warn_on_full_buffer=False
+            )
+        except ValueError:  # not the main thread
+            self._prev_wakeup_fd = None
+
+        shutdown_signals = TERMINATING_SIGNALS | {signal.SIGINT}
+        for signum in signal.valid_signals() & shutdown_signals:
+            with contextlib.suppress(OSError, ValueError):
+                self._original_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, self.handle_signal)
+
+    def restore(self) -> None:
+        """Undo `install`: put back the prior handlers and wakeup fd."""
+        for signum, handler in self._original_handlers.items():
+            with contextlib.suppress(OSError, ValueError):
+                signal.signal(signum, handler)
+        self._original_handlers.clear()
+        if self._prev_wakeup_fd is not None:
+            with contextlib.suppress(ValueError):
+                signal.set_wakeup_fd(self._prev_wakeup_fd)
+            self._prev_wakeup_fd = None
+        for sock in (self._wakeup_recv, self._wakeup_send):
+            if sock is not None:
+                sock.close()
+        self._wakeup_recv = None
+        self._wakeup_send = None
+
+    def wait(self, seconds: float) -> None:
+        """Sleep up to `seconds`, returning as soon as shutdown is requested."""
+        if self._wakeup_recv is None:
+            # Not installed, so nothing can wake the wait early anyway.
+            time.sleep(seconds)
+            return
+        deadline = time.monotonic() + seconds
+        # One pass per delivered signal, not a poll: `select` blocks until
+        # the deadline unless some signal writes a wakeup byte.
+        while not self.requested:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            select.select([self._wakeup_recv], [], [], remaining)
+            self._drain_wakeup_bytes()
+
+    def _drain_wakeup_bytes(self) -> None:
+        """Empty the wakeup socket so stale bytes don't cut a wait short."""
+        assert self._wakeup_recv is not None
+        # recv raises BlockingIOError (an OSError) once the socket is empty.
+        with contextlib.suppress(OSError):
+            while self._wakeup_recv.recv(4096):
+                pass
+
+    def _announce(self) -> None:
+        if self._announced or self._signum is None:
+            return
+        self._announced = True
+        if self._signum == signal.SIGINT:
+            label = "ctrl-c"
+        else:
+            label = signal.Signals(self._signum).name
+        termlog(
+            f"{label} received. Finishing current scheduler iteration before exiting."
+        )
+
+
+@dataclass
+class SchedulerOptions:
+    """How a scheduler drives a sweep, independent of the search strategy.
+
+    `executor` is the backend that schedules runs; the default is the W&B run
+    queue.
+    """
+
+    poll_interval_s: float = 5.0
+    batch_size: int = 1
+    executor: Executor | None = None
+
+
+class Scheduler(ABC):
+    """Drive an `Optimizer` against a sweep, keeping `batch_size` in flight.
+
+    Poll runs, tell the optimizer their results, and enqueue its suggestions.
+    Subclasses implement the hooks below to choose where in-flight state lives
+    and how runs are observed.
+    See `InMemoryScheduler` for the default implementation.
+    """
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        options: SchedulerOptions | None = None,
+    ):
+        options = options or SchedulerOptions()
+        self._optimizer = optimizer
+        self._sweep = sweep
+        self._poll_interval_s = options.poll_interval_s
+        self._batch_size = options.batch_size
+        self._executor = options.executor or WBAgentExecutor(sweep)
+        self._shutdown = _ShutdownMonitor()
+        # The state read at the top of the current iteration; one read
+        # serves everything in it.
+        self._last_sweep_state: SweepState | None = None
+        self._slowdown_s = 0.0
+        self._consecutive_errors = 0
+
+    @abstractmethod
+    def in_flight_runs(self) -> Mapping[str, Any]:
+        """The live, mutable {wandb_run_id: optimizer_run_id} in-flight map."""
+        ...
+
+    @abstractmethod
+    def pop_in_flight_run(self, wandb_run_id: str) -> Any:
+        """Remove a run from the in-flight set."""
+        ...
+
+    @abstractmethod
+    def push_in_flight_run(self, wandb_run_id: str, optimizer_run_id: Any) -> None:
+        """Add a run to the in-flight set.
+
+        Raises:
+            ValueError: If `wandb_run_id` is already in flight.
+        """
+        ...
+
+    @abstractmethod
+    def fetch_existing_finished_runs(self) -> Iterable[RunWithMetrics]:
+        """Terminal runs already in the sweep, with their summary metrics."""
+        ...
+
+    @abstractmethod
+    def fetch_existing_unfinished_runs(self) -> Iterable[Run]:
+        """In-flight runs already in the sweep, without metrics, to adopt."""
+        ...
+
+    @abstractmethod
+    def fetch_active_runs(self) -> Iterable[RunWithMetrics]:
+        """The tracked in-flight runs, with fresh state/metrics and history."""
+        ...
+
+    @abstractmethod
+    def sweep_state(self) -> SweepState:
+        """The sweep's current state; the loop runs while RUNNING/PENDING."""
+        ...
+
+    def unreadable_run_ids(self) -> frozenset[str]:
+        """W&B run ids the last `fetch_active_runs` saw but could not build.
+
+        Such a run still exists on the server, so it must not be reaped as
+        deleted. Override this alongside `fetch_active_runs` when that hook
+        skips runs; the default reports none.
+        """
+        return frozenset()
+
+    @abstractmethod
+    def stop_run(self, wandb_run_id: str) -> bool:
+        """Request that a run stop early; True if the stop was accepted."""
+        ...
+
+    def loop(self) -> None:
+        """Warm-start, then poll and schedule runs until the sweep ends.
+
+        Warm-starting runs first, so runs already in the sweep (e.g. from a
+        previous scheduler instance) count toward the in-flight cap before any
+        new ones are enqueued.
+
+        `ShutdownSignal` (SIGTERM/SIGHUP/SIGQUIT) and `KeyboardInterrupt`
+        (ctrl-c) let the current loop iteration finish before exiting.
+
+        Intermittent W&B API failures don't end the sweep: the loop keeps
+        polling, just further apart, until they clear or
+        `_MAX_CONSECUTIVE_ERRORS` polls have failed in a row. Failures that
+        won't resolve on their own end the loop immediately. See
+        `failure_policy.classify`.
+
+        Raises:
+            Exception: The failure that ended the loop, when a W&B API call
+                failed permanently or kept failing poll after poll.
+        """
+        self._reset_poll_slowdown()
+        self._shutdown.install()  # also resets any earlier request
+        try:
+            # Not retried: `_warm_start` is not idempotent, so a second
+            # attempt would double-count runs it already ingested.
+            self._warm_start()
+
+            while not self._shutdown.requested:
+                try:
+                    # Read inside the try so a failure here is handled too.
+                    if self._refresh_sweep_state() not in _ACTIVE_SWEEP_STATES:
+                        break
+                    if self._loop_iteration() is _LoopControl.TERMINATE:
+                        break
+                    self._reset_poll_slowdown()
+                except (KeyboardInterrupt, ShutdownSignal) as e:
+                    signum = (
+                        signal.SIGINT if isinstance(e, KeyboardInterrupt) else e.signum
+                    )
+                    self._shutdown.request(signum)
+                    break
+                except Exception as e:
+                    self._handle_loop_error(e)  # re-raises unless survivable
+                self._shutdown.wait(self._effective_poll_interval_s)
+        finally:
+            self._shutdown.restore()
+
+        # Report the cached state: another query here could fail from a point
+        # past the handling above.
+        state = self._last_sweep_state
+        if state is None:
+            termlog(f"Sweep {self._sweep.name} has exited")
+        else:
+            termlog(f"Sweep {self._sweep.name} has exited with state {state}")
+
+    def _refresh_sweep_state(self) -> SweepState:
+        """Read the sweep's state and cache it for the current iteration."""
+        self._last_sweep_state = self.sweep_state()
+        return self._last_sweep_state
+
+    @property
+    def _effective_poll_interval_s(self) -> float:
+        """How long to wait before the next poll, including any slowdown."""
+        return self._poll_interval_s + self._slowdown_s
+
+    def _reset_poll_slowdown(self) -> None:
+        """Return to the normal poll rate after a clean iteration."""
+        self._slowdown_s = 0.0
+        self._consecutive_errors = 0
+
+    def _handle_loop_error(self, exc: Exception) -> None:
+        """Slow the poll rate down for a survivable `exc`, or re-raise it.
+
+        `exc` is not retried here -- wandb-core already retried the call that
+        raised it. The next poll will reach the same API anyway; slowing the
+        loop down just spaces those polls out while W&B is unhealthy.
+
+        Args:
+            exc: The exception raised by the current loop iteration.
+
+        Raises:
+            Exception: `exc` itself, when it will not resolve on its own or too
+                many polls have failed in a row.
+        """
+        disposition = classify(exc)
+        if disposition is Disposition.NOT_FOUND:
+            termerror(
+                f"Sweep {self._sweep.name} or one of its runs no longer exists: {exc}"
+            )
+            raise exc
+        if disposition is Disposition.FATAL:
+            termerror(f"Error in scheduler loop for sweep {self._sweep.name}: {exc}")
+            raise exc
+
+        # Being throttled is the server working as intended, so it slows the
+        # poll down indefinitely rather than counting toward giving up.
+        if disposition is not Disposition.RATE_LIMITED:
+            self._consecutive_errors += 1
+            if self._consecutive_errors > _MAX_CONSECUTIVE_ERRORS:
+                termerror(
+                    f"Giving up on sweep {self._sweep.name} after "
+                    f"{self._consecutive_errors} consecutive failed polls: {exc}"
+                )
+                raise exc
+
+        self._slow_polling()
+        if disposition is Disposition.RATE_LIMITED:
+            termwarn(
+                f"W&B is rate limiting the scheduler for sweep "
+                f"{self._sweep.name}; polling every "
+                f"{self._effective_poll_interval_s:.0f}s"
+            )
+        else:
+            termwarn(
+                f"Error polling sweep {self._sweep.name}; polling every "
+                f"{self._effective_poll_interval_s:.0f}s until it clears: {exc}"
+            )
+
+    def _slow_polling(self) -> None:
+        """Double the slowdown, from `_INITIAL_SLOWDOWN_S` up to the cap."""
+        self._slowdown_s = min(
+            max(self._slowdown_s * 2, _INITIAL_SLOWDOWN_S),
+            _MAX_SLOWDOWN_S,
+        )
+
+    def _loop_iteration(self) -> _LoopControl:
+        """Run one scheduler iteration."""
+        # must reload the state just before calling this.
+        if self._last_sweep_state == SweepState.PAUSED:
+            return _LoopControl.CONTINUE
+        active = self._poll_active_runs()
+        self._prune_active_runs(active)
+        if self._optimizer.should_terminate_sweep():
+            termlog(
+                f"Sweep {self._sweep.name} should be terminated;exiting scheduler loop."
+            )
+            self._sweep.finish()
+            return _LoopControl.TERMINATE
+        # Reconcile against the executor's backend: drop runs whose job died
+        # before reporting to W&B (otherwise they'd pin capacity).
+        self._reap_dead_runs()
+        return self._schedule_suggestions()
+
+    def _warm_start(self) -> None:
+        # Warm-start must never block the loop from proposing new runs; errors
+        # ingesting an existing run are skipped with a warning.
+        for run in self.fetch_existing_finished_runs():
+            try:
+                self._optimizer.tell_existing_finished_run(run)
+            except Exception as e:
+                termwarn(
+                    f"Skipping finished run {run.wandb_run_id} while warm-starting "
+                    f"sweep {self._sweep.name}: {e}"
+                )
+        for active_run in self.fetch_existing_unfinished_runs():
+            # Adopt it so the loop keeps driving it and it counts toward the
+            # in-flight cap, instead of being re-proposed.
+            try:
+                optimizer_run_id = self._optimizer.tell_existing_active_run(active_run)
+                if optimizer_run_id is not None:
+                    self.push_in_flight_run(active_run.wandb_run_id, optimizer_run_id)
+            except Exception as e:
+                termwarn(
+                    f"Skipping unfinished run {active_run.wandb_run_id} while "
+                    f"warm-starting sweep {self._sweep.name}: {e}"
+                )
+
+    def _poll_active_runs(self) -> Iterable[RunWithMetrics]:
+        in_flight = self.in_flight_runs()
+        active = self.fetch_active_runs()
+        for data in active:
+            wandb_run_id = data.wandb_run_id
+            if wandb_run_id not in in_flight:
+                # A run we didn't enqueue (e.g. pre-existing); ignore it.
+                continue
+            optimizer_run_id = in_flight[wandb_run_id]
+
+            if (
+                self._optimizer.metric_value(data.summary_metrics) is None
+                and data.state == RunState.FINISHED
+            ):
+                termwarn(
+                    f"Run {wandb_run_id} in sweep {self._sweep.name} "
+                    f"has no metric value"
+                )
+                data.state = RunState.FAILED
+
+            try:
+                self._optimizer.tell_run(optimizer_run_id, data)
+            except Exception as e:
+                termerror(
+                    f"Error telling run {wandb_run_id} in sweep {self._sweep.name}: {e}"
+                )
+                raise
+
+            if data.state.value in _TERMINAL_STATES:
+                self.pop_in_flight_run(wandb_run_id)
+        self._reap_deleted_runs(active)
+        return active
+
+    def _prune_active_runs(self, active: Iterable[RunWithMetrics]) -> None:
+        # Ask the optimizer whether to stop any run still in flight after this
+        # poll's results were told to it. Separate from `_poll_active_runs` so
+        # every run's outcome is recorded before any pruning decision is made.
+        in_flight = self.in_flight_runs()
+        candidates: list[tuple[str, Any, RunWithMetrics]] = []
+        for data in active:
+            wandb_run_id = data.wandb_run_id
+            if wandb_run_id not in in_flight or data.state not in [
+                RunState.RUNNING,
+                RunState.PENDING,
+            ]:
+                continue
+            candidates.append((wandb_run_id, in_flight[wandb_run_id], data))
+        if not candidates:
+            return
+
+        optimizer_run_ids = [optimizer_run_id for _, optimizer_run_id, _ in candidates]
+        runs = [data for _, _, data in candidates]
+        wandb_run_id_by_optimizer_run_id = {
+            optimizer_run_id: wandb_run_id
+            for wandb_run_id, optimizer_run_id, _ in candidates
+        }
+        for optimizer_run_id in self._optimizer.prune_runs(optimizer_run_ids, runs):
+            if optimizer_run_id not in wandb_run_id_by_optimizer_run_id:
+                continue
+            wandb_run_id = wandb_run_id_by_optimizer_run_id[optimizer_run_id]
+            termlog(
+                f"Pruning run {wandb_run_id} (optimizer run {optimizer_run_id}) "
+                f"in sweep {self._sweep.name}"
+            )
+            if self.stop_run(wandb_run_id):
+                self.pop_in_flight_run(wandb_run_id)
+
+    def _reap_deleted_runs(self, active: Iterable[Run]) -> None:
+        # A run that was seen but didn't build is still on the server, so it
+        # counts as present and is retried next poll rather than failed.
+        present = set(run.wandb_run_id for run in active) | self.unreadable_run_ids()
+        runs = set(self.in_flight_runs().keys())
+        for wandb_run_id in runs - present:
+            self._optimizer.tell_run(
+                self.in_flight_runs()[wandb_run_id],
+                RunWithMetrics(
+                    # The run is gone from W&B, so there is no config to
+                    # read back; the outcome (failed) is all the optimizer
+                    # needs.
+                    config=RunConfig({}),
+                    state=RunState.FAILED,
+                    wandb_run_id=wandb_run_id,
+                    summary_metrics={},
+                    history_metrics=[],
+                ),
+            )
+            self.pop_in_flight_run(wandb_run_id)
+
+    def _reap_dead_runs(self) -> None:
+        """Fail and drain in-flight runs whose backend job is no longer alive.
+
+        A direct executor (e.g. SLURM/Volcano) may schedule a job that never
+        reaches `wandb.init` (rejected, preempted, crashed at startup), leaving
+        its W&B run stuck PENDING and pinned in-flight forever.
+        """
+        in_flight = self.in_flight_runs()
+        if not in_flight:
+            return
+        for run_id in self._executor.reap(set(in_flight)):
+            optimizer_run_id = in_flight.get(run_id)
+            if optimizer_run_id is None:
+                continue
+            termwarn(
+                f"Run {run_id} in sweep {self._sweep.name} is no longer alive at "
+                f"the executor but never reached a terminal W&B state; marking it "
+                f"failed."
+            )
+            data = RunWithMetrics(
+                # The run never reported to W&B, so there is no config to read
+                # back; the outcome (failed) is all the optimizer needs here.
+                config=RunConfig({}),
+                state=RunState.FAILED,
+                wandb_run_id=run_id,
+                summary_metrics={},
+                history_metrics=[],
+            )
+            try:
+                self._optimizer.tell_run(optimizer_run_id, data)
+            except Exception as e:
+                termerror(
+                    f"Error telling reaped run {run_id} in sweep "
+                    f"{self._sweep.name}: {e}"
+                )
+            self.pop_in_flight_run(run_id)
+
+    def _schedule_suggestions(self) -> _LoopControl:
+        """Top the sweep back up to `batch_size` runs in flight."""
+        # Keep at most `batch_size` runs in flight. `in_flight_runs` is
+        # populated on enqueue/adoption and drained as runs go terminal, so its
+        # size is the in-flight count.
+        in_flight = self.in_flight_runs()
+        n_to_enqueue = self._batch_size - len(in_flight)
+        if n_to_enqueue <= 0:
+            return _LoopControl.CONTINUE
+        suggestions = self._next_suggestions(n_to_enqueue)
+        if suggestions is None:
+            # search was interrupted
+            return _LoopControl.CONTINUE
+        if len(suggestions) == 0:
+            # search space is exhausted
+            return _LoopControl.TERMINATE
+        for suggestion in suggestions:
+            wandb_run_id = self._executor.schedule(suggestion)
+            self.push_in_flight_run(wandb_run_id, suggestion.run_id)
+            termlog(
+                f"Scheduled run {wandb_run_id} (optimizer run {suggestion.run_id}) "
+                f"in sweep {self._sweep.name} with config "
+                f"{suggestion.config.flat_dict()}"
+            )
+        return _LoopControl.CONTINUE
+
+    def _next_suggestions(self, n: int) -> Sequence[RunSuggestion] | None:
+        """Ask the optimizer for up to `n` runs, polling sweep state.
+
+        An optimizer that proposes nothing has exhausted its search space (grid
+        search, for one, stops proposing once every point has been handed out),
+        so there is nothing left to schedule and the sweep is finished here.
+
+        Returns:
+            The runs to enqueue; an empty sequence once the search space is
+            exhausted and the sweep has been finished; or None when the sweep
+            leaves RUNNING/PENDING/PAUSED (or a shutdown is requested) before
+            the optimizer responds, so the loop can exit without enqueueing
+            new runs.
+        """
+        suggestions: list[RunSuggestion] | None = None
+        done = threading.Event()
+
+        def fetch() -> None:
+            nonlocal suggestions
+            suggestions = list(self._optimizer.ask_n_runs(n))
+            done.set()
+
+        thread = threading.Thread(target=fetch, daemon=True)
+        thread.start()
+        # Waiting on the optimizer can outlast the state read at the top of the
+        # iteration, so these reads are fresh -- at the same slowed-down rate,
+        # so a throttled scheduler queries less often here too.
+        while not done.wait(timeout=self._effective_poll_interval_s):
+            if self._shutdown.requested:
+                return None
+            if self._refresh_sweep_state() not in _ACTIVE_SWEEP_STATES:
+                return None
+        if not suggestions:
+            termlog(
+                f"Optimizer for sweep {self._sweep.name} has no runs left to "
+                f"suggest; the search space is exhausted. Finishing sweep."
+            )
+            self._sweep.finish()
+            return []
+        return suggestions
+
+    def _build_runs(
+        self, runs: Iterable[Any], builder: Callable[[Any], _RunT]
+    ) -> Iterator[_RunT]:
+        # Lazily yield built runs as the paginated query advances, so warm-start
+        # can process them a page at a time rather than holding every run in
+        # memory.
+        for run in runs:
+            # A single unreadable run must not abort warm-starting the rest.
+            try:
+                built = builder(run)
+            except Exception as e:
+                termwarn(
+                    f"Skipping run {run.id} while warm-starting sweep "
+                    f"{self._sweep.name}: {e}"
+                )
+                continue
+            yield built

--- a/wandb/sdk/sweeps/scheduler/scheduler.py
+++ b/wandb/sdk/sweeps/scheduler/scheduler.py
@@ -1,0 +1,685 @@
+from __future__ import annotations
+
+import contextlib
+import select
+import signal
+import socket
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from wandb import termerror, termlog, termwarn
+from wandb.apis.public import Sweep, SweepState
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.failure_policy import Disposition, classify
+from wandb.sdk.sweeps.scheduler.optimizer import (
+    Optimizer,
+    Run,
+    RunConfig,
+    RunSuggestion,
+    RunWithMetrics,
+    is_terminal_state,
+)
+from wandb.wandb_agent import TERMINATING_SIGNALS, ShutdownSignal
+
+_RunT = TypeVar("_RunT", bound=Run)
+_T = TypeVar("_T")
+
+# Terminal states, derived from `is_terminal_state` so the two stay in sync.
+_TERMINAL_STATES = [s.value for s in RunState if is_terminal_state(s)]
+
+# Sweep states the loop keeps polling for. Anything else ends it.
+_ACTIVE_SWEEP_STATES = frozenset(
+    {
+        SweepState.RUNNING,
+        SweepState.PENDING,
+        SweepState.PAUSED,
+    }
+)
+
+# How much longer to wait between polls once W&B calls start failing. This
+# throttles the whole loop -- a failed call is never re-issued, since
+# wandb-core already retried it; the next poll just happens later, so an
+# unhealthy or throttling backend receives fewer requests per minute. The delay
+# is added to `poll_interval_s` (absolute, so a `poll_interval_s` of 0 still
+# slows down) and doubles per consecutive failed poll.
+_INITIAL_SLOWDOWN_S = 1.0
+_MAX_SLOWDOWN_S = 60.0
+
+# Consecutive failed polls to absorb before giving up on the sweep. Rate
+# limiting doesn't count toward this.
+_MAX_CONSECUTIVE_ERRORS = 10
+
+
+class Executor(ABC):
+    """The backend that starts a suggested run and reports on it later.
+
+    Subclass this to schedule runs somewhere other than the W&B run queue, e.g.
+    directly onto SLURM or Volcano. See `WBAgentExecutor` for the default.
+    """
+
+    @abstractmethod
+    def schedule(self, suggestion: RunSuggestion) -> str:
+        """Start or queue a run for `suggestion`; return its W&B run id."""
+        ...
+
+    def reap(self, run_ids: Iterable[str]) -> set[str]:
+        """Return the `run_ids` whose backend jobs are no longer alive.
+
+        Catches jobs that died before `wandb.init` ran (rejected,
+        preempted, crashed at startup) and left their W&B run stuck PENDING.
+        """
+        return set()
+
+
+class WBAgentExecutor(Executor):
+    """Default executor: enqueue the run into the W&B sweep's run queue.
+
+    A W&B agent (`wandb agent <sweep>`) pulls the queued run and executes it.
+    """
+
+    def __init__(self, sweep: Sweep):
+        self._sweep = sweep
+
+    def schedule(self, suggestion: RunSuggestion) -> str:
+        """Enqueue the run in the sweep's queue; return its W&B run id."""
+        return self._sweep.enqueue_run(suggestion.config.wire_dict())
+
+
+class _ShutdownMonitor:
+    """Turn terminating signals into a graceful-shutdown request."""
+
+    def __init__(self) -> None:
+        self._requested = False
+        self._signum: int | None = None
+        self._announced = False
+        self._original_handlers: dict[int, Any] = {}
+        self._wakeup_recv: socket.socket | None = None
+        self._wakeup_send: socket.socket | None = None
+        # The wakeup fd this monitor replaced; None while not installed.
+        self._prev_wakeup_fd: int | None = None
+
+    @property
+    def requested(self) -> bool:
+        """Whether a shutdown has been requested (by signal or `request`).
+
+        A read that observes a signal's request also logs the one-time
+        acknowledgment, which the signal handler could not do safely.
+        """
+        if self._requested:
+            self._announce()
+        return self._requested
+
+    def request(self, signum: int) -> None:
+        """Record a shutdown request from normal (non-handler) code."""
+        self._signum = signum
+        self._requested = True
+        self._announce()
+
+    def handle_signal(self, signum: int, frame: Any) -> None:
+        """Record a shutdown request; installed as the signal handler.
+
+        Plain attribute writes only to prevent deadlocks
+        """
+        self._signum = signum
+        self._requested = True
+
+    def install(self) -> None:
+        """Install the signal handlers and wakeup fd, resetting any request.
+
+        Handlers and the wakeup fd can only be set on the main thread;
+        elsewhere they are skipped and `wait` degrades to a full sleep.
+        """
+        self._requested = False
+        self._signum = None
+        self._announced = False
+        # A socketpair rather than a pipe because on Windows the wakeup fd
+        # must be a socket. Non-blocking on both ends so signal delivery
+        # never blocks on a full buffer.
+        self._wakeup_recv, self._wakeup_send = socket.socketpair()
+        self._wakeup_recv.setblocking(False)
+        self._wakeup_send.setblocking(False)
+        try:
+            self._prev_wakeup_fd = signal.set_wakeup_fd(
+                self._wakeup_send.fileno(), warn_on_full_buffer=False
+            )
+        except ValueError:  # not the main thread
+            self._prev_wakeup_fd = None
+
+        shutdown_signals = TERMINATING_SIGNALS | {signal.SIGINT}
+        skip_signals = {
+            getattr(signal, "SIGKILL", None),
+            getattr(signal, "SIGSTOP", None),
+        }
+        skip_signals.discard(None)
+        for signum in signal.valid_signals():
+            if signum in skip_signals or signum not in shutdown_signals:
+                continue
+            with contextlib.suppress(OSError, ValueError):
+                self._original_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, self.handle_signal)
+
+    def restore(self) -> None:
+        """Undo `install`: put back the prior handlers and wakeup fd."""
+        for signum, handler in self._original_handlers.items():
+            with contextlib.suppress(OSError, ValueError):
+                signal.signal(signum, handler)
+        self._original_handlers.clear()
+        if self._prev_wakeup_fd is not None:
+            with contextlib.suppress(ValueError):
+                signal.set_wakeup_fd(self._prev_wakeup_fd)
+            self._prev_wakeup_fd = None
+        for sock in (self._wakeup_recv, self._wakeup_send):
+            if sock is not None:
+                sock.close()
+        self._wakeup_recv = None
+        self._wakeup_send = None
+
+    def wait(self, seconds: float) -> None:
+        """Sleep up to `seconds`, returning as soon as shutdown is requested."""
+        if self._wakeup_recv is None:
+            # Not installed, so nothing can wake the wait early anyway.
+            time.sleep(seconds)
+            return
+        deadline = time.monotonic() + seconds
+        # One pass per delivered signal, not a poll: `select` blocks until
+        # the deadline unless some signal writes a wakeup byte.
+        while not self.requested:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            select.select([self._wakeup_recv], [], [], remaining)
+            self._drain_wakeup_bytes()
+
+    def _drain_wakeup_bytes(self) -> None:
+        """Empty the wakeup socket so stale bytes don't cut a wait short."""
+        assert self._wakeup_recv is not None
+        # recv raises BlockingIOError (an OSError) once the socket is empty.
+        with contextlib.suppress(OSError):
+            while self._wakeup_recv.recv(4096):
+                pass
+
+    def _announce(self) -> None:
+        if self._announced or self._signum is None:
+            return
+        self._announced = True
+        if self._signum == signal.SIGINT:
+            label = "ctrl-c"
+        else:
+            label = signal.Signals(self._signum).name
+        termlog(
+            f"{label} received. Finishing current scheduler iteration before exiting."
+        )
+
+
+@dataclass
+class SchedulerOptions:
+    """How a scheduler drives a sweep, independent of the search strategy.
+
+    `executor` is the backend that schedules runs; the default is the W&B run
+    queue.
+    """
+
+    poll_interval_s: float = 5.0
+    batch_size: int = 1
+    executor: Executor | None = None
+
+
+class Scheduler(ABC):
+    """Drive an `Optimizer` against a sweep, keeping `batch_size` in flight.
+
+    Poll runs, tell the optimizer their results, and enqueue its suggestions.
+    Subclasses implement the hooks below to choose where in-flight state lives
+    and how runs are observed.
+    See `InMemoryScheduler` for the default implementation.
+    """
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        sweep: Sweep,
+        options: SchedulerOptions | None = None,
+    ):
+        options = options or SchedulerOptions()
+        self._optimizer = optimizer
+        self._sweep = sweep
+        self._poll_interval_s = options.poll_interval_s
+        self._batch_size = options.batch_size
+        self._executor = options.executor or WBAgentExecutor(sweep)
+        self._shutdown = _ShutdownMonitor()
+        # The state read at the top of the current iteration; one read
+        # serves everything in it.
+        self._last_sweep_state: SweepState | None = None
+        self._slowdown_s = 0.0
+        self._consecutive_errors = 0
+
+    @abstractmethod
+    def in_flight_runs(self) -> Mapping[str, Any]:
+        """The live, mutable {wandb_run_id: optimizer_run_id} in-flight map."""
+        ...
+
+    @abstractmethod
+    def pop_in_flight_run(self, wandb_run_id: str) -> Any:
+        """Remove a run from the in-flight set."""
+        ...
+
+    @abstractmethod
+    def push_in_flight_run(self, wandb_run_id: str, optimizer_run_id: Any) -> None:
+        """Add a run to the in-flight set.
+
+        Raises:
+            ValueError: If `wandb_run_id` is already in flight.
+        """
+        ...
+
+    @abstractmethod
+    def fetch_existing_finished_runs(self) -> Iterable[RunWithMetrics]:
+        """Terminal runs already in the sweep, with their summary metrics."""
+        ...
+
+    @abstractmethod
+    def fetch_existing_unfinished_runs(self) -> Iterable[Run]:
+        """In-flight runs already in the sweep, without metrics, to adopt."""
+        ...
+
+    @abstractmethod
+    def fetch_active_runs(self) -> Iterable[RunWithMetrics]:
+        """The tracked in-flight runs, with fresh state/metrics and history."""
+        ...
+
+    @abstractmethod
+    def sweep_state(self) -> SweepState:
+        """The sweep's current state; the loop runs while RUNNING/PENDING."""
+        ...
+
+    def unreadable_run_ids(self) -> frozenset[str]:
+        """W&B run ids the last `fetch_active_runs` saw but could not build.
+
+        Such a run still exists on the server, so it must not be reaped as
+        deleted. Override this alongside `fetch_active_runs` when that hook
+        skips runs; the default reports none.
+        """
+        return frozenset()
+
+    @abstractmethod
+    def stop_run(self, wandb_run_id: str) -> bool:
+        """Request that a run stop early; True if the stop was accepted."""
+        ...
+
+    def loop(self) -> None:
+        """Warm-start, then poll and schedule runs until the sweep ends.
+
+        Warm-starting runs first, so runs already in the sweep (e.g. from a
+        previous scheduler instance) count toward the in-flight cap before any
+        new ones are enqueued.
+
+        `ShutdownSignal` (SIGTERM/SIGHUP/SIGQUIT) and `KeyboardInterrupt`
+        (ctrl-c) let the current loop iteration finish before exiting.
+
+        Intermittent W&B API failures don't end the sweep: the loop keeps
+        polling, just further apart, until they clear or
+        `_MAX_CONSECUTIVE_ERRORS` polls have failed in a row. Failures that
+        won't resolve on their own end the loop immediately. See
+        `failure_policy.classify`.
+
+        Raises:
+            Exception: The failure that ended the loop, when a W&B API call
+                failed permanently or kept failing poll after poll.
+        """
+        self._reset_poll_slowdown()
+        self._shutdown.install()  # also resets any earlier request
+        try:
+            # Not retried: `_warm_start` is not idempotent, so a second
+            # attempt would double-count runs it already ingested.
+            self._warm_start()
+
+            while not self._shutdown.requested:
+                try:
+                    # Read inside the try so a failure here is handled too.
+                    if self._refresh_sweep_state() not in _ACTIVE_SWEEP_STATES:
+                        break
+                    if self._loop_iteration():
+                        break
+                    self._reset_poll_slowdown()
+                except (KeyboardInterrupt, ShutdownSignal) as e:
+                    signum = (
+                        signal.SIGINT if isinstance(e, KeyboardInterrupt) else e.signum
+                    )
+                    self._shutdown.request(signum)
+                    break
+                except Exception as e:
+                    self._handle_loop_error(e)  # re-raises unless survivable
+                self._shutdown.wait(self._effective_poll_interval_s)
+        finally:
+            self._shutdown.restore()
+
+        # Report the cached state: another query here could fail from a point
+        # past the handling above.
+        state = self._last_sweep_state
+        if state is None:
+            termlog(f"Sweep {self._sweep.name} has exited")
+        else:
+            termlog(f"Sweep {self._sweep.name} has exited with state {state}")
+
+    def _refresh_sweep_state(self) -> SweepState:
+        """Read the sweep's state and cache it for the current iteration."""
+        self._last_sweep_state = self.sweep_state()
+        return self._last_sweep_state
+
+    @property
+    def _effective_poll_interval_s(self) -> float:
+        """How long to wait before the next poll, including any slowdown."""
+        return self._poll_interval_s + self._slowdown_s
+
+    def _reset_poll_slowdown(self) -> None:
+        """Return to the normal poll rate after a clean iteration."""
+        self._slowdown_s = 0.0
+        self._consecutive_errors = 0
+
+    def _handle_loop_error(self, exc: Exception) -> None:
+        """Slow the poll rate down for a survivable `exc`, or re-raise it.
+
+        `exc` is not retried here -- wandb-core already retried the call that
+        raised it. The next poll will reach the same API anyway; slowing the
+        loop down just spaces those polls out while W&B is unhealthy.
+
+        Args:
+            exc: The exception raised by the current loop iteration.
+
+        Raises:
+            Exception: `exc` itself, when it will not resolve on its own or too
+                many polls have failed in a row.
+        """
+        disposition = classify(exc)
+        if disposition is Disposition.NOT_FOUND:
+            termerror(
+                f"Sweep {self._sweep.name} or one of its runs no longer exists: {exc}"
+            )
+            raise exc
+        if disposition is Disposition.FATAL:
+            termerror(f"Error in scheduler loop for sweep {self._sweep.name}: {exc}")
+            raise exc
+
+        # Being throttled is the server working as intended, so it slows the
+        # poll down indefinitely rather than counting toward giving up.
+        if disposition is not Disposition.RATE_LIMITED:
+            self._consecutive_errors += 1
+            if self._consecutive_errors > _MAX_CONSECUTIVE_ERRORS:
+                termerror(
+                    f"Giving up on sweep {self._sweep.name} after "
+                    f"{self._consecutive_errors} consecutive failed polls: {exc}"
+                )
+                raise exc
+
+        self._slow_polling()
+        if disposition is Disposition.RATE_LIMITED:
+            termwarn(
+                f"W&B is rate limiting the scheduler for sweep "
+                f"{self._sweep.name}; polling every "
+                f"{self._effective_poll_interval_s:.0f}s"
+            )
+        else:
+            termwarn(
+                f"Error polling sweep {self._sweep.name}; polling every "
+                f"{self._effective_poll_interval_s:.0f}s until it clears: {exc}"
+            )
+
+    def _slow_polling(self) -> None:
+        """Double the slowdown, from `_INITIAL_SLOWDOWN_S` up to the cap."""
+        self._slowdown_s = min(
+            max(self._slowdown_s * 2, _INITIAL_SLOWDOWN_S),
+            _MAX_SLOWDOWN_S,
+        )
+
+    def _loop_iteration(self) -> bool:
+        """Run one scheduler iteration.
+
+        Returns:
+            True when the main loop should exit.
+        """
+        # must reload the state just before calling this.
+        if self._last_sweep_state == SweepState.PAUSED:
+            return False
+        active = self._poll_active_runs()
+        self._prune_active_runs(active)
+        if self._optimizer.should_terminate_sweep():
+            termlog(
+                f"Sweep {self._sweep.name} should be terminated;exiting scheduler loop."
+            )
+            self._sweep.finish()
+            return True
+        # Reconcile against the executor's backend: drop runs whose job died
+        # before reporting to W&B (otherwise they'd pin capacity).
+        self._reap_dead_runs()
+        if self._schedule_suggestions():
+            return True
+        return self._shutdown.requested
+
+    def _warm_start(self) -> None:
+        # Warm-start must never block the loop from proposing new runs; errors
+        # ingesting an existing run are skipped with a warning.
+        for run in self.fetch_existing_finished_runs():
+            try:
+                self._optimizer.tell_existing_finished_run(run)
+            except Exception as e:
+                termwarn(
+                    f"Skipping finished run {run.wandb_run_id} while warm-starting "
+                    f"sweep {self._sweep.name}: {e}"
+                )
+        for active_run in self.fetch_existing_unfinished_runs():
+            # Adopt it so the loop keeps driving it and it counts toward the
+            # in-flight cap, instead of being re-proposed.
+            try:
+                optimizer_run_id = self._optimizer.tell_existing_active_run(active_run)
+                if optimizer_run_id is not None:
+                    self.push_in_flight_run(active_run.wandb_run_id, optimizer_run_id)
+            except Exception as e:
+                termwarn(
+                    f"Skipping unfinished run {active_run.wandb_run_id} while "
+                    f"warm-starting sweep {self._sweep.name}: {e}"
+                )
+
+    def _poll_active_runs(self) -> Iterable[RunWithMetrics]:
+        in_flight = self.in_flight_runs()
+        active = self.fetch_active_runs()
+        for data in active:
+            wandb_run_id = data.wandb_run_id
+            if wandb_run_id not in in_flight:
+                # A run we didn't enqueue (e.g. pre-existing); ignore it.
+                continue
+            optimizer_run_id = in_flight[wandb_run_id]
+
+            if (
+                self._optimizer.metric_value(data.summary_metrics) is None
+                and data.state == RunState.FINISHED
+            ):
+                termwarn(
+                    f"Run {wandb_run_id} in sweep {self._sweep.name} "
+                    f"has no metric value"
+                )
+                data.state = RunState.FAILED
+
+            try:
+                self._optimizer.tell_run(optimizer_run_id, data)
+            except Exception as e:
+                termerror(
+                    f"Error telling run {wandb_run_id} in sweep {self._sweep.name}: {e}"
+                )
+                raise
+
+            if data.state.value in _TERMINAL_STATES:
+                self.pop_in_flight_run(wandb_run_id)
+        self._reap_deleted_runs(active)
+        return active
+
+    def _prune_active_runs(self, active: Iterable[RunWithMetrics]) -> None:
+        # Ask the optimizer whether to stop any run still in flight after this
+        # poll's results were told to it. Separate from `_poll_active_runs` so
+        # every run's outcome is recorded before any pruning decision is made.
+        in_flight = self.in_flight_runs()
+        for data in active:
+            wandb_run_id = data.wandb_run_id
+            if wandb_run_id not in in_flight or data.state not in [
+                RunState.RUNNING,
+                RunState.PENDING,
+            ]:
+                continue
+            optimizer_run_id = in_flight[wandb_run_id]
+            if self._optimizer.prune_run(optimizer_run_id, data):
+                termlog(
+                    f"Pruning run {wandb_run_id} (optimizer run {optimizer_run_id}) "
+                    f"in sweep {self._sweep.name}"
+                )
+                if self.stop_run(wandb_run_id):
+                    self.pop_in_flight_run(wandb_run_id)
+
+    def _reap_deleted_runs(self, active: Iterable[Run]) -> None:
+        # A run that was seen but didn't build is still on the server, so it
+        # counts as present and is retried next poll rather than failed.
+        present = set(run.wandb_run_id for run in active) | self.unreadable_run_ids()
+        runs = set(self.in_flight_runs().keys())
+        for wandb_run_id in runs - present:
+            self._optimizer.tell_run(
+                self.in_flight_runs()[wandb_run_id],
+                RunWithMetrics(
+                    # The run is gone from W&B, so there is no config to
+                    # read back; the outcome (failed) is all the optimizer
+                    # needs.
+                    config=RunConfig({}),
+                    state=RunState.FAILED,
+                    wandb_run_id=wandb_run_id,
+                    summary_metrics={},
+                    history_metrics=[],
+                ),
+            )
+            self.pop_in_flight_run(wandb_run_id)
+
+    def _reap_dead_runs(self) -> None:
+        """Fail and drain in-flight runs whose backend job is no longer alive.
+
+        A direct executor (e.g. SLURM/Volcano) may schedule a job that never
+        reaches `wandb.init` (rejected, preempted, crashed at startup), leaving
+        its W&B run stuck PENDING and pinned in-flight forever.
+        """
+        in_flight = self.in_flight_runs()
+        if not in_flight:
+            return
+        for run_id in self._executor.reap(set(in_flight)):
+            optimizer_run_id = in_flight.get(run_id)
+            if optimizer_run_id is None:
+                continue
+            termwarn(
+                f"Run {run_id} in sweep {self._sweep.name} is no longer alive at "
+                f"the executor but never reached a terminal W&B state; marking it "
+                f"failed."
+            )
+            data = RunWithMetrics(
+                # The run never reported to W&B, so there is no config to read
+                # back; the outcome (failed) is all the optimizer needs here.
+                config=RunConfig({}),
+                state=RunState.FAILED,
+                wandb_run_id=run_id,
+                summary_metrics={},
+                history_metrics=[],
+            )
+            try:
+                self._optimizer.tell_run(optimizer_run_id, data)
+            except Exception as e:
+                termerror(
+                    f"Error telling reaped run {run_id} in sweep "
+                    f"{self._sweep.name}: {e}"
+                )
+            self.pop_in_flight_run(run_id)
+
+    def _schedule_suggestions(self) -> bool:
+        """Top the sweep back up to `batch_size` runs in flight.
+
+        Returns:
+            True when the optimizer's search space is exhausted and the sweep
+            was finished, so the loop should exit.
+        """
+        # Keep at most `batch_size` runs in flight. `in_flight_runs` is
+        # populated on enqueue/adoption and drained as runs go terminal, so its
+        # size is the in-flight count.
+        in_flight = self.in_flight_runs()
+        n_to_enqueue = self._batch_size - len(in_flight)
+        if n_to_enqueue <= 0:
+            return False
+        suggestions = self._next_suggestions(n_to_enqueue)
+        if suggestions is None:
+            # search was interrupted
+            return False
+        if len(suggestions) == 0:
+            # search space is exhausted
+            return True
+        for suggestion in suggestions:
+            wandb_run_id = self._executor.schedule(suggestion)
+            self.push_in_flight_run(wandb_run_id, suggestion.run_id)
+            termlog(
+                f"Scheduled run {wandb_run_id} (optimizer run {suggestion.run_id}) "
+                f"in sweep {self._sweep.name} with config "
+                f"{suggestion.config.flat_dict()}"
+            )
+        return False
+
+    def _next_suggestions(self, n: int) -> Sequence[RunSuggestion] | None:
+        """Ask the optimizer for up to `n` runs, polling sweep state.
+
+        An optimizer that proposes nothing has exhausted its search space (grid
+        search, for one, stops proposing once every point has been handed out),
+        so there is nothing left to schedule and the sweep is finished here.
+
+        Returns:
+            The runs to enqueue; an empty sequence once the search space is
+            exhausted and the sweep has been finished; or None when the sweep
+            leaves RUNNING/PENDING/PAUSED (or a shutdown is requested) before
+            the optimizer responds, so the loop can exit without enqueueing
+            new runs.
+        """
+        suggestions: list[RunSuggestion] | None = None
+        done = threading.Event()
+
+        def fetch() -> None:
+            nonlocal suggestions
+            suggestions = list(self._optimizer.ask_n_runs(n))
+            done.set()
+
+        thread = threading.Thread(target=fetch, daemon=True)
+        thread.start()
+        # Waiting on the optimizer can outlast the state read at the top of the
+        # iteration, so these reads are fresh -- at the same slowed-down rate,
+        # so a throttled scheduler queries less often here too.
+        while not done.wait(timeout=self._effective_poll_interval_s):
+            if self._shutdown.requested:
+                return None
+            if self._refresh_sweep_state() not in _ACTIVE_SWEEP_STATES:
+                return None
+        if not suggestions:
+            termlog(
+                f"Optimizer for sweep {self._sweep.name} has no runs left to "
+                f"suggest; the search space is exhausted. Finishing sweep."
+            )
+            self._sweep.finish()
+            return []
+        return suggestions
+
+    def _build_runs(
+        self, runs: Iterable[Any], builder: Callable[[Any], _RunT]
+    ) -> Iterator[_RunT]:
+        # Lazily yield built runs as the paginated query advances, so warm-start
+        # can process them a page at a time rather than holding every run in
+        # memory.
+        for run in runs:
+            # A single unreadable run must not abort warm-starting the rest.
+            try:
+                built = builder(run)
+            except Exception as e:
+                termwarn(
+                    f"Skipping run {run.id} while warm-starting sweep "
+                    f"{self._sweep.name}: {e}"
+                )
+                continue
+            yield built

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # Signals whose kernel default is "terminate" and that orchestrators use to
 # request graceful shutdown.
-_TERMINATING_SIGNALS = frozenset(
+TERMINATING_SIGNALS = frozenset(
     s
     for s in (
         getattr(signal, "SIGTERM", None),
@@ -186,7 +186,7 @@ class AgentProcess:
         original_handler = self._original_handlers.get(signum)
         if original_handler and callable(original_handler):
             original_handler(signum, frame)
-        elif signum in _TERMINATING_SIGNALS:
+        elif signum in TERMINATING_SIGNALS:
             raise ShutdownSignal(signum)
 
     def _start(self, finished_q, env, function, run_id, in_jupyter):


### PR DESCRIPTION
Description
-----------
- Fixes WB-38287

- `loop()` is the entrypoint that handles the business logic of maintaining batch_size active runs
- `in_flight_runs()` returns all runs that have been pushed to the run queue and not reached a terminal state
- `pop_in_flight_run()` removes a run from tracking
- `push_in_flight_run()` adds a run to tracking
- `fetch_existing_finished_runs()` queries the API for all runs on the sweep that are in a terminal state
- `fetch_existing_unfinished_runs()` queries the API for all runs pending or running
- `fetch_active_runs()` polls the current list of tracked runs from the Api from the in_flight_runs() list
- `sweep_state()` updates the sweep state from the API
- `unreadable_run_ids()` keeps track of runs whose .history() call or other Api call returned an error, or otherwise did not process correctly
- `stop_run()` calls the Api to stop a run from pruning or early_terminate

- [x] CHANGELOG.unreleased.md N/A


Testing
-------
Unit tested with above PRs in the stack
