### PR TITLE
fix(sdk): stop run.finish() from hanging when system metrics collection stops responding

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -55,3 +55,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)
 - Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)
 - Network problems are now reported for the whole run, rather than only for the first few seconds (@dmitryduev in https://github.com/wandb/wandb/pull/12396)
+- `run.finish()` no longer waits forever when system metrics collection stops responding (@dmitryduev in https://github.com/wandb/wandb/pull/12397)

--- a/core/internal/monitor/xpu.go
+++ b/core/internal/monitor/xpu.go
@@ -2,9 +2,14 @@ package monitor
 
 import (
 	"context"
+	"time"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+// xpuSampleTimeout bounds a single stats request to the wandb-xpu sidecar,
+// which can stop responding while blocked in a device query.
+const xpuSampleTimeout = 30 * time.Second
 
 // XPU monitors GPUs (Nvidia, AMD, Apple) and Google TPUs via the
 // wandb-xpu sidecar binary.
@@ -15,6 +20,9 @@ type XPU struct {
 	pid          int32
 	gpuDeviceIds []int32
 	client       spb.SystemMonitorServiceClient
+
+	// sampleTimeout is how long to wait for one Sample to complete.
+	sampleTimeout time.Duration
 }
 
 func NewXPU(
@@ -32,12 +40,16 @@ func NewXPU(
 		pid:             pid,
 		gpuDeviceIds:    gpuDeviceIds,
 		client:          client,
+		sampleTimeout:   xpuSampleTimeout,
 	}, nil
 }
 
 func (a *XPU) Sample() (*spb.StatsRecord, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), a.sampleTimeout)
+	defer cancel()
+
 	stats, err := a.client.GetStats(
-		context.Background(),
+		ctx,
 		&spb.GetStatsRequest{Pid: a.pid, GpuDeviceIds: a.gpuDeviceIds},
 	)
 	if err != nil {

--- a/core/internal/monitor/xpu_test.go
+++ b/core/internal/monitor/xpu_test.go
@@ -1,0 +1,51 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// unresponsiveClient mimics a sidecar that is wedged in a device query and
+// never answers, like a real gRPC client returning only once the caller's
+// context is done.
+type unresponsiveClient struct {
+	spb.SystemMonitorServiceClient
+}
+
+func (c *unresponsiveClient) GetStats(
+	ctx context.Context,
+	_ *spb.GetStatsRequest,
+	_ ...grpc.CallOption,
+) (*spb.GetStatsResponse, error) {
+	<-ctx.Done()
+	return nil, status.FromContextError(ctx.Err()).Err()
+}
+
+func TestXPUSampleUnresponsiveSidecar(t *testing.T) {
+	xpu := &XPU{
+		client:        &unresponsiveClient{},
+		sampleTimeout: 50 * time.Millisecond,
+	}
+
+	sampled := make(chan error, 1)
+	go func() {
+		_, err := xpu.Sample()
+		sampled <- err
+	}()
+
+	select {
+	case err := <-sampled:
+		require.Error(t, err)
+		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	case <-time.After(10 * time.Second):
+		t.Fatal("Sample did not return while the sidecar was unresponsive")
+	}
+}


### PR DESCRIPTION
Description
-----------

System metrics are collected by a helper process. The call asking it for a
sample had no deadline and the connection has no keepalive, so if the helper
wedged, for example inside a driver call against a hung GPU, the sampling
goroutine waited forever and `run.finish()` never returned. The existing finish
timeout does not help, because it is applied later in the shutdown sequence.

A sample call is now bounded by a deadline, and a timed-out sample is treated
like any other sampling error: it is logged, that tick is skipped, and sampling
continues.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test with a stub helper that never answers, asserting the call returns a
deadline error rather than blocking, bounded so a regression fails fast.

Confirmed it fails without the fix, hanging until the test's own 10s bound.
`go test -race ./internal/monitor/...` passes.
