### PR TITLE
fix(sdk): close the run data file when it cannot be reopened for reading

### DIFF
--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -35,6 +35,12 @@ const (
 	printerBufferSize = 128
 )
 
+// Transaction log constructors, overridden in tests.
+var (
+	openTransactionLogWriter = transactionlog.OpenWriter
+	openTransactionLogReader = transactionlog.OpenReader
+)
+
 // Stream processes incoming records for a single run.
 //
 // wandb consists of a service process (this code) to which one or more
@@ -190,14 +196,14 @@ func (s *Stream) maybeSavingToTransactionLog(
 		return work
 	}
 
-	w, err := transactionlog.OpenWriter(s.settings.GetTransactionLogPath())
+	w, err := openTransactionLogWriter(s.settings.GetTransactionLogPath())
 	if err != nil {
 		s.logger.Error(fmt.Sprintf(
 			"stream: error opening transaction log for writing: %v", err))
 		return work
 	}
 
-	r, err := transactionlog.OpenReader(
+	r, err := openTransactionLogReader(
 		s.settings.GetTransactionLogPath(),
 		s.logger,
 	)
@@ -211,6 +217,12 @@ func (s *Stream) maybeSavingToTransactionLog(
 				err,
 			),
 		)
+
+		if err := w.Close(); err != nil {
+			s.logger.Error(fmt.Sprintf(
+				"stream: error closing transaction log: %v", err))
+		}
+
 		return work
 	}
 

--- a/core/internal/stream/stream_test.go
+++ b/core/internal/stream/stream_test.go
@@ -1,0 +1,52 @@
+package stream
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
+	"github.com/wandb/wandb/core/internal/runwork"
+	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/transactionlog"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestTransactionLog_ReaderFails_ClosesWriter(t *testing.T) {
+	realOpenWriter := openTransactionLogWriter
+	t.Cleanup(func() {
+		openTransactionLogWriter = realOpenWriter
+		openTransactionLogReader = transactionlog.OpenReader
+	})
+
+	var logWriter *transactionlog.Writer
+	openTransactionLogWriter = func(path string) (*transactionlog.Writer, error) {
+		w, err := realOpenWriter(path)
+		logWriter = w
+		return w, err
+	}
+	openTransactionLogReader = func(
+		path string,
+		logger *observability.CoreLogger,
+	) (*transactionlog.Reader, error) {
+		return nil, errors.New("test error")
+	}
+
+	stream := &Stream{
+		settings: settings.From(&spb.Settings{
+			SyncFile: wrapperspb.String(
+				filepath.Join(t.TempDir(), "test.wandb")),
+		}),
+		logger: observabilitytest.NewTestLogger(t),
+	}
+
+	_ = stream.maybeSavingToTransactionLog(make(chan runwork.Work))
+
+	require.NotNil(t, logWriter)
+	assert.ErrorContains(t, logWriter.Close(), "already closed")
+}


### PR DESCRIPTION
Description
-----------

When the run data file is created for writing but then cannot be reopened for
reading, the write handle was dropped without being closed, so the descriptor
stayed open until the garbage collector reclaimed it. The situation that
triggers this is usually running out of descriptors, so the leak made that
pressure slightly worse.

Continuing without a run data file here is deliberate and unchanged; this only
adds the missing close.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable
(Not applicable: no user-visible behavior change.)

Testing
-------

Added a test that forces the reopen failure and asserts the write handle is
closed.

Confirmed it fails without the fix. `go test -race ./internal/stream/...`
passes. No changelog entry: the leak is bounded by the process and has no
symptom a user would notice.
