### PR TITLE
fix(sdk): stop creating many wandb.Api() objects from leaking memory and background requests

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -56,3 +56,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)
 - Network problems are now reported for the whole run, rather than only for the first few seconds (@dmitryduev in https://github.com/wandb/wandb/pull/12396)
 - `run.finish()` no longer waits forever when system metrics collection stops responding (@dmitryduev in https://github.com/wandb/wandb/pull/12397)
+- Creating many `wandb.Api()` objects in one program no longer leaks memory and background network requests for the lifetime of the program (@dmitryduev in https://github.com/wandb/wandb/pull/12399)

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -91,6 +91,12 @@ func (op *RunSyncOperation) Do(
 	parallelism int,
 ) *spb.ServerSyncResponse {
 	defer func() {
+		if op.telemetryProxy != nil {
+			if err := op.telemetryProxy.Shutdown(ctx); err != nil {
+				slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
+			}
+		}
+
 		op.logFile.Close()
 		op.printer.Close()
 	}()
@@ -123,12 +129,6 @@ func (op *RunSyncOperation) Do(
 	}
 
 	_ = group.Wait()
-
-	if op.telemetryProxy != nil {
-		if err := op.telemetryProxy.Shutdown(ctx); err != nil {
-			slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
-		}
-	}
 
 	return &spb.ServerSyncResponse{
 		Messages: op.popMessages(),

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/url"
+	"slices"
 	"sync"
 	"time"
 
@@ -34,6 +36,10 @@ import (
 const (
 	messageSize    = 1024 * 1024            // 1MB message size
 	maxMessageSize = 2 * 1024 * 1024 * 1024 // 2GB max message size
+
+	// telemetryShutdownTimeout limits the final telemetry flush, which
+	// performs an HTTP request.
+	telemetryShutdownTimeout = 2 * time.Second
 )
 
 type ConnectionParams struct {
@@ -109,6 +115,15 @@ type Connection struct {
 
 	// apiManager processes API requests.
 	apiManager *wbapi.WandbAPIManager
+
+	// apiTelemetryMu guards apiTelemetryProxies.
+	apiTelemetryMu sync.Mutex
+
+	// apiTelemetryProxies maps API instance IDs to their telemetry proxies.
+	//
+	// Each proxy runs background goroutines and holds an HTTP client until
+	// it is shut down.
+	apiTelemetryProxies map[string]*analytics.OpenTelemetryProxy
 }
 
 func NewConnection(
@@ -134,6 +149,8 @@ func NewConnection(
 		loggerPath:         params.LoggerPath,
 		logLevel:           params.LogLevel,
 		apiManager:         wbapi.NewManager(),
+
+		apiTelemetryProxies: make(map[string]*analytics.OpenTelemetryProxy),
 	}
 }
 
@@ -161,6 +178,11 @@ func (nc *Connection) ManageConnectionData() {
 	nc.Close()
 
 	wg.Wait()
+
+	// Shut down telemetry for API instances the client never cleaned up.
+	for _, proxy := range nc.popAllAPITelemetryProxies() {
+		shutdownTelemetryProxyInBackground(proxy)
+	}
 
 	slog.Info("connection: ManageConnectionData: connection closed", "id", nc.id)
 }
@@ -679,25 +701,6 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	s := settings.From(request.GetSettings())
 
 	telemetryProxy := analytics.NewOpenTelemetryProxy(context.Background(), s)
-	go func() {
-		<-nc.connLifetimeCtx.Done()
-		if telemetryProxy != nil {
-			shutdownCtx, cancel := context.WithTimeout(
-				context.Background(),
-				2*time.Second,
-			)
-			defer cancel()
-
-			err := telemetryProxy.Shutdown(shutdownCtx)
-			if err != nil {
-				slog.Error(
-					"connection: failed to shut down telemetry proxy",
-					"error",
-					err,
-				)
-			}
-		}
-	}()
 
 	logger := observability.NewCoreLogger(
 		slog.Default(),
@@ -709,6 +712,8 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	)
 	wbapiInstance, err := wbapi.New(s, logger)
 	if err != nil {
+		shutdownTelemetryProxyInBackground(telemetryProxy)
+
 		nc.Respond(&spb.ServerResponse{
 			RequestId: id,
 			ServerResponseType: &spb.ServerResponse_ErrorResponse{
@@ -722,6 +727,7 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	}
 
 	wbApiId := nc.apiManager.AddWandbAPI(wbapiInstance)
+	nc.addAPITelemetryProxy(wbApiId, telemetryProxy)
 
 	nc.Respond(&spb.ServerResponse{
 		RequestId: id,
@@ -736,6 +742,67 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 // handleApiCleanup cleans up a wandbAPI instance related to the provided id.
 func (nc *Connection) handleApiCleanup(id string, request *spb.ServerApiCleanupRequest) {
 	nc.apiManager.RemoveWandbAPI(request.GetApiId())
+
+	proxy := nc.popAPITelemetryProxy(request.GetApiId())
+	shutdownTelemetryProxyInBackground(proxy)
+}
+
+// addAPITelemetryProxy associates a telemetry proxy with an API instance.
+func (nc *Connection) addAPITelemetryProxy(
+	apiID string,
+	proxy *analytics.OpenTelemetryProxy,
+) {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+
+	nc.apiTelemetryProxies[apiID] = proxy
+}
+
+// popAPITelemetryProxy forgets and returns the telemetry proxy for an API
+// instance, or nil if there is none.
+func (nc *Connection) popAPITelemetryProxy(
+	apiID string,
+) *analytics.OpenTelemetryProxy {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+
+	proxy := nc.apiTelemetryProxies[apiID]
+	delete(nc.apiTelemetryProxies, apiID)
+	return proxy
+}
+
+// popAllAPITelemetryProxies forgets and returns all remaining telemetry
+// proxies.
+func (nc *Connection) popAllAPITelemetryProxies() []*analytics.OpenTelemetryProxy {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+
+	proxies := slices.Collect(maps.Values(nc.apiTelemetryProxies))
+	clear(nc.apiTelemetryProxies)
+	return proxies
+}
+
+// shutdownTelemetryProxyInBackground flushes and shuts down a telemetry proxy
+// without blocking the caller, which runs on the request dispatch path.
+func shutdownTelemetryProxyInBackground(proxy *analytics.OpenTelemetryProxy) {
+	if proxy == nil {
+		return
+	}
+
+	go func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			telemetryShutdownTimeout,
+		)
+		defer cancel()
+
+		if err := proxy.Shutdown(ctx); err != nil {
+			slog.Error(
+				"connection: failed to shut down telemetry proxy",
+				"error", err,
+			)
+		}
+	}()
 }
 
 func (nc *Connection) handleApi(

--- a/core/pkg/server/connection_api_test.go
+++ b/core/pkg/server/connection_api_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// telemetryExportInterval is how often a telemetry proxy exports metrics.
+const telemetryExportInterval = 500 * time.Millisecond
+
+func apiTelemetryProxyCount(nc *Connection) int {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+	return len(nc.apiTelemetryProxies)
+}
+
+func TestHandleApiCleanupShutsDownTelemetry(t *testing.T) {
+	var exports atomic.Int64
+	backend := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			exports.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+	t.Cleanup(backend.Close)
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	nc := NewConnection(
+		context.Background(),
+		func() {},
+		ConnectionParams{
+			ID:   "test",
+			Conn: serverConn,
+		},
+	)
+
+	nc.handleApiInit("init", &spb.ServerApiInitRequest{
+		Settings: &spb.Settings{
+			BaseUrl: wrapperspb.String(backend.URL),
+			ApiKey:  wrapperspb.String("test-api-key"),
+		},
+	})
+
+	apiID := (<-nc.outChan).GetApiInitResponse().GetApiId()
+	require.NotEmpty(t, apiID, "expected an API instance to be created")
+	require.Equal(t, 1, apiTelemetryProxyCount(nc))
+	require.Eventually(t,
+		func() bool { return exports.Load() > 0 },
+		10*time.Second, 10*time.Millisecond,
+		"expected the telemetry proxy to export to the backend")
+
+	nc.handleApiCleanup("cleanup", &spb.ServerApiCleanupRequest{ApiId: apiID})
+
+	assert.Zero(t, apiTelemetryProxyCount(nc))
+	assert.Eventually(t,
+		func() bool {
+			before := exports.Load()
+			time.Sleep(3 * telemetryExportInterval)
+			return exports.Load() == before
+		},
+		15*time.Second, telemetryExportInterval,
+		"expected telemetry exports to stop after cleanup")
+}


### PR DESCRIPTION
Description
-----------

Each `wandb.Api()` sets up a telemetry exporter that was never shut down when
the API object was cleaned up. It leaked about three goroutines, a repeating
timer, and an HTTP client, held until the whole client connection closed. A
program that creates many API objects accumulated them for its lifetime.

The exporters are now tracked and shut down on cleanup, and anything still
open is drained once when the connection ends. Shutdown runs on its own
goroutine with a short timeout, because it flushes over the network and the
cleanup path dispatches requests.

The sync path had the same gap on one error path, fixed by moving its shutdown
into the cleanup that already runs.

Out of scope, and worth a follow-up: sync operations that are prepared but never
run are still kept, which needs its own expiry design.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test that points the exporter at a server counting requests, runs init,
asserts the count climbs, runs cleanup, then asserts the tracking map is empty.
The map assertion is the primary one so the test does not depend on timing.

Confirmed it fails without the fix. `go test -race ./pkg/server/...
./internal/runsync/...` passes.
