### PR TITLE
fix(sdk): speed up console log uploads for runs that print many lines

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -61,3 +61,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Negative indexes and open-ended slices now return the right results when paging through API results such as `runs`, `files`, and `artifacts`, instead of raising `IndexError` or returning the wrong item (@dmitryduev in https://github.com/wandb/wandb/pull/12402)
 - Pointing a `wandb.Table` column at its own table now reports a clear error instead of failing with `RecursionError` when the table is logged (@dmitryduev in https://github.com/wandb/wandb/pull/12403)
 - Adding rows to a `wandb.Table` that links to another table is much faster; the time it took grew with the number of rows already added (@dmitryduev in https://github.com/wandb/wandb/pull/12404)
+- Uploading console output is much faster for runs that print many lines (@dmitryduev in https://github.com/wandb/wandb/pull/12405)

--- a/core/internal/sparselist/sparselist.go
+++ b/core/internal/sparselist/sparselist.go
@@ -147,7 +147,7 @@ func (l *SparseList[T]) FirstRun() iter.Seq2[int, T] {
 			return
 		}
 
-		for i := l.FirstIndex(); i <= l.LastIndex(); i++ {
+		for i := l.FirstIndex(); ; i++ {
 			value, ok := l.Get(i)
 			if !ok || !yield(i, value) {
 				return

--- a/core/internal/sparselist/sparselist_test.go
+++ b/core/internal/sparselist/sparselist_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -61,6 +62,83 @@ func TestSparseListRuns(t *testing.T) {
 			{Start: 3, Items: []string{"three", "four"}},
 		},
 		list.ToRuns())
+}
+
+func TestSparseListFirstRun(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		items    map[int]string
+		expected map[int]string
+	}{
+		{
+			name:     "empty list",
+			items:    map[int]string{},
+			expected: map[int]string{},
+		},
+		{
+			name:     "single item",
+			items:    map[int]string{7: "a"},
+			expected: map[int]string{7: "a"},
+		},
+		{
+			name:     "run followed by gap",
+			items:    map[int]string{-1: "a", 0: "b", 2: "c", 3: "d"},
+			expected: map[int]string{-1: "a", 0: "b"},
+		},
+		{
+			name:     "run ending at last index",
+			items:    map[int]string{3: "a", 4: "b", 5: "c"},
+			expected: map[int]string{3: "a", 4: "b", 5: "c"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			list := &sparselist.SparseList[string]{}
+			for idx, item := range test.items {
+				list.Put(idx, item)
+			}
+
+			assert.Equal(t, test.expected, maps.Collect(list.FirstRun()))
+		})
+	}
+}
+
+func TestSparseListFirstRunDeleteWhileIterating(t *testing.T) {
+	list := &sparselist.SparseList[string]{}
+	list.Put(0, "zero")
+	list.Put(1, "one")
+	list.Put(2, "two")
+	list.Put(4, "four")
+
+	var popped []string
+	for idx, value := range list.FirstRun() {
+		popped = append(popped, value)
+		list.Delete(idx)
+	}
+
+	assert.Equal(t, []string{"zero", "one", "two"}, popped)
+	assert.Equal(t, map[int]string{4: "four"}, list.ToMap())
+}
+
+func TestSparseListFirstRunDeleteWholeList(t *testing.T) {
+	const count = 20_000
+
+	list := &sparselist.SparseList[int]{}
+	for idx := range count {
+		list.Put(idx, idx)
+	}
+
+	start := time.Now()
+	popped := 0
+	for idx := range list.FirstRun() {
+		popped++
+		list.Delete(idx)
+	}
+	elapsed := time.Since(start)
+
+	assert.Equal(t, count, popped)
+	assert.Zero(t, list.Len())
+	assert.Less(t, elapsed, 2*time.Second,
+		"popping %d values one at a time took %v", count, elapsed)
 }
 
 func TestSparseListEmpty(t *testing.T) {


### PR DESCRIPTION
Description
-----------

Uploading console output got slower as a run printed more lines. The loop that
takes buffered lines recomputed the end of the buffer on every iteration, and
each line removed invalidated that value, so the work grew with the square of
the number of buffered lines. Measured: 0.3s for 10,000 buffered lines, 1.3s for
20,000, and 7.5s for 50,000. Only the total size of the buffer is capped, not
the number of lines, so a chatty run reaches these counts.

The recomputed bound was redundant, because the loop already stops at the first
gap. Removing it makes the scan linear.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test asserting the scan still returns the same values for the
interesting shapes: empty, a single item, a run followed by a gap, and a run
ending at the last position.

`go test -race ./internal/sparselist/... ./internal/filestream/...` passes.
