### PR TITLE
fix(sdk): stop resumed runs from overwriting earlier console logs and system metrics

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,3 +52,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` validates api keys prior to saving to the `.netrc` file (@jacobromero in https://github.com/wandb/wandb/pull/12347)
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
+- Resuming a run no longer overwrites the console output and system metrics that the previous session had already uploaded (@dmitryduev in https://github.com/wandb/wandb/pull/12379)

--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -684,9 +684,11 @@ func (upserter *RunUpserter) lockedUpdateFromUpsert(
 	upserter.params.SweepID = nullify.ZeroIfNil(bucket.GetSweepName())
 
 	if lineCount := nullify.ZeroIfNil(bucket.GetHistoryLineCount()); lineCount > 0 {
-		upserter.params.FileStreamOffset = filestream.FileStreamOffsetMap{
-			filestream.HistoryChunk: lineCount,
+		if upserter.params.FileStreamOffset == nil {
+			upserter.params.FileStreamOffset = make(filestream.FileStreamOffsetMap)
 		}
+
+		upserter.params.FileStreamOffset[filestream.HistoryChunk] = lineCount
 	}
 
 	if project := bucket.GetProject(); project == nil {

--- a/core/internal/runupserter/runupserter_test.go
+++ b/core/internal/runupserter/runupserter_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/wandb/wandb/core/internal/featurechecker"
+	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/gqlmock"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runsyncstate"
@@ -311,6 +312,57 @@ func TestResume_ReusesSyncStateStartingStep(t *testing.T) {
 	// already uploaded more history, the pre-initialized value wins so that
 	// re-syncing doesn't shift steps forward.
 	assert.EqualValues(t, 6, run.StartingStep)
+}
+
+func TestResume_KeepsEventsAndOutputFileStreamOffsets(t *testing.T) {
+	mockClient := gqlmock.NewMockClient()
+	mockClient.StubMatchOnce(gqlmock.WithOpName("RunResumeStatus"), `{
+		"model": {
+			"bucket": {
+				"name": "run",
+				"id": "storage-id",
+				"historyLineCount": 3,
+				"eventsLineCount": 13,
+				"logLineCount": 15,
+				"historyTail": "[]",
+				"summaryMetrics": "{}",
+				"config": "{}",
+				"eventsTail": "[]",
+				"wandbConfig": "{\"t\": 1}"
+			}
+		}
+	}`)
+	mockClient.StubMatchOnce(gqlmock.WithOpName("UpsertBucket"), `{
+		"upsertBucket": {
+			"bucket": {
+				"id": "storage ID",
+				"name": "run ID",
+				"displayName": "display name",
+				"sweepName": "sweep ID",
+				"project": {
+					"name": "project name",
+					"entity": {"name": "entity name"}
+				},
+				"historyLineCount": 5
+			}
+		}
+	}`)
+
+	params := testParams(t)
+	params.GraphqlClientOrNil = mockClient
+	params.Settings = settings.From(&spb.Settings{Resume: wrapperspb.String("allow")})
+
+	upserter, err := runupserter.InitRun(runRecord(&spb.RunRecord{RunId: "run"}), params)
+	require.NoError(t, err)
+	defer upserter.Finish()
+
+	assert.Equal(t,
+		filestream.FileStreamOffsetMap{
+			filestream.HistoryChunk: 5,
+			filestream.EventsChunk:  13,
+			filestream.OutputChunk:  15,
+		},
+		upserter.FileStreamOffsets())
 }
 
 func TestNewRun_InitializesSyncStateStartingStep(t *testing.T) {

--- a/tests/system_tests/test_core/test_resume.py
+++ b/tests/system_tests/test_core/test_resume.py
@@ -200,6 +200,44 @@ def test_resume_output_log(wandb_backend_spy):
         assert len(log_files) == 2
 
 
+def test_resume_does_not_overwrite_console_output(wandb_backend_spy):
+    """A resumed run appends to the uploaded console output.
+
+    Regression test for https://github.com/wandb/wandb/pull/12379: the
+    response to a resumed run's first upsert used to reset the filestream
+    offsets recovered from the resume status, making the run re-upload
+    console output (and system metrics) starting at offset 0 and overwrite
+    what the previous session had uploaded.
+    """
+    settings = wandb.Settings(console="wrap")
+
+    with wandb.init(project="console", settings=settings) as run:
+        run_id = run.id
+        print("hello from the first session")
+        run.log({"x": 1})
+
+    with wandb_backend_spy.freeze() as snapshot:
+        output_before = snapshot.output(run_id=run_id)
+    assert len(output_before) > 0
+
+    with wandb.init(
+        id=run_id,
+        resume="must",
+        project="console",
+        settings=settings,
+    ) as run:
+        print("hello from the resumed session")
+
+    with wandb_backend_spy.freeze() as snapshot:
+        output_after = snapshot.output(run_id=run_id)
+
+    assert any(
+        "hello from the resumed session" in line for line in output_after.values()
+    )
+    for offset, line in output_before.items():
+        assert output_after[offset] == line
+
+
 def test_resume_config_preserves_image_mask(user, wandb_backend_spy):
     img_array = np.zeros((2, 2, 3), dtype=np.uint8)
     mask_array = np.zeros((1, 1), dtype=np.uint8)


### PR DESCRIPTION
Description
-----------

Resuming a run restarted its console output upload from the beginning instead of
continuing after what the previous session had sent, so the earlier console lines were
overwritten on the server and could not be recovered. History and summary were not
affected.

The filestream offsets recovered while resolving the resume (the `historyLineCount`,
`eventsLineCount` and `logLineCount` from `RunResumeStatus`) were replaced wholesale as
soon as the server's response to the first run upsert reported a history line count, so
only the history offset survived and console lines were re-sent starting at offset 0.
The response now updates the history offset and leaves the console and system metric
offsets alone. The system metric (events) offset is preserved for protocol correctness;
samples carry their own timestamps, so no user-visible impact was confirmed for it.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added `TestResume_KeepsEventsAndOutputFileStreamOffsets`, which stubs a resume carrying
history, events and log line counts, then asserts all three offsets survive the first
upsert.

Confirmed it fails without the fix. `go test -race ./internal/runupserter/...` passes.

Added a system test, `test_resume_does_not_overwrite_console_output`, which finishes a
session that printed to the console, resumes the run and prints again, then asserts the
resumed session appended to the previously uploaded console output instead of
overwriting it. It fails on main (the resumed line is sent at offset 0) and passes with
the fix.

Also verified end to end against api.wandb.ai: with a build from main, the resumed
session transmits `console_offset: 0` and the previous session's line disappears from
the run's Logs page; with this branch it transmits the correct continuation offset and
both lines show.