### PR TITLE
fix: allow deleting summary entries for metrics logged as nested values

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -60,6 +60,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
 - `wandb login` no longer removes or corrupts credentials belonging to other machines in your `.netrc` file (@dmitryduev in https://github.com/wandb/wandb/pull/12386)
 - Log messages captured from Python loggers no longer add blank lines to a run's logs (@dmitryduev in https://github.com/wandb/wandb/pull/12387)
+- `del run.summary[key]` now removes metrics that were logged as nested values, which it previously ignored (@dmitryduev in https://github.com/wandb/wandb/pull/12389)
 
 ## Security
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -59,6 +59,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` no longer removes or corrupts credentials belonging to other machines in your `.netrc` file (@dmitryduev in https://github.com/wandb/wandb/pull/12386)
 - Log messages captured from Python loggers no longer add blank lines to a run's logs (@dmitryduev in https://github.com/wandb/wandb/pull/12387)
 - Fixed a crash that could happen when several runs sharing one service process finished at the same time (@dmitryduev in https://github.com/wandb/wandb/pull/12388)
+- `del run.summary[key]` now removes metrics that were logged as nested values, which it previously ignored (@dmitryduev in https://github.com/wandb/wandb/pull/12389)
 
 ## Security
 

--- a/core/internal/runsummary/runsummary.go
+++ b/core/internal/runsummary/runsummary.go
@@ -24,13 +24,16 @@ func (rs *RunSummary) Set(path pathtree.TreePath, value any) {
 }
 
 // Remove deletes the summary for a metric.
+//
+// If the path refers to a metric logged as a nested value, the summaries
+// of all metrics under it are deleted as well.
 func (rs *RunSummary) Remove(path pathtree.TreePath) {
-	summary, ok := rs.summaries.GetLeaf(path)
-	if !ok {
+	if summary, ok := rs.summaries.GetLeaf(path); ok {
+		summary.Clear()
 		return
 	}
 
-	summary.Clear()
+	rs.summaries.Remove(path)
 }
 
 // UpdateSummaries updates metric summaries based on their new values

--- a/core/internal/runsummary/runsummary_test.go
+++ b/core/internal/runsummary/runsummary_test.go
@@ -97,6 +97,42 @@ func TestRemove(t *testing.T) {
 		string(encoded))
 }
 
+func TestRemove_NestedValue(t *testing.T) {
+	rs := runsummary.New()
+	rh := runhistory.New()
+	rh.SetFloat(pathtree.PathOf("nested", "x"), 1.5)
+	rh.SetInt(pathtree.PathOf("nested", "deeper", "y"), 2)
+	rh.SetInt(pathtree.PathOf("other"), 3)
+	_, _ = rs.UpdateSummaries(rh)
+
+	rs.Remove(pathtree.PathOf("nested"))
+
+	encoded, err := rs.Serialize()
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{"other": 3}`,
+		string(encoded))
+}
+
+func TestRemove_KeepsMetricConfiguration(t *testing.T) {
+	rs := runsummary.New()
+	rh := runhistory.New()
+	rh.SetFloat(pathtree.PathOf("x"), 1.5)
+	rs.ConfigureMetric(pathtree.PathOf("x"), false, runsummary.Latest)
+	_, _ = rs.UpdateSummaries(rh)
+
+	rs.Remove(pathtree.PathOf("x"))
+	assert.Empty(t, rs.ToNestedMaps())
+
+	_, _ = rs.UpdateSummaries(rh)
+
+	encoded, err := rs.Serialize()
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{"x": {"last": 1.5}}`,
+		string(encoded))
+}
+
 func TestNoSummary(t *testing.T) {
 	rs := runsummary.New()
 


### PR DESCRIPTION
Description
-----------

`del run.summary[key]` did nothing when the metric had been logged as a nested value. The key stayed in the summary and no error was reported.

Removal only handled a single value at the given path. A metric logged as a nested dictionary is stored as a subtree rather than a single value, so the request was dropped. Removal now handles a subtree as well.

