### PR TITLE
fix(sdk): correct a memory error when collecting NVIDIA DCGM metrics

### DIFF
--- a/xpu/src/gpu_nvidia_dcgm.rs
+++ b/xpu/src/gpu_nvidia_dcgm.rs
@@ -88,7 +88,7 @@ const DCGM_FI_PROF_NVLINK_RX_BYTES: u16 = 1012;
 
 /// DCGM Group IDs.
 /// Represents all GPUs discovered on the node.
-const DCGM_GROUP_ALL_GPUS: u32 = 0x7fffffff;
+const DCGM_GROUP_ALL_GPUS: DcgmGpuGrpT = 0x7fffffff;
 
 // --- Type Aliases for FFI Clarity ---
 
@@ -96,10 +96,10 @@ const DCGM_GROUP_ALL_GPUS: u32 = 0x7fffffff;
 type DcgmReturnT = i32;
 /// Alias for the `dcgmHandle_t` C type (`void*`). Represents the connection handle to DCGM.
 type DcgmHandleT = *mut c_void;
-/// Alias for the `dcgmGpuGrp_t` C type (typically `unsigned int`). Represents a DCGM GPU group ID.
-type DcgmGpuGrpT = u32;
-/// Alias for the `dcgmFieldGrp_t` C type (typically `unsigned int`). Represents a DCGM field group ID.
-type DcgmFieldGrpT = u32;
+/// Alias for the `dcgmGpuGrp_t` C type (`uintptr_t`). Represents a DCGM GPU group ID.
+type DcgmGpuGrpT = usize;
+/// Alias for the `dcgmFieldGrp_t` C type (`uintptr_t`). Represents a DCGM field group ID.
+type DcgmFieldGrpT = usize;
 /// Alias for the `dcgmFieldEntityGroup_t` C type (typically `unsigned int`). Represents the entity type (GPU, VGPU, etc.).
 type DcgmFieldEntityGroupT = u32;
 /// Alias for the `dcgmFieldEid_t` C type (typically `unsigned int`). Represents the entity ID within its group.
@@ -1133,8 +1133,8 @@ extern "C" fn field_value_callback(
 /// collecting metrics).
 struct DcgmWorker {
     dcgm: Box<dyn DcgmLibrary>,
-    group_id: u32,
-    field_group_id: u32,
+    group_id: DcgmGpuGrpT,
+    field_group_id: DcgmFieldGrpT,
     receiver: mpsc::Receiver<DcgmCommand>,
 }
 
@@ -1145,8 +1145,8 @@ impl DcgmWorker {
     /// Takes ownership of the [`DcgmLib`] instance and the MPSC receiver.
     fn new(
         dcgm: Box<dyn DcgmLibrary>,
-        group_id: u32,
-        field_group_id: u32,
+        group_id: DcgmGpuGrpT,
+        field_group_id: DcgmFieldGrpT,
         receiver: mpsc::Receiver<DcgmCommand>,
     ) -> Self {
         DcgmWorker {
@@ -1324,6 +1324,19 @@ mod tests {
     }
 
     // --- Test Cases ---
+
+    #[test]
+    fn test_group_handle_aliases_are_pointer_sized() {
+        // dcgm_structs.h declares both handles as `uintptr_t`.
+        assert_eq!(
+            std::mem::size_of::<DcgmGpuGrpT>(),
+            std::mem::size_of::<usize>()
+        );
+        assert_eq!(
+            std::mem::size_of::<DcgmFieldGrpT>(),
+            std::mem::size_of::<usize>()
+        );
+    }
 
     #[test]
     fn test_worker_collect_metrics_success() {


### PR DESCRIPTION
Description
-----------

Two handle types in the NVIDIA DCGM bindings were declared as 32-bit integers,
but the DCGM headers define them as pointer-sized. On the 64-bit Linux targets
this code builds for, the library writes 8 bytes through a 4-byte slot when
creating a field group, which overwrites 4 bytes of adjacent stack.

It works today only because the extra bytes land in padding and the handles are
small numbers. A change in how the compiler lays out those locals would turn it
into real corruption. Both types are now pointer-sized, matching the headers.

This is behind the `WANDB_ENABLE_DCGM_PROFILING` setting, on Linux, with DCGM
installed, so no user is expected to have seen a symptom.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable
(Not applicable: no user-visible behavior change.)

Testing
-------

Added a test asserting both types are the size of a pointer, so changing them
back to a fixed width fails the build's test step.

`cargo build`, `cargo test`, and `cargo clippy` pass. No changelog entry: there
is no behavior a user could have observed.
