### PR TITLE
fix: stop captured log lines from adding blank lines to the run log

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -59,6 +59,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
 - `wandb login` no longer removes or corrupts credentials belonging to other machines in your `.netrc` file (@dmitryduev in https://github.com/wandb/wandb/pull/12386)
+- Log messages captured from Python loggers no longer add blank lines to a run's logs (@dmitryduev in https://github.com/wandb/wandb/pull/12387)
 
 ## Security
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -57,6 +57,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Downloading an artifact file with `skip_cache=True` now replaces a different file of the same size at the destination instead of keeping it (@dmitryduev in https://github.com/wandb/wandb/pull/12382)
 - Downloading an artifact with `skip_cache=True` no longer changes where later downloads in the same process are written (@dmitryduev in https://github.com/wandb/wandb/pull/12383)
 - `wandb login` no longer removes or corrupts credentials belonging to other machines in your `.netrc` file (@dmitryduev in https://github.com/wandb/wandb/pull/12386)
+- Log messages captured from Python loggers no longer add blank lines to a run's logs (@dmitryduev in https://github.com/wandb/wandb/pull/12387)
 
 ## Security
 

--- a/core/internal/runconsolelogs/runconsolelogs.go
+++ b/core/internal/runconsolelogs/runconsolelogs.go
@@ -218,8 +218,11 @@ func (s *Sender) StreamLoggerOutput(record *spb.OutputLoggerRecord) {
 		return
 	}
 
-	// We can discard the line reference because we never change the line.
-	_ = s.model.NextLine("", s.streamLabel, record.Line)
+	// Lines in the model must not contain '\n'.
+	for line := range strings.SplitSeq(strings.TrimSuffix(record.Line, "\n"), "\n") {
+		// We can discard the line reference because we never change the line.
+		_ = s.model.NextLine("", s.streamLabel, line)
+	}
 }
 
 // StreamLogs updates the run's captured console logs.

--- a/core/internal/runconsolelogs/runconsolelogs_test.go
+++ b/core/internal/runconsolelogs/runconsolelogs_test.go
@@ -85,6 +85,64 @@ func TestFileStreamUpdatesDisabled(t *testing.T) {
 	assert.Empty(t, request.ConsoleLines.ToRuns())
 }
 
+func TestStreamLoggerOutput(t *testing.T) {
+	outputFile, _ := paths.Relative("output.log")
+
+	for _, test := range []struct {
+		name      string
+		line      string
+		wantLines []string
+	}{
+		{
+			name:      "trailing newline",
+			line:      "line1\n",
+			wantLines: []string{"line1"},
+		},
+		{
+			name:      "embedded newlines",
+			line:      "line1\nline2\n",
+			wantLines: []string{"line1", "line2"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			filesDir := t.TempDir()
+			fileStream := filestreamtest.NewFakeFileStream()
+
+			sender := New(Params{
+				FilesDir:      filesDir,
+				EnableCapture: true,
+				Logger:        observabilitytest.NewTestLogger(t),
+				RunfilesUploaderOrNil: runfilestest.WithTestDefaults(t,
+					runfilestest.Params{},
+				),
+				FileStreamOrNil: fileStream,
+				GetNow: func() time.Time {
+					return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+				},
+			})
+
+			sender.StreamLoggerOutput(&spb.OutputLoggerRecord{Line: test.line})
+			sender.Finish()
+
+			contents, err := os.ReadFile(filepath.Join(filesDir, string(*outputFile)))
+			require.NoError(t, err)
+
+			wantContents := &strings.Builder{}
+			wantConsoleLines := []string{}
+			for _, line := range test.wantLines {
+				wantContents.WriteString(line + "\n")
+				wantConsoleLines = append(wantConsoleLines,
+					"2024-01-01T00:00:00.000000 "+line)
+			}
+
+			assert.Equal(t, wantContents.String(), string(contents))
+			assert.Equal(t,
+				[]sparselist.Run[string]{{Start: 0, Items: wantConsoleLines}},
+				fileStream.GetRequest(settings.New()).ConsoleLines.ToRuns())
+		})
+	}
+}
+
 func TestSender_Multipart_WritesChunkAndUploadsOnFinish(t *testing.T) {
 	dir := t.TempDir()
 	uploader := NewFakeUploader()


### PR DESCRIPTION
Description
-----------

Log messages captured from Python loggers (https://github.com/wandb/wandb/pull/11702) each added a blank line to the run's log file and shifted every later line number by one.

The captured text already ends in a newline, and another was added when writing it, so the file and the line counter disagreed. That offset drift also meant an in-place update of an earlier line, such as a progress bar redraw, landed on the wrong line.

Trailing newlines are now trimmed, and text containing newlines produces one line per part.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
