### PR TITLE
security: make debug logging in wandb-core less blabbermouth

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -56,3 +56,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
 - Downloading an artifact file with `skip_cache=True` now replaces a different file of the same size at the destination instead of keeping it (@dmitryduev in https://github.com/wandb/wandb/pull/12382)
 - Downloading an artifact with `skip_cache=True` no longer changes where later downloads in the same process are written (@dmitryduev in https://github.com/wandb/wandb/pull/12383)
+
+## Security
+
+- Debug logs no longer contain your API key (@dmitryduev in https://github.com/wandb/wandb/pull/12384)

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -243,18 +243,12 @@ func (nc *Connection) processIncomingData() {
 	for scanner.Scan() {
 		msg := &spb.ServerRequest{}
 		if err := proto.Unmarshal(scanner.Bytes(), msg); err != nil {
-			dataLen := len(scanner.Bytes())
-			dataTrunc := scanner.Bytes()
-			if len(dataTrunc) > 1<<10 {
-				dataTrunc = dataTrunc[:1<<10]
-			}
-
+			// Client messages may contain credentials and must not be logged.
 			slog.Error(
 				"connection: unmarshalling error, breaking connection",
 				"error", err,
 				"id", nc.id,
-				"token_len", dataLen,
-				"token_1kb", dataTrunc,
+				"token_len", len(scanner.Bytes()),
 			)
 
 			// Stop the server because a client is misbehaving, and it is no
@@ -322,7 +316,12 @@ func (nc *Connection) handleIncomingRequests() {
 	defer wg.Wait()
 
 	for msg := range nc.inChan {
-		slog.Debug("handleIncomingRequests: processing message", "msg", msg, "id", nc.id)
+		// Requests may contain credentials and must not be logged.
+		slog.Debug("handleIncomingRequests: processing message",
+			"type", fmt.Sprintf("%T", msg.ServerRequestType),
+			"requestId", msg.RequestId,
+			"id", nc.id,
+		)
 
 		switch x := msg.ServerRequestType.(type) {
 		case *spb.ServerRequest_Cancel:
@@ -362,7 +361,7 @@ func (nc *Connection) handleIncomingRequests() {
 		default:
 			slog.Error(
 				"handleIncomingRequests: unknown ServerRequestType",
-				"type", x,
+				"type", fmt.Sprintf("%T", x),
 				"id", nc.id,
 			)
 			return

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -243,18 +243,12 @@ func (nc *Connection) processIncomingData() {
 	for scanner.Scan() {
 		msg := &spb.ServerRequest{}
 		if err := proto.Unmarshal(scanner.Bytes(), msg); err != nil {
-			dataLen := len(scanner.Bytes())
-			dataTrunc := scanner.Bytes()
-			if len(dataTrunc) > 1<<10 {
-				dataTrunc = dataTrunc[:1<<10]
-			}
-
+			// Client messages may contain credentials and must not be logged.
 			slog.Error(
 				"connection: unmarshalling error, breaking connection",
 				"error", err,
 				"id", nc.id,
-				"token_len", dataLen,
-				"token_1kb", dataTrunc,
+				"token_len", len(scanner.Bytes()),
 			)
 
 			// Stop the server because a client is misbehaving, and it is no
@@ -322,7 +316,17 @@ func (nc *Connection) handleIncomingRequests() {
 	defer wg.Wait()
 
 	for msg := range nc.inChan {
-		slog.Debug("handleIncomingRequests: processing message", "msg", msg, "id", nc.id)
+		if _, ok := msg.ServerRequestType.(*spb.ServerRequest_InformInit); ok {
+			// The settings on an inform_init request contain credentials,
+			// such as the user's API key, and must not be logged.
+			slog.Debug("handleIncomingRequests: processing message",
+				"type", fmt.Sprintf("%T", msg.ServerRequestType),
+				"requestId", msg.RequestId,
+				"id", nc.id,
+			)
+		} else {
+			slog.Debug("handleIncomingRequests: processing message", "msg", msg, "id", nc.id)
+		}
 
 		switch x := msg.ServerRequestType.(type) {
 		case *spb.ServerRequest_Cancel:

--- a/core/pkg/server/connection_test.go
+++ b/core/pkg/server/connection_test.go
@@ -1,12 +1,37 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
 	"net"
 	"sync"
 	"testing"
 	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+// captureDefaultLogs redirects the default logger to the returned buffer
+// for the duration of the test.
+func captureDefaultLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	logs := &bytes.Buffer{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return logs
+}
 
 func TestConnection_ManageConnectionDataReturnsWhenPeerCloses(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
@@ -76,4 +101,56 @@ func TestConnection_ManageConnectionDataReturnsWhenServerStops(t *testing.T) {
 			t.Fatal("client connection remained open after server shutdown")
 		}
 	})
+}
+
+func TestConnection_DoesNotLogUnparseableRequestBytes(t *testing.T) {
+	const apiKey = "0123456789abcdef0123456789abcdef01234567"
+
+	logs := captureDefaultLogs(t)
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	conn := NewConnection(
+		context.Background(),
+		func() {},
+		ConnectionParams{
+			ID:   "test",
+			Conn: serverConn,
+		},
+	)
+
+	request, err := proto.Marshal(&spb.ServerRequest{
+		ServerRequestType: &spb.ServerRequest_InformInit{
+			InformInit: &spb.ServerInformInitRequest{
+				Settings: &spb.Settings{ApiKey: wrapperspb.String(apiKey)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// A leading invalid tag makes the request unparseable while keeping the
+	// API key in its bytes.
+	payload := append([]byte{0xff}, request...)
+	frame := &bytes.Buffer{}
+	require.NoError(t, binary.Write(frame, binary.LittleEndian, &Header{
+		Magic:      byte('W'),
+		DataLength: uint32(len(payload)),
+	}))
+	_, err = frame.Write(payload)
+	require.NoError(t, err)
+
+	written := make(chan struct{})
+	go func() {
+		defer close(written)
+		_, _ = clientConn.Write(frame.Bytes())
+	}()
+
+	conn.processIncomingData()
+	<-written
+
+	assert.Contains(t, logs.String(), "unmarshalling error")
+	assert.Contains(t, logs.String(),
+		fmt.Sprintf("token_len=%d", len(payload)))
+	assert.NotContains(t, logs.String(), apiKey)
 }

--- a/core/pkg/server/connection_test.go
+++ b/core/pkg/server/connection_test.go
@@ -1,12 +1,81 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+// recordedLogs is a slog handler that keeps log output for inspection.
+type recordedLogs struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+// captureDefaultLogs sends everything logged to the default logger to the
+// returned recorder for the duration of the test.
+func captureDefaultLogs(t *testing.T) *recordedLogs {
+	t.Helper()
+
+	logs := &recordedLogs{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(logs))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return logs
+}
+
+func (l *recordedLogs) Enabled(context.Context, slog.Level) bool { return true }
+
+//nolint:gocritic // the slog.Handler interface fixes this signature.
+func (l *recordedLogs) Handle(_ context.Context, record slog.Record) error {
+	entry := &strings.Builder{}
+	entry.WriteString(record.Message)
+	record.Attrs(func(attr slog.Attr) bool {
+		fmt.Fprintf(entry, " %s=%s", attr.Key, attrText(attr.Value))
+		return true
+	})
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, entry.String())
+
+	return nil
+}
+
+func (l *recordedLogs) WithAttrs([]slog.Attr) slog.Handler { return l }
+
+func (l *recordedLogs) WithGroup(string) slog.Handler { return l }
+
+// String returns all recorded log output.
+func (l *recordedLogs) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.entries, "\n")
+}
+
+// attrText renders a logged value, expanding byte slices into text so that
+// credentials inside raw payloads are visible to assertions.
+func attrText(value slog.Value) string {
+	if raw, ok := value.Any().([]byte); ok {
+		return string(raw)
+	}
+	return value.String()
+}
 
 func TestConnection_ManageConnectionDataReturnsWhenPeerCloses(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
@@ -76,4 +145,93 @@ func TestConnection_ManageConnectionDataReturnsWhenServerStops(t *testing.T) {
 			t.Fatal("client connection remained open after server shutdown")
 		}
 	})
+}
+
+func TestConnection_DoesNotLogRequestContents(t *testing.T) {
+	const apiKey = "0123456789abcdef0123456789abcdef01234567"
+
+	logs := captureDefaultLogs(t)
+	backend := viewerBackend(t,
+		`{"data": {"viewer": {"id": "id", "entity": "myentity"}}}`)
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	conn := NewConnection(
+		context.Background(),
+		func() {},
+		ConnectionParams{
+			ID:   "test",
+			Conn: serverConn,
+		},
+	)
+
+	conn.inChan <- &spb.ServerRequest{
+		RequestId: "my-request-id",
+		ServerRequestType: &spb.ServerRequest_Authenticate{
+			Authenticate: &spb.ServerAuthenticateRequest{
+				ApiKey:  apiKey,
+				BaseUrl: backend.URL,
+			},
+		},
+	}
+	close(conn.inChan)
+
+	conn.handleIncomingRequests()
+
+	assert.NotContains(t, logs.String(), apiKey)
+	assert.Contains(t, logs.String(), "ServerRequest_Authenticate")
+	assert.Contains(t, logs.String(), "my-request-id")
+}
+
+func TestConnection_DoesNotLogUnparseableRequestBytes(t *testing.T) {
+	const apiKey = "0123456789abcdef0123456789abcdef01234567"
+
+	logs := captureDefaultLogs(t)
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	conn := NewConnection(
+		context.Background(),
+		func() {},
+		ConnectionParams{
+			ID:   "test",
+			Conn: serverConn,
+		},
+	)
+
+	request, err := proto.Marshal(&spb.ServerRequest{
+		ServerRequestType: &spb.ServerRequest_InformInit{
+			InformInit: &spb.ServerInformInitRequest{
+				Settings: &spb.Settings{ApiKey: wrapperspb.String(apiKey)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// A leading invalid tag makes the request unparseable while keeping the
+	// API key in its bytes.
+	payload := append([]byte{0xff}, request...)
+	frame := &bytes.Buffer{}
+	require.NoError(t, binary.Write(frame, binary.LittleEndian, &Header{
+		Magic:      byte('W'),
+		DataLength: uint32(len(payload)),
+	}))
+	_, err = frame.Write(payload)
+	require.NoError(t, err)
+
+	written := make(chan struct{})
+	go func() {
+		defer close(written)
+		_, _ = clientConn.Write(frame.Bytes())
+	}()
+
+	conn.processIncomingData()
+	<-written
+
+	assert.Contains(t, logs.String(), "unmarshalling error")
+	assert.Contains(t, logs.String(),
+		fmt.Sprintf("token_len=%d", len(payload)))
+	assert.NotContains(t, logs.String(), apiKey)
 }


### PR DESCRIPTION
Description
-----------

wandb-core logged inbound requests verbatim, and an inform_init request carries the run's settings, potentially including the user's API key.  inform_init is now logged by type and request id only; other requests are unchanged.

The parse-failure path no longer dumps raw request bytes at all (for an inform_init request that is corrupt for some reason the frame would include the key), but I'm open to reconsidering this.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
