### PR TITLE
fix(sdk): support negative indexes and open-ended slices when paging through API results

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -57,3 +57,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Network problems are now reported for the whole run, rather than only for the first few seconds (@dmitryduev in https://github.com/wandb/wandb/pull/12396)
 - `run.finish()` no longer waits forever when system metrics collection stops responding (@dmitryduev in https://github.com/wandb/wandb/pull/12397)
 - Creating many `wandb.Api()` objects in one program no longer leaks memory and background network requests for the lifetime of the program (@dmitryduev in https://github.com/wandb/wandb/pull/12399)
+- Your timeout and retry settings now apply when reading a run's history, which previously used neither (@dmitryduev in https://github.com/wandb/wandb/pull/12401)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -54,3 +54,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)
 - Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)
+- Network problems are now reported for the whole run, rather than only for the first few seconds (@dmitryduev in https://github.com/wandb/wandb/pull/12396)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -56,3 +56,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)
 - Network problems are now reported for the whole run, rather than only for the first few seconds (@dmitryduev in https://github.com/wandb/wandb/pull/12396)
 - `run.finish()` no longer waits forever when system metrics collection stops responding (@dmitryduev in https://github.com/wandb/wandb/pull/12397)
+- Creating many `wandb.Api()` objects in one program no longer leaks memory and background network requests for the lifetime of the program (@dmitryduev in https://github.com/wandb/wandb/pull/12399)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -55,3 +55,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)
 - Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)
 - Network problems are now reported for the whole run, rather than only for the first few seconds (@dmitryduev in https://github.com/wandb/wandb/pull/12396)
+- `run.finish()` no longer waits forever when system metrics collection stops responding (@dmitryduev in https://github.com/wandb/wandb/pull/12397)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -53,3 +53,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)
+- Downloading a large artifact file now reports the error when it cannot be written to disk, such as when the disk is full, instead of waiting forever (@dmitryduev in https://github.com/wandb/wandb/pull/12395)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,3 +52,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` validates api keys prior to saving to the `.netrc` file (@jacobromero in https://github.com/wandb/wandb/pull/12347)
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
+- Reading a run's history now reports an error when the data cannot be read, instead of stopping the background process that uploads data for every active run in the program (@dmitryduev in https://github.com/wandb/wandb/pull/12394)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -58,3 +58,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `run.finish()` no longer waits forever when system metrics collection stops responding (@dmitryduev in https://github.com/wandb/wandb/pull/12397)
 - Creating many `wandb.Api()` objects in one program no longer leaks memory and background network requests for the lifetime of the program (@dmitryduev in https://github.com/wandb/wandb/pull/12399)
 - Your timeout and retry settings now apply when reading a run's history, which previously used neither (@dmitryduev in https://github.com/wandb/wandb/pull/12401)
+- Negative indexes and open-ended slices now return the right results when paging through API results such as `runs`, `files`, and `artifacts`, instead of raising `IndexError` or returning the wrong item (@dmitryduev in https://github.com/wandb/wandb/pull/12402)

--- a/core/internal/monitor/xpu.go
+++ b/core/internal/monitor/xpu.go
@@ -2,9 +2,14 @@ package monitor
 
 import (
 	"context"
+	"time"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+// xpuSampleTimeout bounds a single stats request to the wandb-xpu sidecar,
+// which can stop responding while blocked in a device query.
+const xpuSampleTimeout = 30 * time.Second
 
 // XPU monitors GPUs (Nvidia, AMD, Apple) and Google TPUs via the
 // wandb-xpu sidecar binary.
@@ -15,6 +20,9 @@ type XPU struct {
 	pid          int32
 	gpuDeviceIds []int32
 	client       spb.SystemMonitorServiceClient
+
+	// sampleTimeout is how long to wait for one Sample to complete.
+	sampleTimeout time.Duration
 }
 
 func NewXPU(
@@ -32,12 +40,16 @@ func NewXPU(
 		pid:             pid,
 		gpuDeviceIds:    gpuDeviceIds,
 		client:          client,
+		sampleTimeout:   xpuSampleTimeout,
 	}, nil
 }
 
 func (a *XPU) Sample() (*spb.StatsRecord, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), a.sampleTimeout)
+	defer cancel()
+
 	stats, err := a.client.GetStats(
-		context.Background(),
+		ctx,
 		&spb.GetStatsRequest{Pid: a.pid, GpuDeviceIds: a.gpuDeviceIds},
 	)
 	if err != nil {

--- a/core/internal/monitor/xpu_test.go
+++ b/core/internal/monitor/xpu_test.go
@@ -1,0 +1,51 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// unresponsiveClient mimics a sidecar that is wedged in a device query and
+// never answers, like a real gRPC client returning only once the caller's
+// context is done.
+type unresponsiveClient struct {
+	spb.SystemMonitorServiceClient
+}
+
+func (c *unresponsiveClient) GetStats(
+	ctx context.Context,
+	_ *spb.GetStatsRequest,
+	_ ...grpc.CallOption,
+) (*spb.GetStatsResponse, error) {
+	<-ctx.Done()
+	return nil, status.FromContextError(ctx.Err()).Err()
+}
+
+func TestXPUSampleUnresponsiveSidecar(t *testing.T) {
+	xpu := &XPU{
+		client:        &unresponsiveClient{},
+		sampleTimeout: 50 * time.Millisecond,
+	}
+
+	sampled := make(chan error, 1)
+	go func() {
+		_, err := xpu.Sample()
+		sampled <- err
+	}()
+
+	select {
+	case err := <-sampled:
+		require.Error(t, err)
+		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	case <-time.After(10 * time.Second):
+		t.Fatal("Sample did not return while the sidecar was unresponsive")
+	}
+}

--- a/core/internal/runhistoryreader/parquet/downloader.go
+++ b/core/internal/runhistoryreader/parquet/downloader.go
@@ -128,7 +128,7 @@ func extractStepValuesFromLiveData(liveData []any) ([]int64, error) {
 func GetFileSize(
 	ctx context.Context,
 	fileUrl string,
-	httpClient *retryablehttp.Client,
+	httpClient api.RetryableClient,
 ) (int64, error) {
 	req, err := retryablehttp.NewRequestWithContext(
 		ctx,
@@ -167,7 +167,7 @@ type RunHistoryDownloadOperation struct {
 	downloadDir string
 
 	// httpClient is the HTTP client to use for the download.
-	httpClient *retryablehttp.Client
+	httpClient api.RetryableClient
 
 	// signedUrls is the list of signed URLs for the files to download.
 	signedUrls []string
@@ -184,7 +184,7 @@ type RunHistoryDownloadOperation struct {
 
 func NewRunHistoryDownloadOperation(
 	ctx context.Context,
-	httpClient *retryablehttp.Client,
+	httpClient api.RetryableClient,
 	entity string,
 	project string,
 	runId string,

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -91,6 +91,12 @@ func (op *RunSyncOperation) Do(
 	parallelism int,
 ) *spb.ServerSyncResponse {
 	defer func() {
+		if op.telemetryProxy != nil {
+			if err := op.telemetryProxy.Shutdown(ctx); err != nil {
+				slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
+			}
+		}
+
 		op.logFile.Close()
 		op.printer.Close()
 	}()
@@ -123,12 +129,6 @@ func (op *RunSyncOperation) Do(
 	}
 
 	_ = group.Wait()
-
-	if op.telemetryProxy != nil {
-		if err := op.telemetryProxy.Shutdown(ctx); err != nil {
-			slog.Error("runsync: failed to shutdown telemetry proxy", "error", err)
-		}
-	}
 
 	return &spb.ServerSyncResponse{
 		Messages: op.popMessages(),

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -468,23 +468,22 @@ func (s *Sender) sendRequestNetworkStatus(
 	_ *spb.NetworkStatusRequest,
 	request *runwork.Request,
 ) {
-	// in case of network peeker is not set, we don't need to do anything
-	if s.networkPeeker == nil {
-		return
+	// The client polls with one outstanding request at a time, so it must
+	// always get a response, even if there is nothing to report.
+	var responses []*spb.HttpResponse
+	if s.networkPeeker != nil {
+		responses = s.networkPeeker.Read()
 	}
 
-	// send the network status response if there is any
-	if response := s.networkPeeker.Read(); len(response) > 0 {
-		s.respond(request,
-			&spb.Response{
-				ResponseType: &spb.Response_NetworkStatusResponse{
-					NetworkStatusResponse: &spb.NetworkStatusResponse{
-						NetworkResponses: response,
-					},
+	s.respond(request,
+		&spb.Response{
+			ResponseType: &spb.Response_NetworkStatusResponse{
+				NetworkStatusResponse: &spb.NetworkStatusResponse{
+					NetworkResponses: responses,
 				},
 			},
-		)
-	}
+		},
+	)
 }
 
 func (s *Sender) sendJobFlush() {

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -3,6 +3,7 @@ package stream_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,15 @@ type testFixtures struct {
 }
 
 func makeSender(t *testing.T, client graphql.Client) testFixtures {
+	t.Helper()
+	return makeSenderWithPeeker(t, client, nil)
+}
+
+func makeSenderWithPeeker(
+	t *testing.T,
+	client graphql.Client,
+	peeker *observability.Peeker,
+) testFixtures {
 	t.Helper()
 	runWork := runworktest.New()
 	logger := observabilitytest.NewTestLogger(t)
@@ -81,6 +91,7 @@ func makeSender(t *testing.T, client graphql.Client) testFixtures {
 		GraphqlClient:           client,
 		FeatureProvider:         featurechecker.New(nil, logger),
 		RunHandle:               runHandle,
+		Peeker:                  peeker,
 	}
 	return testFixtures{
 		Sender:    senderFactory.New(runWork),
@@ -246,6 +257,47 @@ func TestSendUseArtifact(t *testing.T) {
 		},
 	}
 	x.Sender.SendRecord(useArtifact, nil)
+}
+
+func TestSendRequestNetworkStatus(t *testing.T) {
+	testCases := []struct {
+		name   string
+		peeker *observability.Peeker
+	}{
+		{"peeker is not set", nil},
+		{"peeker has no buffered responses", &observability.Peeker{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			x := makeSenderWithPeeker(t, gqlmock.NewMockClient(), tc.peeker)
+			networkStatus := &spb.Record{
+				RecordType: &spb.Record_Request{
+					Request: &spb.Request{
+						RequestType: &spb.Request_NetworkStatus{
+							NetworkStatus: &spb.NetworkStatusRequest{},
+						},
+					},
+				},
+				Control: &spb.Control{
+					MailboxSlot: "junk",
+				},
+			}
+
+			request, outputs := runworktest.SimpleRequest(t, "test-id")
+			x.Sender.SendRecord(networkStatus, request)
+
+			select {
+			case response := <-outputs:
+				assert.NotNil(t,
+					response.GetResultCommunicate().
+						GetResponse().
+						GetNetworkStatusResponse())
+			case <-time.After(5 * time.Second):
+				t.Error("timed out waiting for a response")
+			}
+		})
+	}
 }
 
 var validFetchOrgEntityFromEntityResponse = `{

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -35,6 +35,12 @@ const (
 	printerBufferSize = 128
 )
 
+// Transaction log constructors, overridden in tests.
+var (
+	openTransactionLogWriter = transactionlog.OpenWriter
+	openTransactionLogReader = transactionlog.OpenReader
+)
+
 // Stream processes incoming records for a single run.
 //
 // wandb consists of a service process (this code) to which one or more
@@ -190,14 +196,14 @@ func (s *Stream) maybeSavingToTransactionLog(
 		return work
 	}
 
-	w, err := transactionlog.OpenWriter(s.settings.GetTransactionLogPath())
+	w, err := openTransactionLogWriter(s.settings.GetTransactionLogPath())
 	if err != nil {
 		s.logger.Error(fmt.Sprintf(
 			"stream: error opening transaction log for writing: %v", err))
 		return work
 	}
 
-	r, err := transactionlog.OpenReader(
+	r, err := openTransactionLogReader(
 		s.settings.GetTransactionLogPath(),
 		s.logger,
 	)
@@ -211,6 +217,12 @@ func (s *Stream) maybeSavingToTransactionLog(
 				err,
 			),
 		)
+
+		if err := w.Close(); err != nil {
+			s.logger.Error(fmt.Sprintf(
+				"stream: error closing transaction log: %v", err))
+		}
+
 		return work
 	}
 

--- a/core/internal/stream/stream_test.go
+++ b/core/internal/stream/stream_test.go
@@ -1,0 +1,52 @@
+package stream
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/observabilitytest"
+	"github.com/wandb/wandb/core/internal/runwork"
+	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/transactionlog"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+func TestTransactionLog_ReaderFails_ClosesWriter(t *testing.T) {
+	realOpenWriter := openTransactionLogWriter
+	t.Cleanup(func() {
+		openTransactionLogWriter = realOpenWriter
+		openTransactionLogReader = transactionlog.OpenReader
+	})
+
+	var logWriter *transactionlog.Writer
+	openTransactionLogWriter = func(path string) (*transactionlog.Writer, error) {
+		w, err := realOpenWriter(path)
+		logWriter = w
+		return w, err
+	}
+	openTransactionLogReader = func(
+		path string,
+		logger *observability.CoreLogger,
+	) (*transactionlog.Reader, error) {
+		return nil, errors.New("test error")
+	}
+
+	stream := &Stream{
+		settings: settings.From(&spb.Settings{
+			SyncFile: wrapperspb.String(
+				filepath.Join(t.TempDir(), "test.wandb")),
+		}),
+		logger: observabilitytest.NewTestLogger(t),
+	}
+
+	_ = stream.maybeSavingToTransactionLog(make(chan runwork.Work))
+
+	require.NotNil(t, logWriter)
+	assert.ErrorContains(t, logWriter.Close(), "already closed")
+}

--- a/core/internal/wbapi/readrunhistoryhandler.go
+++ b/core/internal/wbapi/readrunhistoryhandler.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/getsentry/sentry-go"
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/wandb/simplejsonext"
 
+	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/runhistoryreader"
 	"github.com/wandb/wandb/core/internal/runhistoryreader/parquet"
@@ -24,7 +24,7 @@ import (
 // related to reading a run's history.
 type RunHistoryAPIHandler struct {
 	graphqlClient graphql.Client
-	httpClient    *retryablehttp.Client
+	httpClient    api.RetryableClient
 	logger        *observability.CoreLogger
 
 	// mu protects scanHistoryReaders and downloadOperations from
@@ -62,7 +62,7 @@ type RunHistoryAPIHandler struct {
 
 func NewRunHistoryAPIHandler(
 	graphqlClient graphql.Client,
-	httpClient *retryablehttp.Client,
+	httpClient api.RetryableClient,
 	logger *observability.CoreLogger,
 ) *RunHistoryAPIHandler {
 

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/hashicorp/go-retryablehttp"
-
 	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/featurechecker"
@@ -70,13 +68,6 @@ func New(
 		s.GetExtraHTTPHeaders(),
 	)
 
-	httpClient := retryablehttp.NewClient()
-	httpClient.RetryMax = int(s.GetFileTransferMaxRetries())
-	httpClient.RetryWaitMin = s.GetFileTransferRetryWaitMin()
-	httpClient.RetryWaitMax = s.GetFileTransferRetryWaitMax()
-	httpClient.HTTPClient.Timeout = s.GetFileTransferTimeout()
-	httpClient.Logger = logger
-
 	fileTransferClient := newFileTransferClient(
 		baseURL,
 		credentialProvider,
@@ -112,7 +103,7 @@ func New(
 		runQueueHandler:     NewRunQueueHandler(graphqlClient),
 		runHistoryApiHandler: NewRunHistoryAPIHandler(
 			graphqlClient,
-			httpClient,
+			fileTransferClient,
 			logger,
 		),
 	}, nil

--- a/core/internal/wbapi/wbapi_test.go
+++ b/core/internal/wbapi/wbapi_test.go
@@ -2,10 +2,18 @@ package wbapi
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/settings"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -29,6 +37,65 @@ func TestHandleRequestUnknownTypeIsError(t *testing.T) {
 	}
 	if !strings.Contains(apiError.GetMessage(), "unsupported API request") {
 		t.Fatalf("expected unsupported request error, got %q", apiError.GetMessage())
+	}
+}
+
+func TestRunHistoryClientUsesFileTransferConfiguration(t *testing.T) {
+	var mu sync.Mutex
+	var requestCount int
+	var extraHeader string
+
+	// The first request fails, so only a retrying client sees a success.
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			requestCount++
+			attempt := requestCount
+			extraHeader = r.Header.Get("X-Test-Header")
+			mu.Unlock()
+
+			if attempt == 1 {
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		},
+	))
+	defer server.Close()
+
+	// The x_file_transfer_* settings are unset, as they are by default.
+	wandbAPI, err := New(
+		settings.From(&spb.Settings{
+			BaseUrl: wrapperspb.String("https://api.wandb.test"),
+			XExtraHttpHeaders: &spb.MapStringKeyStringValue{
+				Value: map[string]string{"X-Test-Header": "test-value"},
+			},
+		}),
+		observability.NewNoOpLogger(),
+	)
+	if err != nil {
+		t.Fatalf("error creating WandbAPI: %v", err)
+	}
+
+	request, err := retryablehttp.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+	response, err := wandbAPI.runHistoryApiHandler.httpClient.Do(request)
+	if err != nil {
+		t.Fatalf("error making request: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected request to succeed, got status %d", response.StatusCode)
+	}
+	if requestCount != 2 {
+		t.Errorf("expected the failed request to be retried once, got %d requests", requestCount)
+	}
+	if extraHeader != "test-value" {
+		t.Errorf("expected configured extra header, got %q", extraHeader)
 	}
 }
 

--- a/core/pkg/server/connection.go
+++ b/core/pkg/server/connection.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/url"
+	"slices"
 	"sync"
 	"time"
 
@@ -34,6 +36,10 @@ import (
 const (
 	messageSize    = 1024 * 1024            // 1MB message size
 	maxMessageSize = 2 * 1024 * 1024 * 1024 // 2GB max message size
+
+	// telemetryShutdownTimeout limits the final telemetry flush, which
+	// performs an HTTP request.
+	telemetryShutdownTimeout = 2 * time.Second
 )
 
 type ConnectionParams struct {
@@ -109,6 +115,15 @@ type Connection struct {
 
 	// apiManager processes API requests.
 	apiManager *wbapi.WandbAPIManager
+
+	// apiTelemetryMu guards apiTelemetryProxies.
+	apiTelemetryMu sync.Mutex
+
+	// apiTelemetryProxies maps API instance IDs to their telemetry proxies.
+	//
+	// Each proxy runs background goroutines and holds an HTTP client until
+	// it is shut down.
+	apiTelemetryProxies map[string]*analytics.OpenTelemetryProxy
 }
 
 func NewConnection(
@@ -134,6 +149,8 @@ func NewConnection(
 		loggerPath:         params.LoggerPath,
 		logLevel:           params.LogLevel,
 		apiManager:         wbapi.NewManager(),
+
+		apiTelemetryProxies: make(map[string]*analytics.OpenTelemetryProxy),
 	}
 }
 
@@ -161,6 +178,11 @@ func (nc *Connection) ManageConnectionData() {
 	nc.Close()
 
 	wg.Wait()
+
+	// Shut down telemetry for API instances the client never cleaned up.
+	for _, proxy := range nc.popAllAPITelemetryProxies() {
+		shutdownTelemetryProxyInBackground(proxy)
+	}
 
 	slog.Info("connection: ManageConnectionData: connection closed", "id", nc.id)
 }
@@ -679,25 +701,6 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	s := settings.From(request.GetSettings())
 
 	telemetryProxy := analytics.NewOpenTelemetryProxy(context.Background(), s)
-	go func() {
-		<-nc.connLifetimeCtx.Done()
-		if telemetryProxy != nil {
-			shutdownCtx, cancel := context.WithTimeout(
-				context.Background(),
-				2*time.Second,
-			)
-			defer cancel()
-
-			err := telemetryProxy.Shutdown(shutdownCtx)
-			if err != nil {
-				slog.Error(
-					"connection: failed to shut down telemetry proxy",
-					"error",
-					err,
-				)
-			}
-		}
-	}()
 
 	logger := observability.NewCoreLogger(
 		slog.Default(),
@@ -709,6 +712,8 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	)
 	wbapiInstance, err := wbapi.New(s, logger)
 	if err != nil {
+		shutdownTelemetryProxyInBackground(telemetryProxy)
+
 		nc.Respond(&spb.ServerResponse{
 			RequestId: id,
 			ServerResponseType: &spb.ServerResponse_ErrorResponse{
@@ -722,6 +727,7 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 	}
 
 	wbApiId := nc.apiManager.AddWandbAPI(wbapiInstance)
+	nc.addAPITelemetryProxy(wbApiId, telemetryProxy)
 
 	nc.Respond(&spb.ServerResponse{
 		RequestId: id,
@@ -736,6 +742,67 @@ func (nc *Connection) handleApiInit(id string, request *spb.ServerApiInitRequest
 // handleApiCleanup cleans up a wandbAPI instance related to the provided id.
 func (nc *Connection) handleApiCleanup(id string, request *spb.ServerApiCleanupRequest) {
 	nc.apiManager.RemoveWandbAPI(request.GetApiId())
+
+	proxy := nc.popAPITelemetryProxy(request.GetApiId())
+	shutdownTelemetryProxyInBackground(proxy)
+}
+
+// addAPITelemetryProxy associates a telemetry proxy with an API instance.
+func (nc *Connection) addAPITelemetryProxy(
+	apiID string,
+	proxy *analytics.OpenTelemetryProxy,
+) {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+
+	nc.apiTelemetryProxies[apiID] = proxy
+}
+
+// popAPITelemetryProxy forgets and returns the telemetry proxy for an API
+// instance, or nil if there is none.
+func (nc *Connection) popAPITelemetryProxy(
+	apiID string,
+) *analytics.OpenTelemetryProxy {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+
+	proxy := nc.apiTelemetryProxies[apiID]
+	delete(nc.apiTelemetryProxies, apiID)
+	return proxy
+}
+
+// popAllAPITelemetryProxies forgets and returns all remaining telemetry
+// proxies.
+func (nc *Connection) popAllAPITelemetryProxies() []*analytics.OpenTelemetryProxy {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+
+	proxies := slices.Collect(maps.Values(nc.apiTelemetryProxies))
+	clear(nc.apiTelemetryProxies)
+	return proxies
+}
+
+// shutdownTelemetryProxyInBackground flushes and shuts down a telemetry proxy
+// without blocking the caller, which runs on the request dispatch path.
+func shutdownTelemetryProxyInBackground(proxy *analytics.OpenTelemetryProxy) {
+	if proxy == nil {
+		return
+	}
+
+	go func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			telemetryShutdownTimeout,
+		)
+		defer cancel()
+
+		if err := proxy.Shutdown(ctx); err != nil {
+			slog.Error(
+				"connection: failed to shut down telemetry proxy",
+				"error", err,
+			)
+		}
+	}()
 }
 
 func (nc *Connection) handleApi(

--- a/core/pkg/server/connection_api_test.go
+++ b/core/pkg/server/connection_api_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// telemetryExportInterval is how often a telemetry proxy exports metrics.
+const telemetryExportInterval = 500 * time.Millisecond
+
+func apiTelemetryProxyCount(nc *Connection) int {
+	nc.apiTelemetryMu.Lock()
+	defer nc.apiTelemetryMu.Unlock()
+	return len(nc.apiTelemetryProxies)
+}
+
+func TestHandleApiCleanupShutsDownTelemetry(t *testing.T) {
+	var exports atomic.Int64
+	backend := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			exports.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+	t.Cleanup(backend.Close)
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	nc := NewConnection(
+		context.Background(),
+		func() {},
+		ConnectionParams{
+			ID:   "test",
+			Conn: serverConn,
+		},
+	)
+
+	nc.handleApiInit("init", &spb.ServerApiInitRequest{
+		Settings: &spb.Settings{
+			BaseUrl: wrapperspb.String(backend.URL),
+			ApiKey:  wrapperspb.String("test-api-key"),
+		},
+	})
+
+	apiID := (<-nc.outChan).GetApiInitResponse().GetApiId()
+	require.NotEmpty(t, apiID, "expected an API instance to be created")
+	require.Equal(t, 1, apiTelemetryProxyCount(nc))
+	require.Eventually(t,
+		func() bool { return exports.Load() > 0 },
+		10*time.Second, 10*time.Millisecond,
+		"expected the telemetry proxy to export to the backend")
+
+	nc.handleApiCleanup("cleanup", &spb.ServerApiCleanupRequest{ApiId: apiID})
+
+	assert.Zero(t, apiTelemetryProxyCount(nc))
+	assert.Eventually(t,
+		func() bool {
+			before := exports.Load()
+			time.Sleep(3 * telemetryExportInterval)
+			return exports.Load() == before
+		},
+		15*time.Second, telemetryExportInterval,
+		"expected telemetry exports to stop after cleanup")
+}

--- a/parquet-rust-wrapper/src/lib.rs
+++ b/parquet-rust-wrapper/src/lib.rs
@@ -43,6 +43,24 @@ pub unsafe extern "C" fn create_reader(
     num_columns: usize,
     out_error: *mut *mut libc::c_char,
 ) -> *mut ReaderHandle {
+    let result =
+        catch_panic(|| create_reader_impl(file_path_or_url, column_names, num_columns, out_error));
+
+    match result {
+        Ok(handle_ptr) => handle_ptr,
+        Err(e) => {
+            *out_error = error_to_c_string(&e);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+unsafe fn create_reader_impl(
+    file_path_or_url: *const libc::c_char,
+    column_names: *const *const libc::c_char,
+    num_columns: usize,
+    out_error: *mut *mut libc::c_char,
+) -> *mut ReaderHandle {
     // Convert the file path from C string to Rust string
     let file_path_cstr = unsafe { CStr::from_ptr(file_path_or_url) };
     let file_path_str = match file_path_cstr.to_str() {
@@ -225,6 +243,21 @@ pub struct StepScanResult {
 /// - Returns a buffer that must be freed by caller using free_buffer
 #[no_mangle]
 pub unsafe extern "C" fn reader_scan_step_range(
+    reader_ptr: *mut ReaderHandle,
+    min_step: i64,
+    max_step: i64,
+    out_result: *mut StepScanResult,
+) -> *const libc::c_char {
+    let result =
+        catch_panic(|| reader_scan_step_range_impl(reader_ptr, min_step, max_step, out_result));
+
+    match result {
+        Ok(error) => error,
+        Err(e) => error_to_c_string(&e),
+    }
+}
+
+unsafe fn reader_scan_step_range_impl(
     reader_ptr: *mut ReaderHandle,
     min_step: i64,
     max_step: i64,
@@ -449,6 +482,24 @@ pub unsafe extern "C" fn free_reader(reader_ptr: *mut ReaderHandle) {
     if !reader_ptr.is_null() {
         let _ = Box::from_raw(reader_ptr);
     }
+}
+
+/// Runs `f` and turns a panic raised inside it into an error message.
+///
+/// Unwinding out of an `extern "C"` function aborts the process, which would
+/// take down every run sharing the service, so each entry point must contain
+/// its own panics.
+fn catch_panic<T>(f: impl FnOnce() -> T) -> Result<T, String> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).map_err(|payload| {
+        let message = if let Some(s) = payload.downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = payload.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "unknown panic".to_string()
+        };
+        format!("panic: {}", message)
+    })
 }
 
 fn error_to_c_string(error: &str) -> *mut libc::c_char {

--- a/parquet-rust-wrapper/tests/lib_tests.rs
+++ b/parquet-rust-wrapper/tests/lib_tests.rs
@@ -1,9 +1,9 @@
-use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::array::{Int64Array, LargeStringArray, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow_rs_wrapper::*;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -687,6 +687,76 @@ fn test_reader_scan_with_int64_step_column() {
 
     unsafe {
         free_buffer(result.vec_ptr as *mut Vec<u8>);
+        free_reader(reader_ptr);
+    }
+}
+
+/// Helper function to create a test parquet file whose value column uses the
+/// 64-bit offset string type, which the serializer does not handle.
+fn create_test_parquet_file_with_large_utf8(path: &str, num_rows: usize) -> std::io::Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(STEP_COLUMN_NAME, DataType::Int64, false),
+        Field::new("name", DataType::LargeUtf8, false),
+    ]));
+
+    let file = File::create(path)?;
+    let props = WriterProperties::builder().build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    let step_values: Vec<i64> = (0..num_rows).map(|i| i as i64).collect();
+    let string_values: Vec<&str> = (0..num_rows)
+        .map(|i| if i % 2 == 0 { "even" } else { "odd" })
+        .collect();
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(step_values)),
+            Arc::new(LargeStringArray::from(string_values)),
+        ],
+    )
+    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    writer
+        .write(&batch)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    writer
+        .close()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    Ok(())
+}
+
+#[test]
+fn test_reader_scan_step_range_returns_panic_as_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test_large_utf8.parquet");
+    create_test_parquet_file_with_large_utf8(file_path.to_str().unwrap(), 100).unwrap();
+
+    let path_cstring = CString::new(file_path.to_str().unwrap()).unwrap();
+    let mut out_error: *mut libc::c_char = std::ptr::null_mut();
+    let reader_ptr = unsafe {
+        create_reader(path_cstring.as_ptr(), std::ptr::null(), 0, &mut out_error)
+    };
+    assert!(!reader_ptr.is_null());
+
+    let mut result = StepScanResult {
+        vec_ptr: 0, data_ptr: 0, data_len: 0, num_rows_returned: 0,
+    };
+
+    let error = unsafe { reader_scan_step_range(reader_ptr, 10, 20, &mut result) };
+    assert!(!error.is_null());
+
+    let error_message = unsafe { CStr::from_ptr(error) }.to_str().unwrap();
+    assert!(
+        error_message.contains("panic"),
+        "unexpected error: {}",
+        error_message
+    );
+
+    unsafe {
+        free_string(error as *mut libc::c_char);
         free_reader(reader_ptr);
     }
 }

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import functools
 import queue
 import shutil
+import threading
+import time
 import unittest.mock as mock
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -738,3 +740,86 @@ def test_artifact_multipart_download_writer_not_on_shared_executor():
         future.result(timeout=5)
     except TimeoutError:
         fail("multipart_download deadlocked: writer likely sharing the chunk executor")
+
+
+class OneSlotChunkQueue(queue.Queue):
+    """Chunk queue with a single slot that tracks producers waiting on it."""
+
+    def __init__(self) -> None:
+        super().__init__(maxsize=1)
+        self._producers = 0
+        self._producers_lock = threading.Lock()
+
+    def put(self, item, block=True, timeout=None):
+        with self._producers_lock:
+            self._producers += 1
+        try:
+            super().put(item, block, timeout)
+        finally:
+            with self._producers_lock:
+                self._producers -= 1
+
+    @property
+    def producers(self) -> int:
+        with self._producers_lock:
+            return self._producers
+
+    def has_waiting_producer(self) -> bool:
+        return self.full() and (self.producers > 0)
+
+    def release_producers(self) -> None:
+        """Make room until no producer is left waiting, so their threads finish."""
+        while self.producers:
+            try:
+                self.get_nowait()
+            except queue.Empty:
+                pass
+            time.sleep(0.01)
+
+
+@responses.activate()
+def test_artifact_multipart_download_disk_error_with_full_queue(
+    monkeypatch: MonkeyPatch,
+):
+    # If the writer dies while the queue is full, the chunk downloaders that are
+    # handing off chunks must notice and stop, so the write error is raised
+    # instead of the download blocking forever.
+    responses.get("https://s3.com/file", body=b"test", status=200)
+
+    chunk_queue = OneSlotChunkQueue()
+    monkeypatch.setattr(
+        "wandb.sdk.artifacts.storage_policies._multipart.Queue",
+        lambda maxsize: chunk_queue,
+    )
+
+    def write_once_queue_is_full(data):
+        deadline = time.monotonic() + 10
+        while not chunk_queue.has_waiting_producer():
+            assert time.monotonic() < deadline, "no downloader waited on the queue"
+            time.sleep(0.01)
+        raise OSError("No space left on device")
+
+    opener = mock.mock_open()
+    opener.return_value.write.side_effect = write_once_queue_is_full
+
+    def run_download():
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            multipart_download(
+                executor,
+                requests.Session(),
+                500 * 1024 * 1024,  # 500MB should have 5 parts
+                opener,
+                initial_url="https://s3.com/file",
+                fetch_fn=lambda: "https://s3.com/file",
+            )
+
+    future = ThreadPoolExecutor(max_workers=1).submit(run_download)
+    try:
+        # Add a timeout to the future to avoid hanging the test.
+        error = future.exception(timeout=15)
+    except TimeoutError:
+        fail("multipart_download hung: chunk downloaders stuck on a full queue")
+    finally:
+        chunk_queue.release_producers()
+
+    assert isinstance(error, OSError)

--- a/tests/unit_tests/test_public_api/test_paginator.py
+++ b/tests/unit_tests/test_public_api/test_paginator.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+import pytest
+from wandb.apis.paginator import Paginator
+
+ITEMS = ["a", "b", "c", "d", "e"]
+
+
+class FakePaginator(Paginator[str]):
+    """A paginator that serves a fixed list of objects, one page at a time."""
+
+    QUERY = None
+
+    def __init__(self, items: Sequence[str], per_page: int = 2):
+        super().__init__(service_api=None, variables={}, per_page=per_page)
+        self._items = list(items)
+        self.pages_loaded = 0
+
+    @property
+    def more(self) -> bool:
+        return len(self.objects) < len(self._items)
+
+    @property
+    def cursor(self) -> str | None:
+        return str(len(self.objects))
+
+    def _update_response(self) -> None:
+        start = len(self.objects)
+        self.last_response = self._items[start : start + self.per_page]
+        self.pages_loaded += 1
+
+    def convert_objects(self) -> Iterable[str]:
+        return self.last_response
+
+
+@pytest.mark.parametrize("index", [-1, -3, -len(ITEMS)])
+def test_negative_index_on_unloaded_paginator(index: int):
+    assert FakePaginator(ITEMS)[index] == ITEMS[index]
+
+
+@pytest.mark.parametrize("index", [-1, -3, -len(ITEMS)])
+def test_negative_index_on_partially_loaded_paginator(index: int):
+    paginator = FakePaginator(ITEMS)
+    assert paginator[0] == ITEMS[0]
+
+    assert paginator[index] == ITEMS[index]
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        slice(None, None),
+        slice(2, None),
+        slice(None, -1),
+        slice(-2, None),
+        slice(None, None, 2),
+        slice(None, None, -1),
+        slice(1, 3),
+        slice(0, 100),
+    ],
+)
+def test_slice_matches_list_slice(index: slice):
+    assert FakePaginator(ITEMS)[index] == ITEMS[index]
+
+
+def test_out_of_range_index_raises_index_error():
+    with pytest.raises(IndexError):
+        FakePaginator(ITEMS)[len(ITEMS)]
+
+    with pytest.raises(IndexError):
+        FakePaginator(ITEMS)[-len(ITEMS) - 1]
+
+
+def test_bounded_index_only_loads_the_pages_it_needs():
+    paginator = FakePaginator(ITEMS)
+
+    assert paginator[1] == ITEMS[1]
+
+    assert paginator.pages_loaded == 1
+    assert paginator.more

--- a/wandb/apis/paginator.py
+++ b/wandb/apis/paginator.py
@@ -111,9 +111,21 @@ class Paginator(Iterator[_WandbT], ABC):
     def __getitem__(self, index: slice) -> list[_WandbT]: ...
 
     def __getitem__(self, index: int | slice) -> _WandbT | list[_WandbT]:
+        # A `stop` of None means the index is relative to the total number of
+        # objects, so every remaining page has to be fetched before indexing.
+        if isinstance(index, slice):
+            start, stop, step = index.start, index.stop, index.step
+            if (
+                (start is not None and start < 0)
+                or (stop is not None and stop < 0)
+                or (step is not None and step <= 0)
+            ):
+                stop = None
+        else:
+            stop = index if (index >= 0) else None
+
         loaded = True
-        stop = index.stop if isinstance(index, slice) else index
-        while loaded and stop > len(self.objects) - 1:
+        while loaded and (stop is None or stop > len(self.objects) - 1):
             loaded = self._load_page()
         return self.objects[index]
 

--- a/wandb/sdk/artifacts/storage_policies/_multipart.py
+++ b/wandb/sdk/artifacts/storage_policies/_multipart.py
@@ -45,6 +45,10 @@ MULTI_DEFAULT_PART_SIZE = 100 * MiB
 # Chunk size for reading http response and writing to disk.
 RSP_CHUNK_SIZE = 1 * MiB
 
+# How long a download thread waits for room on the chunk queue before it
+# rechecks whether the download was cancelled.
+QUEUE_PUT_TIMEOUT = 0.5
+
 
 @final
 class _ChunkSentinel:
@@ -177,15 +181,24 @@ def _download_chunk_with_refresh(
             return True
         return False
 
+    def queue_chunk(content: ChunkContent) -> bool:
+        """Hand a chunk to the writer, returning False if the download was cancelled."""
+        while not ctx.cancel.is_set():
+            try:
+                ctx.q.put(content, timeout=QUEUE_PUT_TIMEOUT)
+            except Full:
+                continue
+            return True
+        return False
+
     def attempt_download() -> None:
         with ctx.session.get(url=ctx.get_url(), headers=headers, stream=True) as rsp:
             rsp.raise_for_status()
 
             offset = start
             for chunk in rsp.iter_content(chunk_size=RSP_CHUNK_SIZE):
-                if ctx.cancel.is_set():
+                if not queue_chunk(ChunkContent(offset=offset, data=chunk)):
                     return
-                ctx.q.put(ChunkContent(offset=offset, data=chunk))
                 offset += len(chunk)
 
     # Use common retry logic with exponential backoff

--- a/xpu/src/gpu_nvidia_dcgm.rs
+++ b/xpu/src/gpu_nvidia_dcgm.rs
@@ -88,7 +88,7 @@ const DCGM_FI_PROF_NVLINK_RX_BYTES: u16 = 1012;
 
 /// DCGM Group IDs.
 /// Represents all GPUs discovered on the node.
-const DCGM_GROUP_ALL_GPUS: u32 = 0x7fffffff;
+const DCGM_GROUP_ALL_GPUS: DcgmGpuGrpT = 0x7fffffff;
 
 // --- Type Aliases for FFI Clarity ---
 
@@ -96,10 +96,10 @@ const DCGM_GROUP_ALL_GPUS: u32 = 0x7fffffff;
 type DcgmReturnT = i32;
 /// Alias for the `dcgmHandle_t` C type (`void*`). Represents the connection handle to DCGM.
 type DcgmHandleT = *mut c_void;
-/// Alias for the `dcgmGpuGrp_t` C type (typically `unsigned int`). Represents a DCGM GPU group ID.
-type DcgmGpuGrpT = u32;
-/// Alias for the `dcgmFieldGrp_t` C type (typically `unsigned int`). Represents a DCGM field group ID.
-type DcgmFieldGrpT = u32;
+/// Alias for the `dcgmGpuGrp_t` C type (`uintptr_t`). Represents a DCGM GPU group ID.
+type DcgmGpuGrpT = usize;
+/// Alias for the `dcgmFieldGrp_t` C type (`uintptr_t`). Represents a DCGM field group ID.
+type DcgmFieldGrpT = usize;
 /// Alias for the `dcgmFieldEntityGroup_t` C type (typically `unsigned int`). Represents the entity type (GPU, VGPU, etc.).
 type DcgmFieldEntityGroupT = u32;
 /// Alias for the `dcgmFieldEid_t` C type (typically `unsigned int`). Represents the entity ID within its group.
@@ -1133,8 +1133,8 @@ extern "C" fn field_value_callback(
 /// collecting metrics).
 struct DcgmWorker {
     dcgm: Box<dyn DcgmLibrary>,
-    group_id: u32,
-    field_group_id: u32,
+    group_id: DcgmGpuGrpT,
+    field_group_id: DcgmFieldGrpT,
     receiver: mpsc::Receiver<DcgmCommand>,
 }
 
@@ -1145,8 +1145,8 @@ impl DcgmWorker {
     /// Takes ownership of the [`DcgmLib`] instance and the MPSC receiver.
     fn new(
         dcgm: Box<dyn DcgmLibrary>,
-        group_id: u32,
-        field_group_id: u32,
+        group_id: DcgmGpuGrpT,
+        field_group_id: DcgmFieldGrpT,
         receiver: mpsc::Receiver<DcgmCommand>,
     ) -> Self {
         DcgmWorker {
@@ -1324,6 +1324,19 @@ mod tests {
     }
 
     // --- Test Cases ---
+
+    #[test]
+    fn test_group_handle_aliases_are_pointer_sized() {
+        // dcgm_structs.h declares both handles as `uintptr_t`.
+        assert_eq!(
+            std::mem::size_of::<DcgmGpuGrpT>(),
+            std::mem::size_of::<usize>()
+        );
+        assert_eq!(
+            std::mem::size_of::<DcgmFieldGrpT>(),
+            std::mem::size_of::<usize>()
+        );
+    }
 
     #[test]
     fn test_worker_collect_metrics_success() {


### PR DESCRIPTION
Description
-----------

Indexing the paginated results of the public API with a negative index, or with
an open-ended slice, gave the wrong answer. A negative index did not load any
further pages, so on a fresh object it raised `IndexError` even though results
existed, and on a partly loaded one it returned the last item loaded so far
rather than the last item there is. This affects everything that pages, so
`runs`, `files`, `projects`, and `artifacts` alike.

The quick path is now used only when the request is fully determined going
forward: a non-negative index, or a slice with a non-negative start, a bounded
stop, and a positive step. Anything else loads the remaining pages first, so
results match ordinary list behavior.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added tests for a negative index on a fresh object, a negative index on a partly
loaded one, and an open-ended slice, each asserting the same answer a list would
give.

Confirmed they fail without the fix.
