### PR TITLE
fix: authenticate with API key when an identity token file is also set

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,3 +52,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` validates api keys prior to saving to the `.netrc` file (@jacobromero in https://github.com/wandb/wandb/pull/12347)
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
+- An API key configured for the session, such as through `wandb.login(key=...)`, is now used for authentication even when the `WANDB_IDENTITY_TOKEN_FILE` environment variable is set. Previously, the identity token file took precedence (@dmitryduev in https://github.com/wandb/wandb/pull/12376)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,4 +52,3 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` validates api keys prior to saving to the `.netrc` file (@jacobromero in https://github.com/wandb/wandb/pull/12347)
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
-- An API key configured for the session, such as through `wandb.login(key=...)`, is now used for authentication even when the `WANDB_IDENTITY_TOKEN_FILE` environment variable is set. Previously, the identity token file took precedence (@dmitryduev in https://github.com/wandb/wandb/pull/12376)

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -831,6 +831,22 @@ class TestJWTAuth:
         assert api._service_api._settings.api_key == "a" * 40
         assert api._service_api._settings.identity_token_file is None
 
+    def test_session_identity_token_file_uses_jwt(self, tmp_path: pathlib.Path):
+        token_file = tmp_path / "token.jwt"
+        token_file.write_text("test.jwt.token")
+        wbauth.use_explicit_auth(
+            wbauth.AuthIdentityTokenFile(
+                host="https://api.wandb.ai",
+                path=str(token_file),
+                credentials_file=str(tmp_path / "credentials.json"),
+            ),
+            source="test",
+        )
+
+        api = internal.InternalApi(environ={})
+
+        assert api.request_auth is None
+
     def test_access_token_none_without_identity_token(self, mocker: MockerFixture):
         # Without federated identity, the token is None and no request is
         # sent to wandb-core.

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -22,6 +22,7 @@ from wandb.apis import internal
 from wandb.errors import CommError
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto.wandb_internal_pb2 import ServerFeature
+from wandb.sdk import wandb_setup
 from wandb.sdk.internal.internal_api import (
     _match_org_with_fetched_org_entities,
     _OrgNames,
@@ -818,6 +819,9 @@ class TestJWTAuth:
             wbauth.AuthApiKey(host="https://api.wandb.ai", api_key="a" * 40),
             source="test",
         )
+        # Simulate global settings that read the environment variable after
+        # login, as in a forked process.
+        wandb_setup.singleton().settings.identity_token_file = str(token_file)
 
         environ = {"WANDB_IDENTITY_TOKEN_FILE": str(token_file)}
         api = internal.InternalApi(environ=environ)
@@ -825,6 +829,7 @@ class TestJWTAuth:
         fetch_mock.assert_not_called()
         assert api.request_auth == ("api", "a" * 40)
         assert api._service_api._settings.api_key == "a" * 40
+        assert api._service_api._settings.identity_token_file is None
 
     def test_access_token_none_without_identity_token(self, mocker: MockerFixture):
         # Without federated identity, the token is None and no request is

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -27,7 +27,7 @@ from wandb.sdk.internal.internal_api import (
     _OrgNames,
 )
 from wandb.sdk.launch.sweeps import SweepNotFoundError
-from wandb.sdk.lib import retry
+from wandb.sdk.lib import retry, wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 from .test_retry import MockTime, mock_time  # noqa: F401
@@ -803,6 +803,28 @@ class TestJWTAuth:
 
         fetch_mock.assert_not_called()
         assert api.request_auth == ("api", "a" * 40)
+
+    def test_session_api_key_takes_precedence_over_jwt(
+        self, tmp_path: pathlib.Path, mocker: MockerFixture
+    ):
+        token_file = tmp_path / "token.jwt"
+        token_file.write_text("test.jwt.token")
+
+        fetch_mock = mocker.patch(
+            "wandb.apis.public.service_api.ServiceApi.access_token",
+            return_value="test_access_token",
+        )
+        wbauth.use_explicit_auth(
+            wbauth.AuthApiKey(host="https://api.wandb.ai", api_key="a" * 40),
+            source="test",
+        )
+
+        environ = {"WANDB_IDENTITY_TOKEN_FILE": str(token_file)}
+        api = internal.InternalApi(environ=environ)
+
+        fetch_mock.assert_not_called()
+        assert api.request_auth == ("api", "a" * 40)
+        assert api._service_api._settings.api_key == "a" * 40
 
     def test_access_token_none_without_identity_token(self, mocker: MockerFixture):
         # Without federated identity, the token is None and no request is

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -38,7 +38,7 @@ from wandb.sdk.internal._generated import SERVER_FEATURES_QUERY_GQL, ServerFeatu
 from wandb.sdk.lib.hashutil import B64MD5, md5_file_b64
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
-from ..lib import retry
+from ..lib import retry, wbauth
 from ..lib.filenames import DIFF_FNAME, METADATA_FNAME
 from .progress import Progress
 
@@ -262,23 +262,25 @@ class Api:
             self._environ.get("WANDB__EXTRA_HTTP_HEADERS", "{}")
         )
 
-        from wandb.sdk.lib import wbauth
-
-        # An API key configured for this session, such as through
-        # wandb.login(), replaces the identity token file.
-        session_auth = wbauth.session_credentials(host=self.api_url)
-
         auth: tuple[str, str] | None = None
         api_key = api_key or self.default_settings.get("api_key")
+        session_auth = wbauth.session_credentials(host=self.api_url)
         if api_key:
+            # Credentials provided explicitly for this instance.
             auth = ("api", api_key)
-        elif (
-            token_file := self._environ.get(env.IDENTITY_TOKEN_FILE)
-        ) and not isinstance(session_auth, wbauth.AuthApiKey):
+        elif isinstance(session_auth, wbauth.AuthApiKey):
+            # Credentials configured for the session, such as through
+            # wandb.login().
+            auth = ("api", session_auth.api_key)
+        elif isinstance(session_auth, wbauth.AuthIdentityTokenFile):
             # Federated identity: wandb-core exchanges the identity token
             # for an access token and authenticates its requests with it.
             # Code that talks to the server directly gets the token from
             # wandb-core through the access_token property.
+            pass
+        elif token_file := self._environ.get(env.IDENTITY_TOKEN_FILE):
+            # Federated identity configured in the environment, before
+            # session credentials are established.
             if not Path(token_file).exists():
                 raise AuthenticationError(
                     f"Identity token file not found: {token_file}"
@@ -399,8 +401,6 @@ class Api:
 
     @property
     def api_key(self) -> str | None:
-        from wandb.sdk.lib import wbauth
-
         if (  #
             (auth := wbauth.session_credentials(host=self.api_url))
             and isinstance(auth, wbauth.AuthApiKey)

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -369,6 +369,10 @@ class Api:
         settings = wandb_setup.singleton().settings.model_copy()
         settings.base_url = self.settings("base_url")
         settings.api_key = self._request_auth[1] if self._request_auth else ""
+        if settings.api_key:
+            # wandb-core prefers an identity token file over an API key,
+            # so clear any token file inherited from the global settings.
+            settings.identity_token_file = None
         settings.x_extra_http_headers = dict(self._request_headers)
         settings.x_graphql_timeout_seconds = self.HTTP_TIMEOUT
 

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -262,11 +262,19 @@ class Api:
             self._environ.get("WANDB__EXTRA_HTTP_HEADERS", "{}")
         )
 
+        from wandb.sdk.lib import wbauth
+
+        # An API key configured for this session, such as through
+        # wandb.login(), replaces the identity token file.
+        session_auth = wbauth.session_credentials(host=self.api_url)
+
         auth: tuple[str, str] | None = None
         api_key = api_key or self.default_settings.get("api_key")
         if api_key:
             auth = ("api", api_key)
-        elif token_file := self._environ.get(env.IDENTITY_TOKEN_FILE):
+        elif (
+            token_file := self._environ.get(env.IDENTITY_TOKEN_FILE)
+        ) and not isinstance(session_auth, wbauth.AuthApiKey):
             # Federated identity: wandb-core exchanges the identity token
             # for an access token and authenticates its requests with it.
             # Code that talks to the server directly gets the token from


### PR DESCRIPTION
Description
-----------

With `WANDB_IDENTITY_TOKEN_FILE` set in the environment, supplying an API key in the same process (`wandb.login(key=...)`, `wandb login <key>`, or `wandb.setup(settings=Settings(api_key=...))`) left requests with no credentials at all, and the server rejected them. `InternalApi` decided that federated identity was in use by reading the environment variable directly, but installing an API key for the session clears the identity token file setting, so neither credential reached the backend. It now takes the identity token path only when the session credentials are not an API key.

This restores behavior changed by #12340 (unreleased, so no changelog entry required).

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test and confirmed that it fails on main.
