### PR TITLE
fix(sdk): raise a clear error when a table column refers to its own table

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -59,3 +59,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Creating many `wandb.Api()` objects in one program no longer leaks memory and background network requests for the lifetime of the program (@dmitryduev in https://github.com/wandb/wandb/pull/12399)
 - Your timeout and retry settings now apply when reading a run's history, which previously used neither (@dmitryduev in https://github.com/wandb/wandb/pull/12401)
 - Negative indexes and open-ended slices now return the right results when paging through API results such as `runs`, `files`, and `artifacts`, instead of raising `IndexError` or returning the wrong item (@dmitryduev in https://github.com/wandb/wandb/pull/12402)
+- Pointing a `wandb.Table` column at its own table now reports a clear error instead of failing with `RecursionError` when the table is logged (@dmitryduev in https://github.com/wandb/wandb/pull/12403)

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -4,7 +4,11 @@ import json
 import numpy as np
 import pytest
 import wandb
-from wandb.sdk.data_types.table import _ForeignKeyType, _PrimaryKeyType
+from wandb.sdk.data_types.table import (
+    _ForeignIndexType,
+    _ForeignKeyType,
+    _PrimaryKeyType,
+)
 
 
 def test_basic_ndx():
@@ -193,6 +197,20 @@ def test_fk_from_pk_local_draft():
             for row in table.data
         ]
     )
+
+
+def test_self_referential_fi_cast():
+    table = wandb.Table(columns=["ndx", "col_1"], data=[[0, "a"], [1, "b"]])
+
+    with pytest.raises(
+        AssertionError, match="Cannot set a foreign table reference to same table."
+    ):
+        table.cast("ndx", _ForeignIndexType(table))
+
+    with pytest.raises(
+        AssertionError, match="Cannot set a foreign table reference to same table."
+    ):
+        table.add_data(table.index_ref(0), "c")
 
 
 def test_loading_from_json_with_mixed_types():

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -536,7 +536,7 @@ class Table(Media):
                 "Primary keys, foreign keys, and foreign indexes cannot be optional."
             )
 
-        if (is_fk or is_fk) and id(wbtype.params["table"]) == id(self):
+        if (is_fk or is_fi) and id(wbtype.params["table"]) == id(self):
             raise AssertionError("Cannot set a foreign table reference to same table.")
 
         if is_pk:


### PR DESCRIPTION
Description
-----------

Setting a `wandb.Table` column to point at its own table was supposed to be
rejected with a clear message. A typo in the check compared one variable with
itself, so the case slipped through and the user instead hit a `RecursionError`
when logging the table, which gives no hint about what they did wrong.

The check now tests what it was meant to test, and the intended error is
raised.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test asserting a self-referential column raises the intended error
rather than `RecursionError`.

Confirmed it fails without the fix.
