### PR TITLE
fix(sdk): keep reporting network status for the whole run

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -54,3 +54,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)
 - Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)
+- Network problems are now reported for the whole run, rather than only for the first few seconds (@dmitryduev in https://github.com/wandb/wandb/pull/12396)

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -468,23 +468,22 @@ func (s *Sender) sendRequestNetworkStatus(
 	_ *spb.NetworkStatusRequest,
 	request *runwork.Request,
 ) {
-	// in case of network peeker is not set, we don't need to do anything
-	if s.networkPeeker == nil {
-		return
+	// The client polls with one outstanding request at a time, so it must
+	// always get a response, even if there is nothing to report.
+	var responses []*spb.HttpResponse
+	if s.networkPeeker != nil {
+		responses = s.networkPeeker.Read()
 	}
 
-	// send the network status response if there is any
-	if response := s.networkPeeker.Read(); len(response) > 0 {
-		s.respond(request,
-			&spb.Response{
-				ResponseType: &spb.Response_NetworkStatusResponse{
-					NetworkStatusResponse: &spb.NetworkStatusResponse{
-						NetworkResponses: response,
-					},
+	s.respond(request,
+		&spb.Response{
+			ResponseType: &spb.Response_NetworkStatusResponse{
+				NetworkStatusResponse: &spb.NetworkStatusResponse{
+					NetworkResponses: responses,
 				},
 			},
-		)
-	}
+		},
+	)
 }
 
 func (s *Sender) sendJobFlush() {

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -3,6 +3,7 @@ package stream_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,15 @@ type testFixtures struct {
 }
 
 func makeSender(t *testing.T, client graphql.Client) testFixtures {
+	t.Helper()
+	return makeSenderWithPeeker(t, client, nil)
+}
+
+func makeSenderWithPeeker(
+	t *testing.T,
+	client graphql.Client,
+	peeker *observability.Peeker,
+) testFixtures {
 	t.Helper()
 	runWork := runworktest.New()
 	logger := observabilitytest.NewTestLogger(t)
@@ -81,6 +91,7 @@ func makeSender(t *testing.T, client graphql.Client) testFixtures {
 		GraphqlClient:           client,
 		FeatureProvider:         featurechecker.New(nil, logger),
 		RunHandle:               runHandle,
+		Peeker:                  peeker,
 	}
 	return testFixtures{
 		Sender:    senderFactory.New(runWork),
@@ -246,6 +257,47 @@ func TestSendUseArtifact(t *testing.T) {
 		},
 	}
 	x.Sender.SendRecord(useArtifact, nil)
+}
+
+func TestSendRequestNetworkStatus(t *testing.T) {
+	testCases := []struct {
+		name   string
+		peeker *observability.Peeker
+	}{
+		{"peeker is not set", nil},
+		{"peeker has no buffered responses", &observability.Peeker{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			x := makeSenderWithPeeker(t, gqlmock.NewMockClient(), tc.peeker)
+			networkStatus := &spb.Record{
+				RecordType: &spb.Record_Request{
+					Request: &spb.Request{
+						RequestType: &spb.Request_NetworkStatus{
+							NetworkStatus: &spb.NetworkStatusRequest{},
+						},
+					},
+				},
+				Control: &spb.Control{
+					MailboxSlot: "junk",
+				},
+			}
+
+			request, outputs := runworktest.SimpleRequest(t, "test-id")
+			x.Sender.SendRecord(networkStatus, request)
+
+			select {
+			case response := <-outputs:
+				assert.NotNil(t,
+					response.GetResultCommunicate().
+						GetResponse().
+						GetNetworkStatusResponse())
+			case <-time.After(5 * time.Second):
+				t.Error("timed out waiting for a response")
+			}
+		})
+	}
 }
 
 var validFetchOrgEntityFromEntityResponse = `{


### PR DESCRIPTION
Description
-----------

Network status was reported for only the first few seconds of a run.

The handler returned without answering when there was nothing buffered to
report, which is the normal case for the first poll of a healthy run. The
polling side reuses one request and gives up when a poll goes unanswered, so it
stopped after that first empty reply and never resumed.

The handler now always answers, with an empty list when there is nothing to
report.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added tests asserting a response is sent when nothing is buffered and when the
component that records traffic is absent.

Confirmed they fail without the fix. `go test -race ./internal/stream/...`
passes.
