### PR TITLE
fix(sdk): apply your SSL and proxy settings when requesting an access token

### DIFF
--- a/core/internal/api/credentials.go
+++ b/core/internal/api/credentials.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -13,8 +14,29 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/httplayers"
 	"github.com/wandb/wandb/core/internal/settings"
+)
+
+const (
+	// tokenExchangeRetryMax is the number of retries for one identity token
+	// exchange.
+	//
+	// It is much smaller than DefaultRetryMax because the request that needs
+	// the access token is itself retried, and because the exchange holds the
+	// lock that every other request waits on.
+	tokenExchangeRetryMax = 3
+
+	// Waits between exchange attempts. These are shorter than the defaults
+	// for the same reason the retry count is lower.
+	tokenExchangeRetryWaitMin = time.Second
+	tokenExchangeRetryWaitMax = 5 * time.Second
+
+	// tokenExchangeTimeout bounds one exchange including its retries.
+	tokenExchangeTimeout = 60 * time.Second
 )
 
 // CredentialProvider adds credentials to HTTP requests.
@@ -26,7 +48,7 @@ type CredentialProvider httplayers.HTTPWrapper
 type AccessTokenProvider interface {
 	// AccessToken returns a valid access token, refreshing it if it is
 	// at or near expiration.
-	AccessToken() (string, error)
+	AccessToken(ctx context.Context) (string, error)
 }
 
 // NewCredentialProvider creates a new credential provider based on the SDK
@@ -37,10 +59,32 @@ func NewCredentialProvider(
 	logger *slog.Logger,
 ) (CredentialProvider, error) {
 	if s.GetIdentityTokenFile() != "" {
+		baseURL, err := url.Parse(s.GetBaseURL())
+		if err != nil {
+			return nil, fmt.Errorf("api: invalid base URL: %v", err)
+		}
+
+		// The exchange must not use a credential provider: supplying its
+		// credentials is what it is being used to make possible.
+		exchangeClient := NewClient(ClientOptions{
+			BaseURL:            baseURL,
+			RetryMax:           tokenExchangeRetryMax,
+			RetryWaitMin:       tokenExchangeRetryWaitMin,
+			RetryWaitMax:       tokenExchangeRetryWaitMax,
+			RetryPolicy:        clients.RetryMostFailures,
+			NonRetryTimeout:    DefaultNonRetryTimeout,
+			ExtraHeaders:       s.GetExtraHTTPHeaders(),
+			Proxy:              clients.ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
+			InsecureDisableSSL: s.IsInsecureDisableSSL(),
+			CredentialProvider: NoopCredentialProvider{},
+			Logger:             logger,
+		})
+
 		return NewOAuth2CredentialProvider(
 			s.GetBaseURL(),
 			s.GetIdentityTokenFile(),
 			s.GetCredentialsFile(),
+			exchangeClient,
 			logger,
 		)
 	}
@@ -107,10 +151,15 @@ func (c NoopCredentialProvider) WrapHTTP(
 // for an access token. It then attempts to save it to the credentials file along
 // with its expiration. The expiration is checked each time the access token is
 // used, and refreshed if it is at or near expiration.
+//
+// The exchange is made with httpClient, which bounds how long a request that
+// depends on the access token can wait for it, and which must not itself
+// supply credentials.
 func NewOAuth2CredentialProvider(
 	baseURL string,
 	identityTokenFilePath string,
 	credentialsFilePath string,
+	httpClient RetryableClient,
 	logger *slog.Logger,
 ) (CredentialProvider, error) {
 	// Fail fast on misconfiguration. The token itself is re-read from the
@@ -124,6 +173,7 @@ func NewOAuth2CredentialProvider(
 		baseURL:               baseURL,
 		identityTokenFilePath: identityTokenFilePath,
 		credentialsFilePath:   credentialsFilePath,
+		httpClient:            httpClient,
 		tokenMu:               &sync.RWMutex{},
 		logger:                logger,
 	}, nil
@@ -178,6 +228,9 @@ type oauth2CredentialProvider struct {
 
 	// The file path to the access token and its metadata.
 	credentialsFilePath string
+
+	// The client used to exchange the identity token for an access token.
+	httpClient RetryableClient
 
 	tokenMu *sync.RWMutex
 
@@ -245,7 +298,7 @@ func (c *oauth2CredentialProvider) WrapHTTP(
 // apply fetches a new access token if necessary and supplies it to the request
 // via the Authorization header as a Bearer token.
 func (c *oauth2CredentialProvider) apply(req *http.Request) error {
-	token, err := c.AccessToken()
+	token, err := c.AccessToken(req.Context())
 	if err != nil {
 		return err
 	}
@@ -257,9 +310,11 @@ func (c *oauth2CredentialProvider) apply(req *http.Request) error {
 var _ AccessTokenProvider = &oauth2CredentialProvider{}
 
 // AccessToken implements AccessTokenProvider.AccessToken.
-func (c *oauth2CredentialProvider) AccessToken() (string, error) {
+func (c *oauth2CredentialProvider) AccessToken(
+	ctx context.Context,
+) (string, error) {
 	if c.shouldRefreshToken() {
-		err := c.loadCredentials()
+		err := c.loadCredentials(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -281,7 +336,7 @@ func (c *oauth2CredentialProvider) shouldRefreshToken() bool {
 // necessary, using a mutex to prevent concurrent refreshes. It first checks for
 // a non-expiring token in memory or the credentials file. If none is found, it
 // fetches a new token and saves it.
-func (c *oauth2CredentialProvider) loadCredentials() error {
+func (c *oauth2CredentialProvider) loadCredentials(ctx context.Context) error {
 	c.tokenMu.Lock()
 	defer c.tokenMu.Unlock()
 
@@ -299,7 +354,7 @@ func (c *oauth2CredentialProvider) loadCredentials() error {
 		}
 	}
 
-	token, err := c.fetchAccessToken()
+	token, err := c.fetchAccessToken(ctx)
 	if err != nil {
 		return fmt.Errorf("api: couldn't fetch access token: %w", err)
 	}
@@ -356,7 +411,9 @@ func (c *oauth2CredentialProvider) trySaveCredentialsToFile(credentials Credenti
 // Reads the identity token from a file and exchanges it for
 // an access token from the authorization server using the JWT Bearer flow defined
 // in OAuth RFC 7523. The access token is then returned with its expiration time.
-func (c *oauth2CredentialProvider) fetchAccessToken() (accessTokenInfo, error) {
+func (c *oauth2CredentialProvider) fetchAccessToken(
+	ctx context.Context,
+) (accessTokenInfo, error) {
 	// Read the file for each exchange: short-lived identity tokens are
 	// re-minted to the same path, and an exchange must use the current
 	// file contents rather than the token present at startup.
@@ -365,18 +422,22 @@ func (c *oauth2CredentialProvider) fetchAccessToken() (accessTokenInfo, error) {
 		return accessTokenInfo{}, err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, tokenExchangeTimeout)
+	defer cancel()
+
 	tokenURL := fmt.Sprintf("%s/oidc/token", c.baseURL)
 	data := fmt.Sprintf(
 		"grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=%s",
 		url.QueryEscape(identityToken),
 	)
-	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data))
+	req, err := retryablehttp.NewRequestWithContext(
+		ctx, http.MethodPost, tokenURL, strings.NewReader(data))
 	if err != nil {
 		return accessTokenInfo{}, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return accessTokenInfo{}, err
 	}

--- a/core/internal/api/credentials_test.go
+++ b/core/internal/api/credentials_test.go
@@ -1,11 +1,15 @@
 package api_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +20,7 @@ import (
 
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/apitest"
+	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/httplayerstest"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	wbsettings "github.com/wandb/wandb/core/internal/settings"
@@ -62,8 +67,8 @@ func TestNewAPIKeyCredentialProvider_NoAPIKey(t *testing.T) {
 	assert.Equal(t, credentialProvider, api.NoopCredentialProvider{})
 }
 
-func authServer(token string, expiresIn time.Duration) *apitest.RecordingServer {
-	handler := func(w http.ResponseWriter, req *http.Request) {
+func authHandler(token string, expiresIn time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
 		response := map[string]interface{}{
 			"access_token": token,
 			"expires_in":   expiresIn.Seconds(),
@@ -76,7 +81,11 @@ func authServer(token string, expiresIn time.Duration) *apitest.RecordingServer 
 			return
 		}
 	}
-	server := apitest.NewRecordingServer(apitest.WithHandlerFunc(handler))
+}
+
+func authServer(token string, expiresIn time.Duration) *apitest.RecordingServer {
+	server := apitest.NewRecordingServer(
+		apitest.WithHandlerFunc(authHandler(token, expiresIn)))
 	return server
 }
 
@@ -421,7 +430,7 @@ func TestOAuth2CredentialProvider_AccessToken(t *testing.T) {
 	tokenProvider, ok := credentialProvider.(api.AccessTokenProvider)
 	require.True(t, ok, "the OAuth2 provider must expose access tokens")
 
-	accessToken, err := tokenProvider.AccessToken()
+	accessToken, err := tokenProvider.AccessToken(t.Context())
 
 	require.NoError(t, err)
 	assert.Equal(t, token, accessToken)
@@ -528,7 +537,8 @@ func TestOAuth2CredentialProvider_RejectedExchangeIsPermanent(t *testing.T) {
 func TestOAuth2CredentialProvider_ExchangeServerErrorIsNotPermanent(t *testing.T) {
 	server := rejectingAuthServer(http.StatusBadGateway, "upstream error")
 	defer server.Close()
-	credentialProvider := oauth2ProviderForServer(t, server.URL)
+	credentialProvider := oauth2ProviderWithClient(t, server.URL,
+		exchangeClient(t, server.URL, tokenExchangeTestRetryMax, time.Minute))
 
 	_, err := httplayerstest.MapRequest(t,
 		credentialProvider, exampleGetRequest(t))
@@ -538,4 +548,251 @@ func TestOAuth2CredentialProvider_ExchangeServerErrorIsNotPermanent(t *testing.T
 	var exchangeErr *api.TokenExchangeError
 	assert.False(t, errors.As(err, &exchangeErr))
 	assert.Contains(t, err.Error(), "upstream error")
+}
+
+// stalledAuthServer is a token endpoint that accepts requests but never
+// answers them, like a server behind a silently dropped connection.
+func stalledAuthServer(t *testing.T) *httptest.Server {
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			select {
+			case <-release:
+			case <-req.Context().Done():
+			}
+		}))
+
+	// The server must stop waiting for its handlers before it is closed.
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	return server
+}
+
+// tokenExchangeTestRetryMax mirrors the retry count the provider uses in
+// production, so tests exercise the same number of attempts.
+const tokenExchangeTestRetryMax = 3
+
+// exchangeClient builds the client used for the token exchange, with the
+// retry behavior the test needs.
+func exchangeClient(
+	t *testing.T,
+	serverURL string,
+	retryMax int,
+	nonRetryTimeout time.Duration,
+) api.RetryableClient {
+	baseURL, err := url.Parse(serverURL)
+	require.NoError(t, err)
+
+	return api.NewClient(api.ClientOptions{
+		BaseURL:            baseURL,
+		RetryMax:           retryMax,
+		RetryWaitMin:       time.Millisecond,
+		RetryWaitMax:       10 * time.Millisecond,
+		RetryPolicy:        clients.RetryMostFailures,
+		NonRetryTimeout:    nonRetryTimeout,
+		CredentialProvider: api.NoopCredentialProvider{},
+		Logger:             observabilitytest.NewTestLogger(t).Logger,
+	})
+}
+
+func oauth2ProviderWithClient(
+	t *testing.T,
+	serverURL string,
+	httpClient api.RetryableClient,
+) api.CredentialProvider {
+	tokenFile := filepath.Join(t.TempDir(), "jwt.txt")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("id-token"), 0o600))
+	credentialsFile := filepath.Join(t.TempDir(), "credentials.json")
+
+	credentialProvider, err := api.NewOAuth2CredentialProvider(
+		serverURL,
+		tokenFile,
+		credentialsFile,
+		httpClient,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+	return credentialProvider
+}
+
+func TestOAuth2CredentialProvider_StalledExchangeFails(t *testing.T) {
+	tests := []struct {
+		name          string
+		clientTimeout time.Duration
+		ctxTimeout    time.Duration
+	}{
+		{
+			name:          "client timeout",
+			clientTimeout: 50 * time.Millisecond,
+			ctxTimeout:    time.Minute,
+		},
+		{
+			name:          "caller context deadline",
+			clientTimeout: time.Minute,
+			ctxTimeout:    50 * time.Millisecond,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := stalledAuthServer(t)
+			credentialProvider := oauth2ProviderWithClient(t, server.URL,
+				exchangeClient(t, server.URL, 0, test.clientTimeout))
+			tokenProvider, ok := credentialProvider.(api.AccessTokenProvider)
+			require.True(t, ok)
+
+			ctx, cancel := context.WithTimeout(t.Context(), test.ctxTimeout)
+			defer cancel()
+
+			exchange := make(chan error, 1)
+			go func() {
+				_, err := tokenProvider.AccessToken(ctx)
+				exchange <- err
+			}()
+
+			select {
+			case err := <-exchange:
+				// An unanswered exchange must not block the requests that
+				// depend on the access token.
+				assert.Error(t, err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("the token exchange never returned")
+			}
+		})
+	}
+}
+
+// countingAuthServer is a token endpoint that replies with the given statuses
+// in order, repeating the last one, and counts the requests it received.
+func countingAuthServer(
+	t *testing.T,
+	count *atomic.Int32,
+	statuses ...int,
+) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			n := int(count.Add(1)) - 1
+			status := statuses[min(n, len(statuses)-1)]
+
+			if status == http.StatusOK {
+				authHandler("fake-token", time.Hour)(w, req)
+				return
+			}
+
+			http.Error(w, "nope", status)
+		}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestOAuth2CredentialProvider_ExchangeRetries(t *testing.T) {
+	tests := []struct {
+		name          string
+		statuses      []int
+		wantRequests  int32
+		wantPermanent bool
+	}{
+		{
+			name:          "a rejected identity token is not retried",
+			statuses:      []int{http.StatusUnauthorized},
+			wantRequests:  1,
+			wantPermanent: true,
+		},
+		{
+			name:          "a forbidden exchange is not retried",
+			statuses:      []int{http.StatusForbidden},
+			wantRequests:  1,
+			wantPermanent: true,
+		},
+		{
+			name:         "a server error is retried until it succeeds",
+			statuses:     []int{http.StatusInternalServerError, http.StatusOK},
+			wantRequests: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := countingAuthServer(t, &requests, test.statuses...)
+			credentialProvider := oauth2ProviderWithClient(t, server.URL,
+				exchangeClient(t, server.URL,
+					tokenExchangeTestRetryMax, time.Minute))
+			tokenProvider, ok := credentialProvider.(api.AccessTokenProvider)
+			require.True(t, ok)
+
+			token, err := tokenProvider.AccessToken(t.Context())
+
+			assert.Equal(t, test.wantRequests, requests.Load())
+			if !test.wantPermanent {
+				require.NoError(t, err)
+				assert.Equal(t, "fake-token", token)
+				return
+			}
+
+			require.Error(t, err)
+			var exchangeErr *api.TokenExchangeError
+			require.ErrorAs(t, err, &exchangeErr)
+			assert.True(t, exchangeErr.PermanentError())
+		})
+	}
+}
+
+// tlsAuthServer is a token endpoint served over HTTPS with a self-signed
+// certificate, like an on-prem deployment.
+func tlsAuthServer(t *testing.T, token string) *httptest.Server {
+	server := httptest.NewTLSServer(authHandler(token, time.Hour))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestNewOAuth2CredentialProvider_InsecureDisableSSL(t *testing.T) {
+	tests := []struct {
+		name               string
+		insecureDisableSSL bool
+	}{
+		{name: "certificate is verified by default"},
+		{name: "verification is disabled by the setting", insecureDisableSSL: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := tlsAuthServer(t, "fake-token")
+
+			tokenFile := filepath.Join(t.TempDir(), "jwt.txt")
+			require.NoError(t,
+				os.WriteFile(tokenFile, []byte("id-token"), 0o600))
+
+			settings := wbsettings.From(&spb.Settings{
+				BaseUrl:           &wrapperspb.StringValue{Value: server.URL},
+				IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+				CredentialsFile: &wrapperspb.StringValue{
+					Value: filepath.Join(t.TempDir(), "credentials.json"),
+				},
+				InsecureDisableSsl: &wrapperspb.BoolValue{
+					Value: test.insecureDisableSSL,
+				},
+			})
+			credentialProvider, err := api.NewCredentialProvider(
+				settings,
+				observabilitytest.NewTestLogger(t).Logger,
+			)
+			require.NoError(t, err)
+
+			reqs, err := httplayerstest.MapRequest(t,
+				credentialProvider, exampleGetRequest(t))
+
+			if !test.insecureDisableSSL {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "certificate")
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, reqs, 1)
+			assert.Equal(t,
+				"Bearer fake-token", reqs[0].Header.Get("Authorization"))
+		})
+	}
 }

--- a/core/internal/wbapi/authhandler.go
+++ b/core/internal/wbapi/authhandler.go
@@ -116,13 +116,13 @@ func (h *AuthHandler) HandleAuthenticate(
 // it is at or near expiration. For other credential types, the response
 // contains an empty access token.
 func (h *AuthHandler) HandleGetAccessToken(
-	_ context.Context,
+	ctx context.Context,
 	_ *spb.GetAccessTokenRequest,
 ) *spb.ApiResponse {
 	response := &spb.GetAccessTokenResponse{}
 
 	if provider, ok := h.credentialProvider.(api.AccessTokenProvider); ok {
-		token, err := provider.AccessToken()
+		token, err := provider.AccessToken(ctx)
 		if err != nil {
 			return apiErrorResponse(err.Error(), 0)
 		}

--- a/core/internal/wbapi/authhandler_test.go
+++ b/core/internal/wbapi/authhandler_test.go
@@ -157,7 +157,9 @@ type fakeAccessTokenProvider struct {
 	err   error
 }
 
-func (p *fakeAccessTokenProvider) AccessToken() (string, error) {
+func (p *fakeAccessTokenProvider) AccessToken(
+	_ context.Context,
+) (string, error) {
 	return p.token, p.err
 }
 

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -27,7 +27,7 @@ from wandb.sdk.internal.internal_api import (
     _OrgNames,
 )
 from wandb.sdk.launch.sweeps import SweepNotFoundError
-from wandb.sdk.lib import retry
+from wandb.sdk.lib import retry, wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 from .test_retry import MockTime, mock_time  # noqa: F401
@@ -803,6 +803,28 @@ class TestJWTAuth:
 
         fetch_mock.assert_not_called()
         assert api.request_auth == ("api", "a" * 40)
+
+    def test_session_api_key_takes_precedence_over_jwt(
+        self, tmp_path: pathlib.Path, mocker: MockerFixture
+    ):
+        token_file = tmp_path / "token.jwt"
+        token_file.write_text("test.jwt.token")
+
+        fetch_mock = mocker.patch(
+            "wandb.apis.public.service_api.ServiceApi.access_token",
+            return_value="test_access_token",
+        )
+        wbauth.use_explicit_auth(
+            wbauth.AuthApiKey(host="https://api.wandb.ai", api_key="a" * 40),
+            source="test",
+        )
+
+        environ = {"WANDB_IDENTITY_TOKEN_FILE": str(token_file)}
+        api = internal.InternalApi(environ=environ)
+
+        fetch_mock.assert_not_called()
+        assert api.request_auth == ("api", "a" * 40)
+        assert api._service_api._settings.api_key == "a" * 40
 
     def test_access_token_none_without_identity_token(self, mocker: MockerFixture):
         # Without federated identity, the token is None and no request is

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -262,11 +262,19 @@ class Api:
             self._environ.get("WANDB__EXTRA_HTTP_HEADERS", "{}")
         )
 
+        from wandb.sdk.lib import wbauth
+
+        # An API key configured for this session, such as through
+        # wandb.login(), replaces the identity token file.
+        session_auth = wbauth.session_credentials(host=self.api_url)
+
         auth: tuple[str, str] | None = None
         api_key = api_key or self.default_settings.get("api_key")
         if api_key:
             auth = ("api", api_key)
-        elif token_file := self._environ.get(env.IDENTITY_TOKEN_FILE):
+        elif (
+            token_file := self._environ.get(env.IDENTITY_TOKEN_FILE)
+        ) and not isinstance(session_auth, wbauth.AuthApiKey):
             # Federated identity: wandb-core exchanges the identity token
             # for an access token and authenticates its requests with it.
             # Code that talks to the server directly gets the token from


### PR DESCRIPTION
Description
-----------

The access token request used Go's default HTTP transport, so it ignored the SSL and
proxy settings configured for the SDK, while every other request to W&B honored them.
On a deployment with a self-signed certificate, signing in failed with a certificate
error even though API key authentication against the same host worked. Behind a proxy
configured through settings rather than environment variables, the request did not use it.

The exchange client's transport is now built from the same settings, matching how the
rest of the API client is constructed.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added `TestNewOAuth2CredentialProvider_InsecureDisableSSL`, which runs the exchange
against a TLS test server with a self-signed certificate and asserts it fails by default
and succeeds when the setting is enabled.

Confirmed it fails without the fix. `go test -race ./internal/api/... ./internal/wbapi/...`
passes.
