### PR TITLE
fix(sdk): stop resending the whole run config for every image logged with masks or boxes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -62,3 +62,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Pointing a `wandb.Table` column at its own table now reports a clear error instead of failing with `RecursionError` when the table is logged (@dmitryduev in https://github.com/wandb/wandb/pull/12403)
 - Adding rows to a `wandb.Table` that links to another table is much faster; the time it took grew with the number of rows already added (@dmitryduev in https://github.com/wandb/wandb/pull/12404)
 - Uploading console output is much faster for runs that print many lines (@dmitryduev in https://github.com/wandb/wandb/pull/12405)
+- Logging images with segmentation masks or bounding boxes no longer re-sends the entire run configuration for every image, which could make the local run files many times larger than needed (@dmitryduev in https://github.com/wandb/wandb/pull/12406)

--- a/tests/unit_tests/test_wandb_run.py
+++ b/tests/unit_tests/test_wandb_run.py
@@ -142,6 +142,23 @@ def test_run_publish_config(mock_run, parse_records, record_q):
     assert config[1]["t2"] == "2"
 
 
+def test_add_singleton_publishes_config_only_on_change(
+    mock_run, parse_records, record_q
+):
+    run = mock_run()
+    key = "img_wandb_delimeter_mask"
+
+    run._add_singleton("mask/class_labels", key, {1: "car"})
+    run._add_singleton("mask/class_labels", key, {1: "car"})
+    run._add_singleton("mask/class_labels", key, {1: "car"})
+
+    assert len(parse_records(record_q).config) == 1
+
+    run._add_singleton("mask/class_labels", key, {1: "truck"})
+
+    assert len(parse_records(record_q).config) == 1
+
+
 def test_run_publish_history(mock_run, parse_records, record_q):
     run = mock_run()
     run.log(dict(this=1))

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1699,7 +1699,7 @@ class Run:
         if data_type not in self._config["_wandb"]:
             self._config["_wandb"][data_type] = {}
 
-        if data_type in self._config["_wandb"][data_type]:
+        if key in self._config["_wandb"][data_type]:
             old_value = self._config["_wandb"][data_type][key]
         else:
             old_value = None


### PR DESCRIPTION
Description
-----------

Logging an image with segmentation masks or bounding boxes re-sent the entire
run configuration every time, because the check meant to skip that when nothing
changed compared the wrong value and never matched. The docstring already
promised the value is only re-sent when it changes.

Measured end to end on an offline run logging masks: 87.7% of the run's local
data file was duplicate configuration, and the file is 6.5x smaller with the
fix, with the same final configuration. Offline users pay for that again in sync
time.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test asserting that logging the same mask labels repeatedly sends the
configuration once, and that changing the value sends it again.

Confirmed it fails without the fix. Nothing covered this before.
