### PR TITLE
fix(artifacts): report the error instead of hanging when a large download cannot be written to disk

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -53,3 +53,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)
+- Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import functools
 import queue
 import shutil
+import threading
+import time
 import unittest.mock as mock
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -738,3 +740,86 @@ def test_artifact_multipart_download_writer_not_on_shared_executor():
         future.result(timeout=5)
     except TimeoutError:
         fail("multipart_download deadlocked: writer likely sharing the chunk executor")
+
+
+class OneSlotChunkQueue(queue.Queue):
+    """Chunk queue with a single slot that tracks producers waiting on it."""
+
+    def __init__(self) -> None:
+        super().__init__(maxsize=1)
+        self._producers = 0
+        self._producers_lock = threading.Lock()
+
+    def put(self, item, block=True, timeout=None):
+        with self._producers_lock:
+            self._producers += 1
+        try:
+            super().put(item, block, timeout)
+        finally:
+            with self._producers_lock:
+                self._producers -= 1
+
+    @property
+    def producers(self) -> int:
+        with self._producers_lock:
+            return self._producers
+
+    def has_waiting_producer(self) -> bool:
+        return self.full() and (self.producers > 0)
+
+    def release_producers(self) -> None:
+        """Make room until no producer is left waiting, so their threads finish."""
+        while self.producers:
+            try:
+                self.get_nowait()
+            except queue.Empty:
+                pass
+            time.sleep(0.01)
+
+
+@responses.activate()
+def test_artifact_multipart_download_disk_error_with_full_queue(
+    monkeypatch: MonkeyPatch,
+):
+    # If the writer dies while the queue is full, the chunk downloaders that are
+    # handing off chunks must notice and stop, so the write error is raised
+    # instead of the download blocking forever.
+    responses.get("https://s3.com/file", body=b"test", status=200)
+
+    chunk_queue = OneSlotChunkQueue()
+    monkeypatch.setattr(
+        "wandb.sdk.artifacts.storage_policies._multipart.Queue",
+        lambda maxsize: chunk_queue,
+    )
+
+    def write_once_queue_is_full(data):
+        deadline = time.monotonic() + 10
+        while not chunk_queue.has_waiting_producer():
+            assert time.monotonic() < deadline, "no downloader waited on the queue"
+            time.sleep(0.01)
+        raise OSError("No space left on device")
+
+    opener = mock.mock_open()
+    opener.return_value.write.side_effect = write_once_queue_is_full
+
+    def run_download():
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            multipart_download(
+                executor,
+                requests.Session(),
+                500 * 1024 * 1024,  # 500MB should have 5 parts
+                opener,
+                initial_url="https://s3.com/file",
+                fetch_fn=lambda: "https://s3.com/file",
+            )
+
+    future = ThreadPoolExecutor(max_workers=1).submit(run_download)
+    try:
+        # Add a timeout to the future to avoid hanging the test.
+        error = future.exception(timeout=15)
+    except TimeoutError:
+        fail("multipart_download hung: chunk downloaders stuck on a full queue")
+    finally:
+        chunk_queue.release_producers()
+
+    assert isinstance(error, OSError)

--- a/wandb/sdk/artifacts/storage_policies/_multipart.py
+++ b/wandb/sdk/artifacts/storage_policies/_multipart.py
@@ -45,6 +45,10 @@ MULTI_DEFAULT_PART_SIZE = 100 * MiB
 # Chunk size for reading http response and writing to disk.
 RSP_CHUNK_SIZE = 1 * MiB
 
+# How long a download thread waits for room on the chunk queue before it
+# rechecks whether the download was cancelled.
+QUEUE_PUT_TIMEOUT = 0.5
+
 
 @final
 class _ChunkSentinel:
@@ -177,15 +181,24 @@ def _download_chunk_with_refresh(
             return True
         return False
 
+    def queue_chunk(content: ChunkContent) -> bool:
+        """Hand a chunk to the writer, returning False if the download was cancelled."""
+        while not ctx.cancel.is_set():
+            try:
+                ctx.q.put(content, timeout=QUEUE_PUT_TIMEOUT)
+            except Full:
+                continue
+            return True
+        return False
+
     def attempt_download() -> None:
         with ctx.session.get(url=ctx.get_url(), headers=headers, stream=True) as rsp:
             rsp.raise_for_status()
 
             offset = start
             for chunk in rsp.iter_content(chunk_size=RSP_CHUNK_SIZE):
-                if ctx.cancel.is_set():
+                if not queue_chunk(ChunkContent(offset=offset, data=chunk)):
                     return
-                ctx.q.put(ChunkContent(offset=offset, data=chunk))
                 offset += len(chunk)
 
     # Use common retry logic with exponential backoff


### PR DESCRIPTION
Description
-----------

Downloading an artifact file of about 2 GiB or more splits the work between
several download threads and one writer thread. The download threads put chunks
on a queue that holds 500 of them, using a blocking put that only checked the
cancel flag before waiting.

If the writer died partway through, from a full disk, a quota, or an I/O error,
the queue stayed full and every download thread waited on it forever. The
futures never completed, so the download never returned and never reported the
write error. A training job pulling a checkpoint would sit there burning GPU
hours.

Chunks are now offered with a short timeout in a loop that re-checks the cancel
flag, so a dead writer lets the download threads exit and the real error
surfaces.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test with a small queue and a writer that raises, asserting the failure
surfaces as an error rather than hanging, bounded by a timeout so a regression
fails instead of hanging the suite.

Confirmed it fails without the fix: the test times out after 15s with `chunk
downloaders stuck on a full queue`. Passed 10/10 runs under flake-finder.
`tests/unit_tests/test_artifacts` passes (209).
