### PR TITLE
security: stop writing cw cluster credentials to the debug log

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -60,3 +60,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 ## Security
 
 - Debug logs no longer contain your API key (@dmitryduev in https://github.com/wandb/wandb/pull/12384)
+- Debug logs no longer contain CoreWeave cluster credentials (@dmitryduev in https://github.com/wandb/wandb/pull/12385)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -58,3 +58,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
+
+## Security
+
+- Debug logs no longer contain CoreWeave cluster credentials (@dmitryduev in https://github.com/wandb/wandb/pull/12385)

--- a/core/internal/monitor/cwmetadata.go
+++ b/core/internal/monitor/cwmetadata.go
@@ -23,6 +23,10 @@ import (
 )
 
 // CoreWeaveInstanceData holds the parsed metadata from the CoreWeave endpoint.
+//
+// The endpoint also returns cluster credentials, such as the kubeadm join
+// token, the CA certificate hash and the Teleport join token. Those are
+// deliberately not parsed so that they cannot reach a log or a record.
 type CoreWeaveInstanceData struct {
 	CalicoCleanupAPI    string `meta:"calico_cleanup_api"`
 	K8sVersion          string `meta:"k8s_version"`
@@ -33,11 +37,8 @@ type CoreWeaveInstanceData struct {
 	FDERaid             bool   `meta:"fde_raid"`
 	TeleportClass       string `meta:"teleport_class"`
 	EtcHosts            string `meta:"etc_hosts"`
-	JoinToken           string `meta:"join_token"`
 	ClusterName         string `meta:"cluster_name"`
 	RegistryProxyServer string `meta:"registry_proxy_server"`
-	CACertHash          string `meta:"ca_cert_hash"`
-	TeleportToken       string `meta:"teleport_token"`
 	APIServer           string `meta:"apiserver"`
 }
 
@@ -261,7 +262,12 @@ func (cwm *CoreWeaveMetadata) parseResponse(body io.Reader) (*CoreWeaveInstanceD
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
 
-	cwm.logger.Debug("cwmetadata: successfully parsed metadata", "data", data)
+	cwm.logger.Debug(
+		"cwmetadata: successfully parsed metadata",
+		"cluster_name", data.ClusterName,
+		"org_id", data.OrgID,
+		"region", data.Region,
+	)
 	return data, nil
 }
 
@@ -306,7 +312,7 @@ func (cwm *CoreWeaveMetadata) parseLine(
 
 	field, ok := fieldMap[key]
 	if !ok || !field.CanSet() {
-		cwm.logger.Debug("cwmetadata: unknown or unsettable field", "key", key, "value", value)
+		cwm.logger.Debug("cwmetadata: unknown or unsettable field", "key", key)
 		return
 	}
 

--- a/core/internal/monitor/cwmetadata_test.go
+++ b/core/internal/monitor/cwmetadata_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +50,26 @@ func newTestRetryableHTTPClient(logger *observability.CoreLogger) *retryablehttp
 	return client
 }
 
+// sampleMetadataValue returns the value of a key in
+// coreWeaveSampleMetadataResponse, failing the test if it is absent so
+// that assertions about the value cannot pass trivially.
+func sampleMetadataValue(t *testing.T, key string) string {
+	t.Helper()
+
+	for line := range strings.Lines(coreWeaveSampleMetadataResponse) {
+		k, v, ok := strings.Cut(line, ":")
+		if ok && k == key {
+			value := strings.TrimSpace(v)
+			require.NotEmpty(t, value,
+				"%q has no value in coreWeaveSampleMetadataResponse", key)
+			return value
+		}
+	}
+
+	t.Fatalf("%q is not in coreWeaveSampleMetadataResponse", key)
+	return ""
+}
+
 func TestCoreWeaveMetadataProbeDoesNotLogCredentials(t *testing.T) {
 	logger, logs := observabilitytest.NewDebugRecordingTestLogger(t)
 
@@ -89,13 +110,14 @@ func TestCoreWeaveMetadataProbeDoesNotLogCredentials(t *testing.T) {
 	assert.Equal(t, "b13ad0", e.Coreweave.OrgId)
 	assert.Equal(t, "us-east-04", e.Coreweave.Region)
 
-	for name, value := range map[string]string{
-		"join_token":     "6r2nt2.vbt9w6s72pzcwkh7",
-		"ca_cert_hash":   "7dae4dfc5b7e430ea2d7f87776d498ec00844c06f4eacb134ea9c1d06a072761",
-		"teleport_token": "a5b0f5d6645183e3b6fa3891ce66e0e8",
-	} {
+	// The metadata must have been logged for the assertions below to be
+	// meaningful: credentials cannot appear in a log that was never written.
+	assert.Contains(t, logs.String(), "cwmetadata: successfully parsed metadata")
+
+	for _, key := range []string{"join_token", "ca_cert_hash", "teleport_token"} {
+		value := sampleMetadataValue(t, key)
 		assert.NotContains(t, logs.String(), value,
-			"the value of %q must not be logged", name)
+			"the value of %q must not be logged", key)
 	}
 }
 

--- a/core/internal/monitor/cwmetadata_test.go
+++ b/core/internal/monitor/cwmetadata_test.go
@@ -49,6 +49,56 @@ func newTestRetryableHTTPClient(logger *observability.CoreLogger) *retryablehttp
 	return client
 }
 
+func TestCoreWeaveMetadataProbeDoesNotLogCredentials(t *testing.T) {
+	logger, logs := observabilitytest.NewDebugRecordingTestLogger(t)
+
+	mockGQLClient := gqlmock.NewMockClient()
+	mockGQLClient.StubMatchOnce(
+		gqlmock.WithOpName("OrganizationCoreWeaveOrganizationID"),
+		`{"entity":{"organization":{"coreWeaveOrganizationId":"cw1337"}}}`,
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(coreWeaveSampleMetadataResponse))
+		},
+	))
+	defer server.Close()
+
+	s := settings.New()
+	s.UpdateStatsCoreWeaveMetadataBaseURL(server.URL)
+	s.UpdateStatsCoreWeaveMetadataEndpoint(testEndpointPath)
+
+	runHandle := runhandle.New()
+	require.NoError(t, runHandle.Init(runupsertertest.NewOfflineUpserter(t)))
+
+	cwm, err := monitor.NewCoreWeaveMetadata(monitor.CoreWeaveMetadataParams{
+		Client:        newTestRetryableHTTPClient(logger),
+		Logger:        logger,
+		GraphqlClient: mockGQLClient,
+		RunHandle:     runHandle,
+		Settings:      s,
+	})
+	require.NoError(t, err)
+
+	e := cwm.Probe(context.Background())
+
+	require.NotNil(t, e)
+	require.NotNil(t, e.Coreweave)
+	assert.Equal(t, "cks-wb", e.Coreweave.ClusterName)
+	assert.Equal(t, "b13ad0", e.Coreweave.OrgId)
+	assert.Equal(t, "us-east-04", e.Coreweave.Region)
+
+	for name, value := range map[string]string{
+		"join_token":     "6r2nt2.vbt9w6s72pzcwkh7",
+		"ca_cert_hash":   "7dae4dfc5b7e430ea2d7f87776d498ec00844c06f4eacb134ea9c1d06a072761",
+		"teleport_token": "a5b0f5d6645183e3b6fa3891ce66e0e8",
+	} {
+		assert.NotContains(t, logs.String(), value,
+			"the value of %q must not be logged", name)
+	}
+}
+
 func TestCoreWeaveMetadataProbe(t *testing.T) {
 	testCases := []struct {
 		name                string

--- a/core/internal/observabilitytest/logging.go
+++ b/core/internal/observabilitytest/logging.go
@@ -45,6 +45,27 @@ func NewRecordingTestLogger(t *testing.T) (
 	), recordedLogs
 }
 
+// NewDebugRecordingTestLogger is like NewRecordingTestLogger but also
+// captures messages below the INFO level.
+func NewDebugRecordingTestLogger(t *testing.T) (
+	*observability.CoreLogger,
+	*bytes.Buffer,
+) {
+	t.Helper()
+
+	recordedLogs := &bytes.Buffer{}
+	writer := io.MultiWriter(t.Output(), recordedLogs)
+
+	return observability.NewCoreLogger(
+		slog.New(slog.NewJSONHandler(
+			writer,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		)),
+		nil,
+		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
+	), recordedLogs
+}
+
 // NewSentryTestLogger is like NewRecordingTestLogger but also returns a
 // mock Sentry transport for checking captured events.
 func NewSentryTestLogger(t *testing.T) (

--- a/core/internal/observabilitytest/logging.go
+++ b/core/internal/observabilitytest/logging.go
@@ -34,20 +34,22 @@ func NewRecordingTestLogger(t *testing.T) (
 	*bytes.Buffer,
 ) {
 	t.Helper()
-
-	recordedLogs := &bytes.Buffer{}
-	writer := io.MultiWriter(t.Output(), recordedLogs)
-
-	return observability.NewCoreLogger(
-		slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
-		nil,
-		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
-	), recordedLogs
+	return newRecordingTestLogger(t, slog.LevelInfo)
 }
 
 // NewDebugRecordingTestLogger is like NewRecordingTestLogger but also
 // captures messages below the INFO level.
 func NewDebugRecordingTestLogger(t *testing.T) (
+	*observability.CoreLogger,
+	*bytes.Buffer,
+) {
+	t.Helper()
+	return newRecordingTestLogger(t, slog.LevelDebug)
+}
+
+// newRecordingTestLogger returns a logger that records messages at or
+// above the given level into the returned buffer.
+func newRecordingTestLogger(t *testing.T, level slog.Level) (
 	*observability.CoreLogger,
 	*bytes.Buffer,
 ) {
@@ -59,7 +61,7 @@ func NewDebugRecordingTestLogger(t *testing.T) (
 	return observability.NewCoreLogger(
 		slog.New(slog.NewJSONHandler(
 			writer,
-			&slog.HandlerOptions{Level: slog.LevelDebug},
+			&slog.HandlerOptions{Level: level},
 		)),
 		nil,
 		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),


### PR DESCRIPTION
Description
-----------

On CoreWeave deployments the instance metadata probe logged the whole parsed metadata response at debug level, which wrote the cluster join token, the CA certificate hash and
the Teleport registration token in plain text into the run's debug log for no particular reason.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
