### PR TITLE
fix(automations): move server-compatibility checks for automations out of wandb.Api

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -33,6 +33,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Response parsing is now faster for many `wandb.Api` operations, including artifact and registry queries (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12213)
 - `wandb.init()` now reports the error it was retrying (such as a network error) when it times out, instead of a generic timeout message. The `init_timeout` setting now also bounds the backend's retries during run initialization (@skhanna-cw in https://github.com/wandb/wandb/pull/12216)
 - `wandb.Api().create_run_queue()`, `wandb.Api().create_custom_chart()`, and `wandb.Api().upsert_run_queue()` now raise `WandbApiFailedError` when the operation fails on the backend. (@jacobromero in https://github.com/wandb/wandb/pull/12307)
+- `Api.{create,update}_automation()` now raise `UnsupportedError` instead of `CommError` when the server doesn't support the given automation (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12194)
 
 ## Removed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,3 +13,7 @@ sections:
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Changed
+
+- `Api.{create,update}_automation()` now raise `UnsupportedError` instead of `CommError` when the server doesn't support the given automation (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12194)

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -31,15 +31,19 @@ from wandb.automations import (
     SendWebhook,
     WebhookIntegration,
 )
+from wandb.automations._compat import action_enabled, event_enabled, scope_enabled
 from wandb.automations._generated import (
     CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL,
     CreateGenericWebhookIntegration,
 )
-from wandb.automations._utils import INVALID_INPUT_ACTIONS, INVALID_INPUT_EVENTS
+from wandb.automations._inputs import INVALID_INPUT_ACTIONS, INVALID_INPUT_EVENTS
 from wandb.automations.events import InputEvent
 
 if TYPE_CHECKING:
-    from tests.system_tests.backend_fixtures import BackendFixtureFactory
+    from tests.system_tests.backend_fixtures import (
+        BackendFixtureFactory,
+        TeamAndOrgNames,
+    )
 
 ScopableWandbType: TypeAlias = ArtifactCollection | Project | Team | Organization
 
@@ -65,8 +69,43 @@ def make_name(worker_id: str) -> Callable[[str], str]:
 
 
 @fixture(scope="module")
-def project(
+def team_and_org(
     module_user: str,
+    backend_fixture_factory: BackendFixtureFactory,
+) -> TeamAndOrgNames:
+    """A test team (entity) and org.
+
+    The module user is a bare user with no organization, so it can't itself be an
+    entity scope: entity-scoped automations require an org-associated entity. We
+    therefore create a real org+team for the user and scope to the team entity.
+    """
+    return backend_fixture_factory.make_team(username=module_user)
+
+
+@fixture(scope="module")
+def team(
+    team_and_org: TeamAndOrgNames,
+    make_module_api: Callable[[], wandb.Api],
+) -> Team:
+    """A wandb Team entity for tests in this module."""
+    team = make_module_api().team(team_and_org.team)
+    # This fixture is module-scoped; load attrs before per-test teardown invalidates the API.
+    _ = team.id
+    return team
+
+
+@fixture(scope="module")
+def org(
+    team_and_org: TeamAndOrgNames,
+    make_module_api: Callable[[], wandb.Api],
+) -> Organization:
+    """A wandb Organization for tests in this module."""
+    return make_module_api().organization(team_and_org.org)
+
+
+@fixture(scope="module")
+def project(
+    team: Team,
     make_module_api: Callable[[], wandb.Api],
     make_name,
 ) -> Project:
@@ -74,17 +113,17 @@ def project(
     # Create the project first if it doesn't exist yet
     name = make_name("test-project")
     api = make_module_api()
-    api.create_project(name=name, entity=module_user)
-    project = api.project(name=name, entity=module_user)
+    api.create_project(name=name, entity=team.name)
+    project = api.project(name=name, entity=team.name)
     # This fixture is module-scoped; load attrs before per-test teardown invalidates the API.
     _ = project.id
     return project
 
 
 @fixture(scope="module")
-def artifact(module_user: str, project: Project, make_name) -> Artifact:
+def artifact(team: Team, project: Project, make_name) -> Artifact:
     name = make_name("test-artifact")
-    with wandb.init(entity=module_user, project=project.name) as run:
+    with wandb.init(entity=team.name, project=project.name) as run:
         artifact = Artifact(name, "dataset")
         logged_artifact = run.log_artifact(artifact)
         return logged_artifact.wait()
@@ -98,23 +137,9 @@ def artifact_collection(
     """A test ArtifactCollection for tests in this module."""
     return (
         make_module_api()
-        .artifact(
-            name=artifact.qualified_name,
-            type=artifact.type,
-        )
+        .artifact(name=artifact.qualified_name, type=artifact.type)
         .collection
     )
-
-
-@fixture(scope="module")
-def team(
-    backend_fixture_factory: BackendFixtureFactory,
-    module_user: str,
-    make_module_api: Callable[[], wandb.Api],
-) -> Team:
-    """A test team entity for tests in this module."""
-    name = backend_fixture_factory.make_team(username=module_user).team
-    return make_module_api().team(name)
 
 
 @fixture(scope="module")
@@ -221,7 +246,7 @@ def pytest_collection_modifyitems(config, items):
 @fixture(params=valid_input_scopes(), ids=lambda x: f"scope={x.value}")
 def scope_type(request: FixtureRequest, module_api: wandb.Api) -> ScopeType:
     """A fixture that parametrizes over all valid scope types."""
-    if not module_api._supports_automation(scope=(scope_type := request.param)):
+    if not scope_enabled(module_api._service_api, scope_type := request.param):
         skip(f"Server does not support scope type: {scope_type!r}")
 
     return scope_type
@@ -234,7 +259,7 @@ def event_type(
     module_api: wandb.Api,
 ) -> EventType:
     """A fixture that parametrizes over all valid event types."""
-    if not module_api._supports_automation(event=(event_type := request.param)):
+    if not event_enabled(module_api._service_api, event_type := request.param):
         skip(f"Server does not support event type: {event_type!r}")
 
     if (event_type, scope_type) in invalid_events_and_scopes():
@@ -249,7 +274,7 @@ def action_type(
     module_api: wandb.Api,
 ) -> ActionType:
     """A fixture that parametrizes over all valid action types."""
-    if not module_api._supports_automation(action=(action_type := request.param)):
+    if not action_enabled(module_api._service_api, action_type := request.param):
         skip(f"Server does not support action type: {action_type!r}")
 
     return action_type

--- a/tests/system_tests/test_automations/conftest.py
+++ b/tests/system_tests/test_automations/conftest.py
@@ -35,7 +35,13 @@ from wandb.automations._generated import (
     CREATE_GENERIC_WEBHOOK_INTEGRATION_GQL,
     CreateGenericWebhookIntegration,
 )
-from wandb.automations._utils import INVALID_INPUT_ACTIONS, INVALID_INPUT_EVENTS
+from wandb.automations._utils import (
+    INVALID_INPUT_ACTIONS,
+    INVALID_INPUT_EVENTS,
+    action_enabled,
+    event_enabled,
+    scope_enabled,
+)
 from wandb.automations.events import InputEvent
 
 if TYPE_CHECKING:
@@ -221,7 +227,7 @@ def pytest_collection_modifyitems(config, items):
 @fixture(params=valid_input_scopes(), ids=lambda x: f"scope={x.value}")
 def scope_type(request: FixtureRequest, module_api: wandb.Api) -> ScopeType:
     """A fixture that parametrizes over all valid scope types."""
-    if not module_api._supports_automation(scope=(scope_type := request.param)):
+    if not scope_enabled(module_api._service_api, scope_type := request.param):
         skip(f"Server does not support scope type: {scope_type!r}")
 
     return scope_type
@@ -234,7 +240,7 @@ def event_type(
     module_api: wandb.Api,
 ) -> EventType:
     """A fixture that parametrizes over all valid event types."""
-    if not module_api._supports_automation(event=(event_type := request.param)):
+    if not event_enabled(module_api._service_api, event_type := request.param):
         skip(f"Server does not support event type: {event_type!r}")
 
     if (event_type, scope_type) in invalid_events_and_scopes():
@@ -249,7 +255,7 @@ def action_type(
     module_api: wandb.Api,
 ) -> ActionType:
     """A fixture that parametrizes over all valid action types."""
-    if not module_api._supports_automation(action=(action_type := request.param)):
+    if not action_enabled(module_api._service_api, action_type := request.param):
         skip(f"Server does not support action type: {action_type!r}")
 
     return action_type

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -4,7 +4,7 @@ import math
 from collections import deque
 from collections.abc import Callable, Generator
 from itertools import islice
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import wandb
 from pytest import FixtureRequest, fixture, mark, raises, skip
@@ -29,11 +29,15 @@ from wandb.automations import (
     SendWebhook,
     WebhookIntegration,
 )
+from wandb.automations._compat import event_enabled
 from wandb.automations._run_metric_filters import ChangeDir
 from wandb.automations._run_state_filters import ReportedRunState, StateFilter
 from wandb.automations.actions import InputAction, SavedNoOpAction, SavedWebhookAction
 from wandb.automations.events import InputEvent, RunMetricFilter, RunStateFilter
-from wandb.errors.errors import CommError
+from wandb.errors.errors import CommError, UnsupportedError
+
+if TYPE_CHECKING:
+    from wandb.apis.public import Team
 
 
 @fixture
@@ -42,10 +46,11 @@ def automation_name(make_name: Callable[[str], str]) -> str:
 
 
 @fixture
-def reset_automations(module_api: wandb.Api):
+def reset_automations(module_api: wandb.Api, team: Team):
     """Request this fixture to clear any existing automations before a test."""
+    # All automations in this module are scoped in or under the team entity.
     # There has to be a better way to do this
-    for automation in module_api.automations():
+    for automation in module_api.automations(entity=team.name):
         module_api.delete_automation(automation)
     yield
 
@@ -120,8 +125,8 @@ def test_fetch_slack_integrations(
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_automation(
-    module_user: str,
     module_api: wandb.Api,
+    team: Team,
     event,
     action,
     automation_name: str,
@@ -130,13 +135,9 @@ def test_create_automation(
         (event >> action), name=automation_name, description="test description"
     )
 
-    # We should be able to fetch the automation by name (optionally filtering by entity)
     assert created.name == automation_name
 
-    fetched_a = module_api.automation(
-        entity=module_user,
-        name=created.name,
-    )
+    fetched_a = module_api.automation(entity=team.name, name=created.name)
     fetched_b = module_api.automation(name=created.name)
 
     assert fetched_a == created
@@ -146,6 +147,7 @@ def test_create_automation(
 @mark.usefixtures(reset_automations.__name__)
 def test_create_existing_automation_raises_by_default_if_existing(
     module_api: wandb.Api,
+    team: Team,
     event,
     action,
     automation_name: str,
@@ -158,13 +160,14 @@ def test_create_existing_automation_raises_by_default_if_existing(
         module_api.create_automation((event >> action), name=created.name)
 
     # Fetching the automation by name should return the original automation, unchanged.
-    fetched = module_api.automation(name=created.name)
+    fetched = module_api.automation(entity=team.name, name=created.name)
     assert fetched == created
 
 
 @mark.usefixtures(reset_automations.__name__)
 def test_create_existing_automation_fetches_existing_if_requested(
     module_api: wandb.Api,
+    team: Team,
     event,
     action,
     automation_name: str,
@@ -184,7 +187,7 @@ def test_create_existing_automation_fetches_existing_if_requested(
     )
 
     # Fetch the automation by name
-    fetched = module_api.automation(name=created.name)
+    fetched = module_api.automation(entity=team.name, name=created.name)
 
     assert created == existing
     assert existing == fetched
@@ -232,12 +235,8 @@ def test_create_automation_for_run_metric_threshold_event(
         payload={"test": {"key": "value"}},
     )
 
-    server_supports_event = module_api._supports_automation(
-        event=event.event_type,
-    )
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -298,12 +297,8 @@ def test_create_automation_for_run_metric_change_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = module_api._supports_automation(
-        event=event.event_type,
-    )
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -349,12 +344,8 @@ def test_create_automation_for_run_state_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = module_api._supports_automation(
-        event=event.event_type,
-    )
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -415,10 +406,8 @@ def test_create_automation_for_run_metric_zscore_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = module_api._supports_automation(event=event.event_type)
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -443,6 +432,7 @@ def test_create_automation_for_run_metric_zscore_event(
 @fixture
 def created_automation(
     module_api: wandb.Api,
+    team: Team,
     reset_automations,
     event,
     action,
@@ -454,46 +444,64 @@ def created_automation(
         name=automation_name,
     )
 
-    fetched = module_api.automation(name=created.name)
+    fetched = module_api.automation(entity=team.name, name=created.name)
 
     assert created.name == fetched.name == automation_name  # Sanity check
     return fetched
 
 
 def test_delete_automation(
-    module_api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api,
+    team: Team,
+    automation_name: str,
+    created_automation: Automation,
 ):
-    assert module_api.automation(name=automation_name) == created_automation
+    assert (
+        module_api.automation(entity=team.name, name=automation_name)
+        == created_automation
+    )
 
     module_api.delete_automation(created_automation)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        module_api.automation(name=automation_name)
+        module_api.automation(entity=team.name, name=automation_name)
 
 
 def test_delete_automation_by_id(
-    module_api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api,
+    team: Team,
+    automation_name: str,
+    created_automation: Automation,
 ):
-    assert module_api.automation(name=automation_name) == created_automation
+    assert (
+        module_api.automation(entity=team.name, name=automation_name)
+        == created_automation
+    )
 
     module_api.delete_automation(created_automation.id)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        module_api.automation(name=automation_name)
+        module_api.automation(entity=team.name, name=automation_name)
 
 
 def test_automation_cannot_be_deleted_again(
-    module_api: wandb.Api, automation_name: str, created_automation: Automation
+    module_api: wandb.Api,
+    team: Team,
+    automation_name: str,
+    created_automation: Automation,
 ):
-    assert module_api.automation(name=automation_name) == created_automation
+    assert (
+        module_api.automation(entity=team.name, name=automation_name)
+        == created_automation
+    )
 
     module_api.delete_automation(created_automation)
 
     # We should no longer be able to fetch the deleted automation
     with raises(ValueError):
-        module_api.automation(name=automation_name)
+        module_api.automation(entity=team.name, name=automation_name)
 
     # Deleting the automation again (by object or ID) should raise the same error
     with raises(CommError):
@@ -817,7 +825,7 @@ class TestUpdateAutomation:
         project: Project,
     ):
         """Updating an automation with a new run event must preserve its filter."""
-        if not module_api._supports_automation(event=event_type):
+        if not event_enabled(module_api._service_api, event_type):
             skip(f"Server does not support event type {event_type.value!r}")
 
         # Run events only work with a project scope, and an update keeps the
@@ -884,9 +892,9 @@ class TestPaginatedAutomations:
     @fixture(scope="class")
     def setup_paginated_automations(
         self,
-        module_user: str,
         make_module_api: Callable[[], wandb.Api],
         webhook: WebhookIntegration,
+        team: Team,
         num_projects: int,
         make_name: Callable[[str], str],
     ):
@@ -908,8 +916,8 @@ class TestPaginatedAutomations:
             project_names, automation_names, strict=True
         ):
             # Create the placeholder project for the automation
-            setup_api.create_project(name=project_name, entity=module_user)
-            project = setup_api.project(name=project_name, entity=module_user)
+            setup_api.create_project(name=project_name, entity=team.name)
+            project = setup_api.project(name=project_name, entity=team.name)
 
             # Create the actual automation
             event = OnLinkArtifact(scope=project)
@@ -934,8 +942,8 @@ class TestPaginatedAutomations:
     def test_paginated_automations(
         self,
         mocker,
-        module_user: str,
         module_api: wandb.Api,
+        team: Team,
         num_projects,
         page_size,
     ):
@@ -943,7 +951,7 @@ class TestPaginatedAutomations:
         client_spy = mocker.spy(module_api._service_api, "execute_graphql")
 
         # Fetch the automations
-        list(module_api.automations(entity=module_user, per_page=page_size))
+        list(module_api.automations(entity=team.name, per_page=page_size))
 
         # Check that the number of GQL requests is at least what we expect from the pagination params
         # Note that a (cached) introspection query may add an extra request the first time this is
@@ -955,23 +963,23 @@ class TestPaginatedAutomations:
     @mark.usefixtures(setup_paginated_automations.__name__)
     def test_paginated_automations_start(
         self,
-        module_user: str,
         module_api: wandb.Api,
-        page_size,
+        team: Team,
+        page_size: int,
     ):
         all_automations = list(
-            module_api.automations(entity=module_user, per_page=page_size)
+            module_api.automations(entity=team.name, per_page=page_size)
         )
         all_ids = [a.id for a in all_automations]
 
-        paginator = module_api.automations(entity=module_user, per_page=page_size)
+        paginator = module_api.automations(entity=team.name, per_page=page_size)
         first_ids = [obj.id for obj in islice(paginator, page_size)]
 
         saved_cursor = paginator.cursor
         assert saved_cursor is not None
 
         resumed_paginator = module_api.automations(
-            entity=module_user, per_page=page_size, start=saved_cursor
+            entity=team.name, per_page=page_size, start=saved_cursor
         )
         remaining_ids = [a.id for a in resumed_paginator]
 

--- a/tests/system_tests/test_automations/test_automations_api.py
+++ b/tests/system_tests/test_automations/test_automations_api.py
@@ -31,9 +31,10 @@ from wandb.automations import (
 )
 from wandb.automations._run_metric_filters import ChangeDir
 from wandb.automations._run_state_filters import ReportedRunState, StateFilter
+from wandb.automations._utils import event_enabled
 from wandb.automations.actions import InputAction, SavedNoOpAction, SavedWebhookAction
 from wandb.automations.events import InputEvent, RunMetricFilter, RunStateFilter
-from wandb.errors.errors import CommError
+from wandb.errors.errors import CommError, UnsupportedError
 
 
 @fixture
@@ -232,12 +233,8 @@ def test_create_automation_for_run_metric_threshold_event(
         payload={"test": {"key": "value"}},
     )
 
-    server_supports_event = module_api._supports_automation(
-        event=event.event_type,
-    )
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -298,12 +295,8 @@ def test_create_automation_for_run_metric_change_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = module_api._supports_automation(
-        event=event.event_type,
-    )
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -349,12 +342,8 @@ def test_create_automation_for_run_state_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = module_api._supports_automation(
-        event=event.event_type,
-    )
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -415,10 +404,8 @@ def test_create_automation_for_run_metric_zscore_event(
     )
     action = SendWebhook.from_integration(webhook)
 
-    server_supports_event = module_api._supports_automation(event=event.event_type)
-
-    if not server_supports_event:
-        with raises(CommError):
+    if not event_enabled(module_api._service_api, event.event_type):
+        with raises(UnsupportedError):
             module_api.create_automation(
                 (event >> action),
                 name=automation_name,
@@ -817,7 +804,7 @@ class TestUpdateAutomation:
         project: Project,
     ):
         """Updating an automation with a new run event must preserve its filter."""
-        if not module_api._supports_automation(event=event_type):
+        if not event_enabled(module_api._service_api, event_type):
             skip(f"Server does not support event type {event_type.value!r}")
 
         # Run events only work with a project scope, and an update keeps the

--- a/tests/unit_tests/test_automations/conftest.py
+++ b/tests/unit_tests/test_automations/conftest.py
@@ -30,7 +30,7 @@ from wandb.automations import (
     SendNotification,
     SendWebhook,
 )
-from wandb.automations._utils import INVALID_INPUT_ACTIONS, INVALID_INPUT_EVENTS
+from wandb.automations._inputs import INVALID_INPUT_ACTIONS, INVALID_INPUT_EVENTS
 from wandb.automations.actions import (
     InputAction,
     SavedAction,

--- a/tests/unit_tests/test_automations/test_automations.py
+++ b/tests/unit_tests/test_automations/test_automations.py
@@ -21,7 +21,7 @@ from wandb.automations import (
     OnUnlinkArtifact,
     RunEvent,
 )
-from wandb.automations._utils import (
+from wandb.automations._inputs import (
     INVALID_INPUT_ACTIONS,
     INVALID_INPUT_EVENTS,
     prepare_to_create,

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -28,7 +28,6 @@ import wandb
 from wandb import env
 from wandb._analytics import tracked
 from wandb._iterutils import one
-from wandb._strutils import nameof
 from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public.registries import Registries, Registry
@@ -40,6 +39,7 @@ from wandb.apis.public.utils import (
     parse_org_from_registry_path,
 )
 from wandb.errors import UsageError
+from wandb.errors.errors import UnsupportedError
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
@@ -53,16 +53,13 @@ from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 if TYPE_CHECKING:
     from wandb.automations import (
-        ActionType,
         Automation,
-        EventType,
         Integration,
         NewAutomation,
-        ScopeType,
         SlackIntegration,
         WebhookIntegration,
     )
-    from wandb.automations._utils import WriteAutomationsKwargs
+    from wandb.automations._inputs import WriteAutomationsKwargs
     from wandb.sdk.artifacts.artifact import Artifact
 
     from .artifacts import (
@@ -2293,96 +2290,6 @@ class Api:
             self._service_api, variables=variables, per_page=per_page, start=start
         )
 
-    def _supports_automation(
-        self,
-        *,
-        scope: ScopeType | None = None,
-        event: EventType | None = None,
-        action: ActionType | None = None,
-    ) -> bool:
-        """Returns whether the server recognizes the automation event and/or action."""
-        from wandb.automations._utils import (
-            ALWAYS_SUPPORTED_ACTIONS,
-            ALWAYS_SUPPORTED_EVENTS,
-            ALWAYS_SUPPORTED_SCOPES,
-        )
-
-        supports_scope = (
-            (scope is None)
-            or (scope in ALWAYS_SUPPORTED_SCOPES)
-            or self._service_api.feature_enabled(f"AUTOMATION_SCOPE_{scope.value}")
-        )
-        supports_event = (
-            (event is None)
-            or (event in ALWAYS_SUPPORTED_EVENTS)
-            or self._service_api.feature_enabled(f"AUTOMATION_EVENT_{event.value}")
-        )
-        supports_action = (
-            (action is None)
-            or (action in ALWAYS_SUPPORTED_ACTIONS)
-            or self._service_api.feature_enabled(f"AUTOMATION_ACTION_{action.value}")
-        )
-        return supports_event and supports_action and supports_scope
-
-    def _omitted_automation_fragments(self) -> set[str]:
-        """Returns the names of unsupported automation-related fragments.
-
-        Older servers won't recognize newer GraphQL types, so a valid request may
-        unnecessarily error out because it won't recognize fragments defined on those types.
-
-        So e.g. if a server does not support `NO_OP` action types, then the following need to be
-        removed from the body of the GraphQL request:
-
-            - Fragment definition:
-                ```
-                fragment NoOpActionFields on NoOpTriggeredAction {
-                    noOp
-                }
-                ```
-
-            - Fragment spread in selection set:
-                ```
-                {
-                    ...NoOpActionFields
-                    # ... other fields ...
-                }
-                ```
-        """
-        from wandb.automations import ActionType, ScopeType
-        from wandb.automations._generated import (
-            EntityScopeFields,
-            GenericWebhookActionFields,
-            NoOpActionFields,
-            NotificationActionFields,
-            QueueJobActionFields,
-        )
-
-        # Note: we can't currently define this as a constant outside the method
-        # and still keep it nearby in this module, because it relies on pydantic v2-only imports
-        scope_fragment_names: dict[ScopeType, str] = {
-            ScopeType.ENTITY: nameof(EntityScopeFields),
-        }
-        action_fragment_names: dict[ActionType, str] = {
-            ActionType.NO_OP: nameof(NoOpActionFields),
-            ActionType.QUEUE_JOB: nameof(QueueJobActionFields),
-            ActionType.NOTIFICATION: nameof(NotificationActionFields),
-            ActionType.GENERIC_WEBHOOK: nameof(GenericWebhookActionFields),
-        }
-
-        omitted_scope_fragments = set(
-            name
-            for scope in ScopeType
-            if (not self._supports_automation(scope=scope))
-            and (name := scope_fragment_names.get(scope))
-        )
-        omitted_action_fragments = set(
-            name
-            for action in ActionType
-            if (not self._supports_automation(action=action))
-            and (name := action_fragment_names.get(action))
-        )
-        return omitted_scope_fragments | omitted_action_fragments
-
     @tracked
     def automation(
         self,
@@ -2476,7 +2383,6 @@ class Api:
             per_page=per_page,
             start=start,
             _query=gql_str,
-            omit_fragments=self._omitted_automation_fragments(),
         )
 
         # FIXME: this is crude, move this client-side filtering logic into backend
@@ -2544,23 +2450,28 @@ class Api:
         ```
         """
         from wandb.automations import Automation
+        from wandb.automations._compat import (
+            automation_enabled,
+            omit_automation_fragments,
+        )
         from wandb.automations._generated import CREATE_AUTOMATION_GQL, CreateAutomation
-        from wandb.automations._utils import prepare_to_create
+        from wandb.automations._inputs import prepare_to_create
 
         gql_input = prepare_to_create(obj, **kwargs)
 
-        if not self._supports_automation(
+        if not automation_enabled(
+            self._service_api,
+            scope=(scope := gql_input.scope_type),
             event=(event := gql_input.triggering_event_type),
             action=(action := gql_input.triggered_action_type),
         ):
-            raise ValueError(
-                f"Automation event or action ({event!r} -> {action!r}) "
+            msg = (
+                f"Automation scope, event, and/or action ({scope.value!r}, {event.value!r}, {action.value!r}) "
                 "is not supported on this wandb server version. "
-                "Please upgrade your server version, or contact support at "
-                "support@wandb.com."
+                "Please upgrade your server version, or contact support at support@wandb.com."
             )
+            raise UnsupportedError(msg) from None
 
-        omit_fragments = self._omitted_automation_fragments()
         variables = {"input": gql_input.model_dump()}
 
         name = gql_input.name
@@ -2568,7 +2479,7 @@ class Api:
             data = self._service_api.execute_graphql(
                 CREATE_AUTOMATION_GQL,
                 variables=variables,
-                omit_fragments=omit_fragments,
+                omit_fragments=omit_automation_fragments(self._service_api),
                 parse=CreateAutomation.model_validate_json,
             )
         except WandbApiFailedError as e:
@@ -2652,33 +2563,28 @@ class Api:
         )
         ```
         """
-        from wandb.automations import ActionType, Automation
+        from wandb.automations import Automation
+        from wandb.automations._compat import (
+            automation_enabled,
+            omit_automation_fragments,
+        )
         from wandb.automations._generated import UPDATE_AUTOMATION_GQL, UpdateAutomation
-        from wandb.automations._utils import prepare_to_update
-
-        # Check if the server even supports updating automations.
-        #
-        # NOTE: Unfortunately, there is no current server feature flag for this.  As a workaround,
-        # we check whether the server supports the NO_OP action, which is a reasonably safe proxy
-        # for whether it supports updating automations.
-        if not self._supports_automation(action=ActionType.NO_OP):
-            raise RuntimeError(
-                "Updating existing automations is not enabled on this wandb server version. "
-                "Please upgrade your server version, or contact support at support@wandb.com."
-            )
+        from wandb.automations._inputs import prepare_to_update
 
         gql_input = prepare_to_update(obj, **kwargs)
 
-        if not self._supports_automation(
+        if not automation_enabled(
+            self._service_api,
+            scope=(scope := gql_input.scope_type),
             event=(event := gql_input.triggering_event_type),
             action=(action := gql_input.triggered_action_type),
         ):
-            raise ValueError(
-                f"Automation event or action ({event.value} -> {action.value}) "
+            msg = (
+                f"Automation scope, event, and/or action ({scope.value!r}, {event.value!r}, {action.value!r}) "
                 "is not supported on this wandb server version. "
-                "Please upgrade your server version, or contact support at "
-                "support@wandb.com."
+                "Please upgrade your server version, or contact support at support@wandb.com."
             )
+            raise UnsupportedError(msg)
 
         variables = {"input": gql_input.model_dump()}
 
@@ -2687,7 +2593,7 @@ class Api:
             data = self._service_api.execute_graphql(
                 UPDATE_AUTOMATION_GQL,
                 variables=variables,
-                omit_fragments=self._omitted_automation_fragments(),
+                omit_fragments=omit_automation_fragments(self._service_api),
                 parse=UpdateAutomation.model_validate_json,
             )
         except WandbApiFailedError as e:
@@ -2726,7 +2632,7 @@ class Api:
             True if the automation was deleted successfully.
         """
         from wandb.automations._generated import DELETE_AUTOMATION_GQL, DeleteAutomation
-        from wandb.automations._utils import extract_id
+        from wandb.automations._inputs import extract_id
 
         id_ = extract_id(obj)
 

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -28,7 +28,6 @@ import wandb
 from wandb import env
 from wandb._analytics import tracked
 from wandb._iterutils import one
-from wandb._strutils import nameof
 from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public.registries import Registries, Registry
@@ -40,6 +39,7 @@ from wandb.apis.public.utils import (
     parse_org_from_registry_path,
 )
 from wandb.errors import UsageError
+from wandb.errors.errors import UnsupportedError
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.proto.wandb_telemetry_pb2 import Deprecated
@@ -53,12 +53,9 @@ from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 if TYPE_CHECKING:
     from wandb.automations import (
-        ActionType,
         Automation,
-        EventType,
         Integration,
         NewAutomation,
-        ScopeType,
         SlackIntegration,
         WebhookIntegration,
     )
@@ -2293,96 +2290,6 @@ class Api:
             self._service_api, variables=variables, per_page=per_page, start=start
         )
 
-    def _supports_automation(
-        self,
-        *,
-        scope: ScopeType | None = None,
-        event: EventType | None = None,
-        action: ActionType | None = None,
-    ) -> bool:
-        """Returns whether the server recognizes the automation event and/or action."""
-        from wandb.automations._utils import (
-            ALWAYS_SUPPORTED_ACTIONS,
-            ALWAYS_SUPPORTED_EVENTS,
-            ALWAYS_SUPPORTED_SCOPES,
-        )
-
-        supports_scope = (
-            (scope is None)
-            or (scope in ALWAYS_SUPPORTED_SCOPES)
-            or self._service_api.feature_enabled(f"AUTOMATION_SCOPE_{scope.value}")
-        )
-        supports_event = (
-            (event is None)
-            or (event in ALWAYS_SUPPORTED_EVENTS)
-            or self._service_api.feature_enabled(f"AUTOMATION_EVENT_{event.value}")
-        )
-        supports_action = (
-            (action is None)
-            or (action in ALWAYS_SUPPORTED_ACTIONS)
-            or self._service_api.feature_enabled(f"AUTOMATION_ACTION_{action.value}")
-        )
-        return supports_event and supports_action and supports_scope
-
-    def _omitted_automation_fragments(self) -> set[str]:
-        """Returns the names of unsupported automation-related fragments.
-
-        Older servers won't recognize newer GraphQL types, so a valid request may
-        unnecessarily error out because it won't recognize fragments defined on those types.
-
-        So e.g. if a server does not support `NO_OP` action types, then the following need to be
-        removed from the body of the GraphQL request:
-
-            - Fragment definition:
-                ```
-                fragment NoOpActionFields on NoOpTriggeredAction {
-                    noOp
-                }
-                ```
-
-            - Fragment spread in selection set:
-                ```
-                {
-                    ...NoOpActionFields
-                    # ... other fields ...
-                }
-                ```
-        """
-        from wandb.automations import ActionType, ScopeType
-        from wandb.automations._generated import (
-            EntityScopeFields,
-            GenericWebhookActionFields,
-            NoOpActionFields,
-            NotificationActionFields,
-            QueueJobActionFields,
-        )
-
-        # Note: we can't currently define this as a constant outside the method
-        # and still keep it nearby in this module, because it relies on pydantic v2-only imports
-        scope_fragment_names: dict[ScopeType, str] = {
-            ScopeType.ENTITY: nameof(EntityScopeFields),
-        }
-        action_fragment_names: dict[ActionType, str] = {
-            ActionType.NO_OP: nameof(NoOpActionFields),
-            ActionType.QUEUE_JOB: nameof(QueueJobActionFields),
-            ActionType.NOTIFICATION: nameof(NotificationActionFields),
-            ActionType.GENERIC_WEBHOOK: nameof(GenericWebhookActionFields),
-        }
-
-        omitted_scope_fragments = set(
-            name
-            for scope in ScopeType
-            if (not self._supports_automation(scope=scope))
-            and (name := scope_fragment_names.get(scope))
-        )
-        omitted_action_fragments = set(
-            name
-            for action in ActionType
-            if (not self._supports_automation(action=action))
-            and (name := action_fragment_names.get(action))
-        )
-        return omitted_scope_fragments | omitted_action_fragments
-
     @tracked
     def automation(
         self,
@@ -2476,7 +2383,6 @@ class Api:
             per_page=per_page,
             start=start,
             _query=gql_str,
-            omit_fragments=self._omitted_automation_fragments(),
         )
 
         # FIXME: this is crude, move this client-side filtering logic into backend
@@ -2545,22 +2451,27 @@ class Api:
         """
         from wandb.automations import Automation
         from wandb.automations._generated import CREATE_AUTOMATION_GQL, CreateAutomation
-        from wandb.automations._utils import prepare_to_create
+        from wandb.automations._utils import (
+            automation_enabled,
+            omit_automation_fragments,
+            prepare_to_create,
+        )
 
         gql_input = prepare_to_create(obj, **kwargs)
 
-        if not self._supports_automation(
+        if not automation_enabled(
+            self._service_api,
+            scope=(scope := gql_input.scope_type),
             event=(event := gql_input.triggering_event_type),
             action=(action := gql_input.triggered_action_type),
         ):
-            raise ValueError(
-                f"Automation event or action ({event!r} -> {action!r}) "
+            msg = (
+                f"Automation scope, event, and/or action ({scope.value!r}, {event.value!r}, {action.value!r}) "
                 "is not supported on this wandb server version. "
-                "Please upgrade your server version, or contact support at "
-                "support@wandb.com."
+                "Please upgrade your server version, or contact support at support@wandb.com."
             )
+            raise UnsupportedError(msg) from None
 
-        omit_fragments = self._omitted_automation_fragments()
         variables = {"input": gql_input.model_dump()}
 
         name = gql_input.name
@@ -2568,7 +2479,7 @@ class Api:
             data = self._service_api.execute_graphql(
                 CREATE_AUTOMATION_GQL,
                 variables=variables,
-                omit_fragments=omit_fragments,
+                omit_fragments=omit_automation_fragments(self._service_api),
                 parse=CreateAutomation.model_validate_json,
             )
         except WandbApiFailedError as e:
@@ -2652,33 +2563,28 @@ class Api:
         )
         ```
         """
-        from wandb.automations import ActionType, Automation
+        from wandb.automations import Automation
         from wandb.automations._generated import UPDATE_AUTOMATION_GQL, UpdateAutomation
-        from wandb.automations._utils import prepare_to_update
-
-        # Check if the server even supports updating automations.
-        #
-        # NOTE: Unfortunately, there is no current server feature flag for this.  As a workaround,
-        # we check whether the server supports the NO_OP action, which is a reasonably safe proxy
-        # for whether it supports updating automations.
-        if not self._supports_automation(action=ActionType.NO_OP):
-            raise RuntimeError(
-                "Updating existing automations is not enabled on this wandb server version. "
-                "Please upgrade your server version, or contact support at support@wandb.com."
-            )
+        from wandb.automations._utils import (
+            automation_enabled,
+            omit_automation_fragments,
+            prepare_to_update,
+        )
 
         gql_input = prepare_to_update(obj, **kwargs)
 
-        if not self._supports_automation(
+        if not automation_enabled(
+            self._service_api,
+            scope=(scope := gql_input.scope_type),
             event=(event := gql_input.triggering_event_type),
             action=(action := gql_input.triggered_action_type),
         ):
-            raise ValueError(
-                f"Automation event or action ({event.value} -> {action.value}) "
+            msg = (
+                f"Automation scope, event, and/or action ({scope.value!r}, {event.value!r}, {action.value!r}) "
                 "is not supported on this wandb server version. "
-                "Please upgrade your server version, or contact support at "
-                "support@wandb.com."
+                "Please upgrade your server version, or contact support at support@wandb.com."
             )
+            raise UnsupportedError(msg)
 
         variables = {"input": gql_input.model_dump()}
 
@@ -2687,7 +2593,7 @@ class Api:
             data = self._service_api.execute_graphql(
                 UPDATE_AUTOMATION_GQL,
                 variables=variables,
-                omit_fragments=self._omitted_automation_fragments(),
+                omit_fragments=omit_automation_fragments(self._service_api),
                 parse=UpdateAutomation.model_validate_json,
             )
         except WandbApiFailedError as e:

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterator, Mapping
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import ValidationError
@@ -37,21 +37,16 @@ class _LegacyAutomationsPaginator(
         name: str | None = None,
         per_page: int = 50,
         start: str | None = None,
-        omit_variables: Iterable[str] | None = None,
-        omit_fragments: Iterable[str] | None = None,
-        omit_fields: Iterable[str] | None = None,
-        rename_fields: Mapping[str, str] | None = None,
     ):
+        from wandb.automations._compat import omit_automation_fragments
+
         self._name = name
         super().__init__(
             service_api,
             variables=variables,
             per_page=per_page,
             start=start,
-            omit_variables=omit_variables,
-            omit_fragments=omit_fragments,
-            omit_fields=omit_fields,
-            rename_fields=rename_fields,
+            omit_fragments=omit_automation_fragments(service_api),
         )
 
     @classmethod
@@ -105,10 +100,6 @@ class Automations(_LegacyAutomationsPaginator):
         *,
         start: str | None = None,
         _query: str,
-        omit_variables: Iterable[str] | None = None,
-        omit_fragments: Iterable[str] | None = None,
-        omit_fields: Iterable[str] | None = None,
-        rename_fields: Mapping[str, str] | None = None,
     ):
         self.QUERY = _query
         super().__init__(
@@ -116,10 +107,6 @@ class Automations(_LegacyAutomationsPaginator):
             variables=variables,
             per_page=per_page,
             start=start,
-            omit_variables=omit_variables,
-            omit_fragments=omit_fragments,
-            omit_fields=omit_fields,
-            rename_fields=rename_fields,
         )
 
     @override
@@ -149,7 +136,6 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
         name: str | None = None,
         per_page: int = 50,
         start: str | None = None,
-        omit_fragments: Iterable[str] | None = None,
     ):
         if self.QUERY is None:
             from wandb.automations._generated import GET_AUTOMATIONS_LEGACY_GQL
@@ -162,7 +148,6 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
             name=name,
             per_page=per_page,
             start=start,
-            omit_fragments=omit_fragments,
         )
 
     @classmethod
@@ -184,7 +169,6 @@ class LegacyEntityAutomations(_LegacyAutomationsPaginator):
         name: str | None = None,
         per_page: int = 50,
         start: str | None = None,
-        omit_fragments: Iterable[str] | None = None,
     ):
         if self.QUERY is None:
             from wandb.automations._generated import GET_ENTITY_AUTOMATIONS_LEGACY_GQL
@@ -197,7 +181,6 @@ class LegacyEntityAutomations(_LegacyAutomationsPaginator):
             name=name,
             per_page=per_page,
             start=start,
-            omit_fragments=omit_fragments,
         )
 
     @classmethod

--- a/wandb/apis/public/automations.py
+++ b/wandb/apis/public/automations.py
@@ -42,6 +42,11 @@ class _LegacyAutomationsPaginator(
         omit_fields: Iterable[str] | None = None,
         rename_fields: Mapping[str, str] | None = None,
     ):
+        if omit_fragments is None:
+            from wandb.automations._utils import omit_automation_fragments
+
+            omit_fragments = omit_automation_fragments(service_api)
+
         self._name = name
         super().__init__(
             service_api,
@@ -149,7 +154,6 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
         name: str | None = None,
         per_page: int = 50,
         start: str | None = None,
-        omit_fragments: Iterable[str] | None = None,
     ):
         if self.QUERY is None:
             from wandb.automations._generated import GET_AUTOMATIONS_LEGACY_GQL
@@ -162,7 +166,6 @@ class LegacyAutomations(_LegacyAutomationsPaginator):
             name=name,
             per_page=per_page,
             start=start,
-            omit_fragments=omit_fragments,
         )
 
     @classmethod
@@ -184,7 +187,6 @@ class LegacyEntityAutomations(_LegacyAutomationsPaginator):
         name: str | None = None,
         per_page: int = 50,
         start: str | None = None,
-        omit_fragments: Iterable[str] | None = None,
     ):
         if self.QUERY is None:
             from wandb.automations._generated import GET_ENTITY_AUTOMATIONS_LEGACY_GQL
@@ -197,7 +199,6 @@ class LegacyEntityAutomations(_LegacyAutomationsPaginator):
             name=name,
             per_page=per_page,
             start=start,
-            omit_fragments=omit_fragments,
         )
 
     @classmethod

--- a/wandb/automations/_compat.py
+++ b/wandb/automations/_compat.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import TYPE_CHECKING, Final
+
+from wandb._strutils import nameof
+
+from ._generated import (
+    EntityScopeFields,
+    GenericWebhookActionFields,
+    NoOpActionFields,
+    NotificationActionFields,
+    QueueJobActionFields,
+)
+from .actions import ActionType
+from .events import EventType
+from .scopes import ScopeType
+
+if TYPE_CHECKING:
+    from wandb.apis.public.service_api import ServiceApi
+
+UNGATED_SCOPES: Final[Collection[ScopeType]] = frozenset(
+    {
+        ScopeType.ARTIFACT_COLLECTION,
+        ScopeType.PROJECT,
+    }
+)
+"""Scope types that should be supported by all current, non-EOL server versions."""
+
+UNGATED_EVENTS: Final[Collection[EventType]] = frozenset(
+    {
+        EventType.CREATE_ARTIFACT,
+        EventType.LINK_ARTIFACT,
+        EventType.ADD_ARTIFACT_ALIAS,
+        EventType.RUN_METRIC_THRESHOLD,  # Added in 0.67.0
+        EventType.RUN_METRIC_CHANGE,  # Added in 0.67.0
+        EventType.RUN_STATE,  # Added in 0.69.0
+    }
+)
+"""Event types that should be supported by all current, non-EOL server versions."""
+
+UNGATED_ACTIONS: Final[Collection[ActionType]] = frozenset(
+    {
+        ActionType.NOTIFICATION,
+        ActionType.GENERIC_WEBHOOK,
+        ActionType.NO_OP,  # Added in 0.67.0
+    }
+)
+"""Action types that should be supported by all current, non-EOL server versions."""
+
+
+def scope_enabled(service_api: ServiceApi, scope: ScopeType) -> bool:
+    """Returns whether the server supports the automation scope."""
+    flag_name = f"AUTOMATION_SCOPE_{scope.value}"
+    return (scope in UNGATED_SCOPES) or service_api.feature_enabled(flag_name)
+
+
+def event_enabled(service_api: ServiceApi, event: EventType) -> bool:
+    """Returns whether the server supports the automation event."""
+    flag_name = f"AUTOMATION_EVENT_{event.value}"
+    return (event in UNGATED_EVENTS) or service_api.feature_enabled(flag_name)
+
+
+def action_enabled(service_api: ServiceApi, action: ActionType) -> bool:
+    """Returns whether the server supports the automation action."""
+    flag_name = f"AUTOMATION_ACTION_{action.value}"
+    return (action in UNGATED_ACTIONS) or service_api.feature_enabled(flag_name)
+
+
+def automation_enabled(
+    service_api: ServiceApi,
+    *,
+    scope: ScopeType,
+    event: EventType,
+    action: ActionType,
+) -> bool:
+    """Returns whether the server supports the automation's scope, event, and action."""
+    return (
+        scope_enabled(service_api, scope)
+        and event_enabled(service_api, event)
+        and action_enabled(service_api, action)
+    )
+
+
+SCOPE_FRAGMENT_NAMES: Final[dict[ScopeType, str]] = {
+    ScopeType.ENTITY: nameof(EntityScopeFields),
+}
+
+ACTION_FRAGMENT_NAMES: Final[dict[ActionType, str]] = {
+    ActionType.NO_OP: nameof(NoOpActionFields),
+    ActionType.QUEUE_JOB: nameof(QueueJobActionFields),
+    ActionType.NOTIFICATION: nameof(NotificationActionFields),
+    ActionType.GENERIC_WEBHOOK: nameof(GenericWebhookActionFields),
+}
+
+
+def omit_automation_fragments(service_api: ServiceApi) -> set[str]:
+    """Returns the names of unsupported automation-related fragments.
+
+    Older servers won't recognize newer GraphQL types, so a valid request may
+    unnecessarily error out because it won't recognize fragments defined on those types.
+
+    So e.g. if a server does not support `NO_OP` action types, then the following must be
+    removed from the body of the GraphQL request:
+
+        - Fragment definition:
+            ```
+            fragment NoOpActionFields on NoOpTriggeredAction {
+                noOp
+            }
+            ```
+
+        - Fragment spread in selection set:
+            ```
+            {
+                ...NoOpActionFields
+                # ... other fields ...
+            }
+            ```
+    """
+    omit_scope_fragments = set(
+        name
+        for scope in ScopeType
+        if (not scope_enabled(service_api, scope))
+        and (name := SCOPE_FRAGMENT_NAMES.get(scope))
+    )
+    omit_action_fragments = set(
+        name
+        for action in ActionType
+        if (not action_enabled(service_api, action))
+        and (name := ACTION_FRAGMENT_NAMES.get(action))
+    )
+    return omit_scope_fragments | omit_action_fragments

--- a/wandb/automations/_inputs.py
+++ b/wandb/automations/_inputs.py
@@ -52,31 +52,6 @@ While we forbid new/edited automations from assigning these action types,
 they're defined so that we can still parse existing automations that may use them.
 """
 
-ALWAYS_SUPPORTED_SCOPES: Final[Collection[ScopeType]] = frozenset(
-    {
-        ScopeType.ARTIFACT_COLLECTION,
-        ScopeType.PROJECT,
-    }
-)
-"""Scope types that should be supported by all current, non-EOL server versions."""
-
-ALWAYS_SUPPORTED_EVENTS: Final[Collection[EventType]] = frozenset(
-    {
-        EventType.CREATE_ARTIFACT,
-        EventType.LINK_ARTIFACT,
-        EventType.ADD_ARTIFACT_ALIAS,
-    }
-)
-"""Event types that should be supported by all current, non-EOL server versions."""
-
-ALWAYS_SUPPORTED_ACTIONS: Final[Collection[ActionType]] = frozenset(
-    {
-        ActionType.NOTIFICATION,
-        ActionType.GENERIC_WEBHOOK,
-    }
-)
-"""Action types that should be supported by all current, non-EOL server versions."""
-
 
 class HasId(Protocol):
     id: str
@@ -84,9 +59,6 @@ class HasId(Protocol):
 
 def extract_id(obj: HasId | str) -> str:
     return obj if isinstance(obj, str) else obj.id
-
-
-# ---------------------------------------------------------------------------
 
 
 class ActionSpecInput(TriggeredActionConfig):

--- a/wandb/automations/_utils.py
+++ b/wandb/automations/_utils.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 from collections.abc import Collection
-from typing import Annotated, Any, Final, Protocol, TypedDict
+from functools import lru_cache
+from typing import TYPE_CHECKING, Annotated, Any, Final, Protocol, TypedDict
 
 from pydantic import Field
 from typing_extensions import Self, Unpack
 
 from wandb._filters import MongoLikeFilter
 from wandb._pydantic import GQLId, GQLInput, computed_field, model_validator, to_json
+from wandb._strutils import nameof
 
 from ._generated import (
     CreateFilterTriggerInput,
+    EntityScopeFields,
+    GenericWebhookActionFields,
+    NoOpActionFields,
+    NotificationActionFields,
+    QueueJobActionFields,
     QueueJobActionInput,
     TriggeredActionConfig,
     UpdateFilterTriggerInput,
@@ -35,6 +42,9 @@ from .events import (
 )
 from .scopes import AutomationScope, ScopeType
 
+if TYPE_CHECKING:
+    from wandb.apis.public.service_api import ServiceApi
+
 INVALID_INPUT_EVENTS: Final[Collection[EventType]] = (EventType.UPDATE_ARTIFACT_ALIAS,)
 """Event types that should NOT be allowed as new values on new or edited automations.
 
@@ -52,7 +62,7 @@ While we forbid new/edited automations from assigning these action types,
 they're defined so that we can still parse existing automations that may use them.
 """
 
-ALWAYS_SUPPORTED_SCOPES: Final[Collection[ScopeType]] = frozenset(
+UNGATED_SCOPES: Final[Collection[ScopeType]] = frozenset(
     {
         ScopeType.ARTIFACT_COLLECTION,
         ScopeType.PROJECT,
@@ -60,22 +70,114 @@ ALWAYS_SUPPORTED_SCOPES: Final[Collection[ScopeType]] = frozenset(
 )
 """Scope types that should be supported by all current, non-EOL server versions."""
 
-ALWAYS_SUPPORTED_EVENTS: Final[Collection[EventType]] = frozenset(
+UNGATED_EVENTS: Final[Collection[EventType]] = frozenset(
     {
         EventType.CREATE_ARTIFACT,
         EventType.LINK_ARTIFACT,
         EventType.ADD_ARTIFACT_ALIAS,
+        EventType.RUN_METRIC_THRESHOLD,  # Added in 0.67.0
+        EventType.RUN_METRIC_CHANGE,  # Added in 0.67.0
+        EventType.RUN_STATE,  # Added in 0.69.0
     }
 )
 """Event types that should be supported by all current, non-EOL server versions."""
 
-ALWAYS_SUPPORTED_ACTIONS: Final[Collection[ActionType]] = frozenset(
+UNGATED_ACTIONS: Final[Collection[ActionType]] = frozenset(
     {
         ActionType.NOTIFICATION,
         ActionType.GENERIC_WEBHOOK,
+        ActionType.NO_OP,  # Added in 0.67.0
     }
 )
 """Action types that should be supported by all current, non-EOL server versions."""
+
+
+@lru_cache(maxsize=16)
+def scope_enabled(service_api: ServiceApi, scope: ScopeType) -> bool:
+    """Returns whether the server supports the automation scope."""
+    flag_name = f"AUTOMATION_SCOPE_{scope.value}"
+    return (scope in UNGATED_SCOPES) or service_api.feature_enabled(flag_name)
+
+
+@lru_cache(maxsize=16)
+def event_enabled(service_api: ServiceApi, event: EventType) -> bool:
+    """Returns whether the server supports the automation event."""
+    flag_name = f"AUTOMATION_EVENT_{event.value}"
+    return (event in UNGATED_EVENTS) or service_api.feature_enabled(flag_name)
+
+
+@lru_cache(maxsize=16)
+def action_enabled(service_api: ServiceApi, action: ActionType) -> bool:
+    """Returns whether the server supports the automation action."""
+    flag_name = f"AUTOMATION_ACTION_{action.value}"
+    return (action in UNGATED_ACTIONS) or service_api.feature_enabled(flag_name)
+
+
+def automation_enabled(
+    service_api: ServiceApi,
+    *,
+    scope: ScopeType,
+    event: EventType,
+    action: ActionType,
+) -> bool:
+    """Returns whether the server supports the automation's scope, event, and action."""
+    return (
+        scope_enabled(service_api, scope)
+        and event_enabled(service_api, event)
+        and action_enabled(service_api, action)
+    )
+
+
+SCOPE_FRAGMENT_NAMES: Final[dict[ScopeType, str]] = {
+    ScopeType.ENTITY: nameof(EntityScopeFields),
+}
+
+ACTION_FRAGMENT_NAMES: Final[dict[ActionType, str]] = {
+    ActionType.NO_OP: nameof(NoOpActionFields),
+    ActionType.QUEUE_JOB: nameof(QueueJobActionFields),
+    ActionType.NOTIFICATION: nameof(NotificationActionFields),
+    ActionType.GENERIC_WEBHOOK: nameof(GenericWebhookActionFields),
+}
+
+
+@lru_cache(maxsize=16)
+def omit_automation_fragments(service_api: ServiceApi) -> set[str]:
+    """Returns the names of unsupported automation-related fragments.
+
+    Older servers won't recognize newer GraphQL types, so a valid request may
+    unnecessarily error out because it won't recognize fragments defined on those types.
+
+    So e.g. if a server does not support `NO_OP` action types, then the following must be
+    removed from the body of the GraphQL request:
+
+        - Fragment definition:
+            ```
+            fragment NoOpActionFields on NoOpTriggeredAction {
+                noOp
+            }
+            ```
+
+        - Fragment spread in selection set:
+            ```
+            {
+                ...NoOpActionFields
+                # ... other fields ...
+            }
+            ```
+    """
+    omit_scope_fragments = set(
+        name
+        for scope in ScopeType
+        if (not scope_enabled(service_api, scope))
+        and (name := SCOPE_FRAGMENT_NAMES.get(scope))
+    )
+    omit_action_fragments = set(
+        name
+        for action in ActionType
+        if (not action_enabled(service_api, action))
+        and (name := ACTION_FRAGMENT_NAMES.get(action))
+    )
+    return omit_scope_fragments | omit_action_fragments
 
 
 class HasId(Protocol):


### PR DESCRIPTION
*This description was AI-generated, then reviewed and revised by the author.*

## JIRA Issue(s)

- https://coreweave.atlassian.net/browse/WB-37082

## Description

PR centralizes server compatibility checks for automation queries and writes.

- Validates scope, event, and action support through shared capability helpers before create and update operations.
- Raises `UnsupportedError` when the server does not support the requested automation.
- Moves GraphQL fragment omission and capability detection out of private `wandb.Api` methods.

Updates `CHANGELOG.unreleased.md` for the new `UnsupportedError` behavior.

## Testing

Updates system coverage for unsupported automation events and the shared capability checks.
