### PR TITLE
fix(sdk): speed up adding rows to a table that links to another table

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -60,3 +60,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Your timeout and retry settings now apply when reading a run's history, which previously used neither (@dmitryduev in https://github.com/wandb/wandb/pull/12401)
 - Negative indexes and open-ended slices now return the right results when paging through API results such as `runs`, `files`, and `artifacts`, instead of raising `IndexError` or returning the wrong item (@dmitryduev in https://github.com/wandb/wandb/pull/12402)
 - Pointing a `wandb.Table` column at its own table now reports a clear error instead of failing with `RecursionError` when the table is logged (@dmitryduev in https://github.com/wandb/wandb/pull/12403)
+- Adding rows to a `wandb.Table` that links to another table is much faster; the time it took grew with the number of rows already added (@dmitryduev in https://github.com/wandb/wandb/pull/12404)

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -199,6 +199,45 @@ def test_fk_from_pk_local_draft():
     )
 
 
+def test_fk_add_data_casts_column_once(mocker):
+    table_a = wandb.Table(columns=["id", "col_1"], data=[["1", "a"], ["2", "b"]])
+    table_a.set_pk("id")
+
+    table = wandb.Table(columns=["fk", "col_2"])
+    cast = mocker.spy(wandb.Table, "cast")
+    for _ in range(10):
+        table.add_data(table_a.data[0][0], "c")
+
+    assert cast.call_count == 1
+    assert isinstance(
+        table._column_types.params["type_map"]["fk"],
+        _ForeignKeyType,
+    )
+    assert [row[0] for row in table.data] == ["1"] * 10
+    assert all(
+        [row[0]._table == table_a and row[0]._col_name == "id" for row in table.data]
+    )
+
+
+def test_fi_add_data_casts_column_once(mocker):
+    table_a = wandb.Table(columns=["b"], data=[["a"], ["b"]])
+
+    table = wandb.Table(columns=["fi", "c"])
+    cast = mocker.spy(wandb.Table, "cast")
+    for _ in range(5):
+        for ndx, _row in table_a.iterrows():
+            table.add_data(ndx, "x")
+
+    assert cast.call_count == 1
+    assert [row[0] for row in table.data] == [0, 1] * 5
+    assert all([row[0]._table == table_a for row in table.data])
+
+    # A link to a different table still updates the column type
+    table_b = wandb.Table(columns=["b"], data=[["c"]])
+    with pytest.raises(TypeError):
+        table.add_data(table_b.index_ref(0), "x")
+
+
 def test_self_referential_fi_cast():
     table = wandb.Table(columns=["ndx", "col_1"], data=[[0, "a"], [1, "b"]])
 

--- a/wandb/sdk/data_types/table.py
+++ b/wandb/sdk/data_types/table.py
@@ -612,13 +612,20 @@ class Table(Media):
 
         # Special case to pre-emptively cast a column as a key.
         # Needed as String.assign(Key) is invalid
+        type_map = self._column_types.params["type_map"]
         for ndx, item in enumerate(data):
-            if isinstance(item, _TableLinkMixin):
-                self.cast(
-                    self.columns[ndx],
-                    _dtypes.TypeRegistry.type_of(item),
-                    optional=False,
-                )
+            if not isinstance(item, _TableLinkMixin):
+                continue
+
+            col_name = self.columns[ndx]
+            col_type = type_map.get(col_name)
+            item_type = _dtypes.TypeRegistry.type_of(item)
+            if isinstance(
+                col_type, (_PrimaryKeyType, _ForeignKeyType, _ForeignIndexType)
+            ) and not isinstance(col_type.assign_type(item_type), _dtypes.InvalidType):
+                continue
+
+            self.cast(col_name, item_type, optional=False)
 
         # Update the table's column types
         result_type = self._get_updated_result_type(data)


### PR DESCRIPTION
Description
-----------

Adding a row to a `wandb.Table` that links to another table re-validated every
row already in the table, so the cost of adding row n grew with n and building a
table got slower the longer it went. Measured on the current code: 0.06s at 500
rows, 0.98s at 2,000, and 3.9s at 4,000, against constant time for tables
without links.

The redundant re-validation is skipped when the column is already the matching
type, so every case that was rejected before is still rejected.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test asserting cross-table linking still behaves the same, and a guard
against the slow behavior returning that counts validation calls rather than
measuring wall-clock time, so it is not flaky.

Confirmed it fails without the fix.
