### PR TITLE
dduev/parquet read error not crash

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,3 +52,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` validates api keys prior to saving to the `.netrc` file (@jacobromero in https://github.com/wandb/wandb/pull/12347)
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
+- Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)

--- a/parquet-rust-wrapper/src/lib.rs
+++ b/parquet-rust-wrapper/src/lib.rs
@@ -43,6 +43,24 @@ pub unsafe extern "C" fn create_reader(
     num_columns: usize,
     out_error: *mut *mut libc::c_char,
 ) -> *mut ReaderHandle {
+    let result =
+        catch_panic(|| create_reader_impl(file_path_or_url, column_names, num_columns, out_error));
+
+    match result {
+        Ok(handle_ptr) => handle_ptr,
+        Err(e) => {
+            *out_error = error_to_c_string(&e);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+unsafe fn create_reader_impl(
+    file_path_or_url: *const libc::c_char,
+    column_names: *const *const libc::c_char,
+    num_columns: usize,
+    out_error: *mut *mut libc::c_char,
+) -> *mut ReaderHandle {
     // Convert the file path from C string to Rust string
     let file_path_cstr = unsafe { CStr::from_ptr(file_path_or_url) };
     let file_path_str = match file_path_cstr.to_str() {
@@ -225,6 +243,21 @@ pub struct StepScanResult {
 /// - Returns a buffer that must be freed by caller using free_buffer
 #[no_mangle]
 pub unsafe extern "C" fn reader_scan_step_range(
+    reader_ptr: *mut ReaderHandle,
+    min_step: i64,
+    max_step: i64,
+    out_result: *mut StepScanResult,
+) -> *const libc::c_char {
+    let result =
+        catch_panic(|| reader_scan_step_range_impl(reader_ptr, min_step, max_step, out_result));
+
+    match result {
+        Ok(error) => error,
+        Err(e) => error_to_c_string(&e),
+    }
+}
+
+unsafe fn reader_scan_step_range_impl(
     reader_ptr: *mut ReaderHandle,
     min_step: i64,
     max_step: i64,
@@ -449,6 +482,24 @@ pub unsafe extern "C" fn free_reader(reader_ptr: *mut ReaderHandle) {
     if !reader_ptr.is_null() {
         let _ = Box::from_raw(reader_ptr);
     }
+}
+
+/// Runs `f` and turns a panic raised inside it into an error message.
+///
+/// Unwinding out of an `extern "C"` function aborts the process, which would
+/// take down every run sharing the service, so each entry point must contain
+/// its own panics.
+fn catch_panic<T>(f: impl FnOnce() -> T) -> Result<T, String> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).map_err(|payload| {
+        let message = if let Some(s) = payload.downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = payload.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "unknown panic".to_string()
+        };
+        format!("panic: {}", message)
+    })
 }
 
 fn error_to_c_string(error: &str) -> *mut libc::c_char {

--- a/parquet-rust-wrapper/tests/lib_tests.rs
+++ b/parquet-rust-wrapper/tests/lib_tests.rs
@@ -1,9 +1,9 @@
-use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::array::{Int64Array, LargeStringArray, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow_rs_wrapper::*;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -687,6 +687,76 @@ fn test_reader_scan_with_int64_step_column() {
 
     unsafe {
         free_buffer(result.vec_ptr as *mut Vec<u8>);
+        free_reader(reader_ptr);
+    }
+}
+
+/// Helper function to create a test parquet file whose value column uses the
+/// 64-bit offset string type, which the serializer does not handle.
+fn create_test_parquet_file_with_large_utf8(path: &str, num_rows: usize) -> std::io::Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(STEP_COLUMN_NAME, DataType::Int64, false),
+        Field::new("name", DataType::LargeUtf8, false),
+    ]));
+
+    let file = File::create(path)?;
+    let props = WriterProperties::builder().build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    let step_values: Vec<i64> = (0..num_rows).map(|i| i as i64).collect();
+    let string_values: Vec<&str> = (0..num_rows)
+        .map(|i| if i % 2 == 0 { "even" } else { "odd" })
+        .collect();
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(step_values)),
+            Arc::new(LargeStringArray::from(string_values)),
+        ],
+    )
+    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    writer
+        .write(&batch)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    writer
+        .close()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    Ok(())
+}
+
+#[test]
+fn test_reader_scan_step_range_returns_panic_as_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test_large_utf8.parquet");
+    create_test_parquet_file_with_large_utf8(file_path.to_str().unwrap(), 100).unwrap();
+
+    let path_cstring = CString::new(file_path.to_str().unwrap()).unwrap();
+    let mut out_error: *mut libc::c_char = std::ptr::null_mut();
+    let reader_ptr = unsafe {
+        create_reader(path_cstring.as_ptr(), std::ptr::null(), 0, &mut out_error)
+    };
+    assert!(!reader_ptr.is_null());
+
+    let mut result = StepScanResult {
+        vec_ptr: 0, data_ptr: 0, data_len: 0, num_rows_returned: 0,
+    };
+
+    let error = unsafe { reader_scan_step_range(reader_ptr, 10, 20, &mut result) };
+    assert!(!error.is_null());
+
+    let error_message = unsafe { CStr::from_ptr(error) }.to_str().unwrap();
+    assert!(
+        error_message.contains("panic"),
+        "unexpected error: {}",
+        error_message
+    );
+
+    unsafe {
+        free_string(error as *mut libc::c_char);
         free_reader(reader_ptr);
     }
 }


### PR DESCRIPTION
Description
-----------

The Rust code that reads run history from parquet files is called across a C
boundary from Go. Several of its type conversions panic on column types it
explicitly matches, including large string and large binary columns and some
dictionary columns. Nothing caught those panics at the boundary, and the crate
does not abort on panic, so the unwind hit Go's no-unwind shim and aborted the
whole process. Because that process is shared, it took down data uploads for
every active run in the program, not just the caller's.

The two entry points now catch a panic and return it through the error path
they already use for ordinary failures, which the Go side parses. Handling the
column types properly is separate work; this change only makes the boundary
safe.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test that scans a parquet file with a large string column, which hits
one of the panicking conversions, and asserts the call returns an error string.

Confirmed it fails without the fix, and instructively so: the test binary died
with `thread caused non-unwinding panic. aborting` and SIGABRT, taking the other
11 tests in that binary with it. That is the production symptom.

`cargo build` and `cargo test` pass (41 tests across all targets).
