### PR TITLE
fix: keep other machines' credentials intact when saving login info to .netrc

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -58,6 +58,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
+- `wandb login` no longer removes or corrupts credentials belonging to other machines in your `.netrc` file (@dmitryduev in https://github.com/wandb/wandb/pull/12386)
 
 ## Security
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -56,6 +56,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
 - Downloading an artifact file with `skip_cache=True` now replaces a different file of the same size at the destination instead of keeping it (@dmitryduev in https://github.com/wandb/wandb/pull/12382)
 - Downloading an artifact with `skip_cache=True` no longer changes where later downloads in the same process are written (@dmitryduev in https://github.com/wandb/wandb/pull/12383)
+- `wandb login` no longer removes or corrupts credentials belonging to other machines in your `.netrc` file (@dmitryduev in https://github.com/wandb/wandb/pull/12386)
 
 ## Security
 

--- a/tests/unit_tests/test_lib/test_auth_netrc.py
+++ b/tests/unit_tests/test_lib/test_auth_netrc.py
@@ -1,3 +1,4 @@
+import netrc
 import pathlib
 import textwrap
 
@@ -91,6 +92,99 @@ def test_write(fake_netrc_path: pathlib.Path):
               login user-2
               password pass-2
             machine test-host:123
+              login user
+              password new-pass
+        """)
+
+
+def test_write_keeps_machine_with_matching_prefix(fake_netrc_path: pathlib.Path):
+    fake_netrc_path.write_text(
+        textwrap.dedent("""\
+            machine test-host.corp.internal
+              login user-1
+              password pass-1
+            machine test-host
+              login user
+              password pass
+        """)
+    )
+
+    wbnetrc.write_netrc_auth(host="https://test-host/", api_key="new-pass")
+
+    assert fake_netrc_path.read_text() == textwrap.dedent("""\
+            machine test-host.corp.internal
+              login user-1
+              password pass-1
+            machine test-host
+              login user
+              password new-pass
+        """)
+
+
+def test_write_keeps_single_line_entries(fake_netrc_path: pathlib.Path):
+    fake_netrc_path.write_text(
+        textwrap.dedent("""\
+            machine test-host login user password pass
+            machine other-host login user-2 password pass-2
+        """)
+    )
+
+    wbnetrc.write_netrc_auth(host="https://test-host/", api_key="new-pass")
+
+    assert fake_netrc_path.read_text() == textwrap.dedent("""\
+            machine other-host login user-2 password pass-2
+            machine test-host
+              login user
+              password new-pass
+        """)
+
+
+def test_write_entry_with_account_field(fake_netrc_path: pathlib.Path):
+    fake_netrc_path.write_text(
+        textwrap.dedent("""\
+            machine test-host
+              login user
+              account test-account
+              password pass
+            machine other-host
+              login user-2
+              password pass-2
+        """)
+    )
+
+    wbnetrc.write_netrc_auth(host="https://test-host/", api_key="new-pass")
+
+    assert fake_netrc_path.read_text() == textwrap.dedent("""\
+            machine other-host
+              login user-2
+              password pass-2
+            machine test-host
+              login user
+              password new-pass
+        """)
+    assert netrc.netrc(fake_netrc_path).hosts.keys() == {"other-host", "test-host"}
+
+
+def test_write_keeps_default_entry(fake_netrc_path: pathlib.Path):
+    fake_netrc_path.write_text(
+        textwrap.dedent("""\
+            machine test-host
+              login user
+              account test-account
+              password pass
+            default
+              login user-2
+              password pass-2
+        """)
+    )
+
+    wbnetrc.write_netrc_auth(host="https://test-host/", api_key="new-pass")
+
+    assert fake_netrc_path.read_text() == textwrap.dedent("""\
+            default
+              login user-2
+              password pass-2
+            machine test-host
               login user
               password new-pass
         """)

--- a/wandb/sdk/lib/wbauth/wbnetrc.py
+++ b/wandb/sdk/lib/wbauth/wbnetrc.py
@@ -120,10 +120,9 @@ def _update_netrc(
     #
     # The .netrc file format allows using quotes in the same way
     # as in sh syntax; the built-in netrc library also uses shlex.
-    machine = shlex.quote(machine)
-    password = shlex.quote(password)
+    quoted_machine = shlex.quote(machine)
+    quoted_password = shlex.quote(password)
 
-    machine_line = f"machine {machine}"
     orig_lines = []
     try:
         orig_lines = path.read_text().splitlines()
@@ -138,20 +137,23 @@ def _update_netrc(
     new_lines: list[str] = []
 
     # Copy over the original lines, minus the machine section we're updating.
-    skip = 0
+    in_old_entry = False
     for line in orig_lines:
-        if machine_line in line:
-            skip = 2
-        elif skip > 0:
-            skip -= 1
-        else:
+        tokens = _split_netrc_line(line)
+
+        if tokens[:2] == ["machine", machine]:
+            in_old_entry = True
+        elif tokens and tokens[0] in ("machine", "default"):
+            in_old_entry = False
+
+        if not in_old_entry:
             new_lines.append(line)
 
     new_lines.extend(
         [
-            f"machine {machine}",
+            f"machine {quoted_machine}",
             "  login user",
-            f"  password {password}",
+            f"  password {quoted_password}",
             "",  # End with a blank line, by convention.
         ]
     )
@@ -163,6 +165,18 @@ def _update_netrc(
         # Include the original error message because the stack trace
         # will not be shown to the user.
         raise WriteNetrcError(f"Unable to write {path}: {e}") from e
+
+
+def _split_netrc_line(line: str) -> list[str]:
+    """Returns the .netrc tokens in a line.
+
+    Falls back to splitting on whitespace if the line uses quotes incorrectly,
+    since a malformed file must not prevent writing an API key.
+    """
+    try:
+        return shlex.split(line)
+    except ValueError:
+        return line.split()
 
 
 def _write_text(path: pathlib.Path, text: str) -> None:


### PR DESCRIPTION
Description
-----------

`wandb login` could delete or corrupt credentials belonging to other machines in `.netrc`.

It found the existing entry by looking for the text `machine <host>` anywhere in a line, so it also removed entries for hosts that merely share a prefix, such as `api.wandb.ai.corp.internal` when writing `api.wandb.ai`. It then skipped a fixed two lines, so an entry written on a single line, or one carrying an extra field such as `account` (there's a bunch of valid tokens actually: https://www.ibm.com/docs/bg/aix/7.2.0?topic=formats-netrc-file-format-tcpip), took part of the next entry with it.

Entries are now matched on exact tokens, and the old entry ends at the next `machine` or `default` keyword rather than after a fixed number of lines.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
