### PR TITLE
feat: wandb sync-tensorboard

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -45,6 +45,7 @@ from wandb.sync import TFEVENT_SUBSTRING, SyncManager, get_runs
 from .beta import beta
 from .clean import clean
 from .leet import leet
+from .sync_tensorboard import sync_tensorboard
 
 
 def _get_wandb_dir(root_dir: str | None = None) -> str:
@@ -3730,3 +3731,4 @@ def purge_cache(
 cli.add_command(beta)
 cli.add_command(leet)
 cli.add_command(clean)
+cli.add_command(sync_tensorboard)

--- a/wandb/cli/sync_tensorboard.py
+++ b/wandb/cli/sync_tensorboard.py
@@ -1,0 +1,41 @@
+"""Implements `wandb sync-tensorboard`."""
+
+import click
+
+import wandb
+
+
+@click.command()
+@click.argument("path")
+@click.option(
+    "--save-to",
+    help="""Run folder where to put the tfevents files.
+
+    Defaults to the run's root directory. Ignored if PATH is a cloud URI.
+    """,
+    default="",
+)
+@click.option(
+    "--namespace",
+    help="""Prefix to add to metric names. No prefix by default.""",
+    default="",
+)
+def sync_tensorboard(
+    path: str,
+    save_to: str,
+    namespace: str,
+) -> None:
+    """Sync TensorBoard tfevents files to W&B.
+
+    This is a convenience command for using `wandb.init()` and calling
+    `run.sync_tensorboard(..., existing_files=True)`.
+    See the `run.sync_tensorboard()` method for more information about this
+    feature and its options.
+    """
+    with wandb.init() as run:
+        run.sync_tensorboard(
+            path,
+            save_to=save_to,
+            namespace=namespace,
+            existing_files=True,
+        )


### PR DESCRIPTION
Adds the `wandb sync-tensorboard` command to replace `wandb sync --sync-tensorboard`.

TODO: I still need to deprecate `wandb sync --sync-tensorboard` and run some more tests. I'd also like to fix up some inconveniences in our TB integration before merging this.