### PR TITLE
fix(sdk): clean up properly when run.finish() is interrupted

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -63,3 +63,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Adding rows to a `wandb.Table` that links to another table is much faster; the time it took grew with the number of rows already added (@dmitryduev in https://github.com/wandb/wandb/pull/12404)
 - Uploading console output is much faster for runs that print many lines (@dmitryduev in https://github.com/wandb/wandb/pull/12405)
 - Logging images with segmentation masks or bounding boxes no longer re-sends the entire run configuration for every image, which could make the local run files many times larger than needed (@dmitryduev in https://github.com/wandb/wandb/pull/12406)
+- Interrupting `run.finish()`, such as with Ctrl-C, now cleans up the run properly; afterwards the run could not be finished again and its log file stayed open (@dmitryduev in https://github.com/wandb/wandb/pull/12407)

--- a/tests/unit_tests/test_wandb_run.py
+++ b/tests/unit_tests/test_wandb_run.py
@@ -253,6 +253,35 @@ def test_run_pub_history(mock_run, record_q, parse_records):
     assert history[1]["that"] == "2"
 
 
+def test_finish_tears_down_when_cleanup_fails(mock_run, mocker):
+    run = mock_run()
+    # "unsafe" allows mocking assert_service(), whose name looks like an
+    # assertion method to MagicMock.
+    library = mocker.MagicMock(unsafe=True)
+    run._set_library(library)
+    hook = mocker.Mock()
+    run._set_teardown_hooks(
+        [
+            wandb_run.TeardownHook(
+                call=hook,
+                stage=wandb_run.TeardownStage.LATE,
+            )
+        ]
+    )
+    mocker.patch.object(run, "_atexit_cleanup", side_effect=Exception("boom"))
+
+    with pytest.raises(Exception, match="boom"):
+        run.finish()
+
+    hook.assert_called_once_with()
+    assert run._teardown_hooks == []
+    library.assert_service().inform_finish.assert_called_once_with(run_id=run.id)
+
+    run.finish()
+
+    hook.assert_called_once_with()
+
+
 def test_use_artifact_offline(mock_run):
     run = mock_run(settings=wandb.Settings(mode="offline"))
     with pytest.raises(Exception) as e_info:

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -2412,21 +2412,27 @@ class Run:
         try:
             self._atexit_cleanup(exit_code=exit_code)
 
+        finally:
             # Run hooks that should happen after the last messages to the
             # internal service, like detaching the logger.
             for hook in self._teardown_hooks:
                 if hook.stage == TeardownStage.LATE:
-                    hook.call()
+                    try:
+                        hook.call()
+                    except Exception:
+                        logger.exception("Problem running teardown hook")
             self._teardown_hooks = []
 
             # Inform the service that we're done sending messages for this run.
             #
             # TODO: Why not do this in _atexit_cleanup()?
             if self._settings.run_id:
-                service = self._wl.assert_service()
-                service.inform_finish(run_id=self._settings.run_id)
+                try:
+                    service = self._wl.assert_service()
+                    service.inform_finish(run_id=self._settings.run_id)
+                except Exception:
+                    logger.exception("Problem informing service that run finished")
 
-        finally:
             if wandb.run is self:
                 module.unset_globals()
             get_sentry().end_session()


### PR DESCRIPTION
Description
-----------

If something interrupted `run.finish()`, usually Ctrl-C during the final upload
or the uploading process dying, the run was left half-finished with no way to
recover it in that program. The flags marking the run finished were set before
the work that can fail, and the cleanup steps were not in a `finally`, so the
run's log handler was never removed and its file stayed open, and calling
`finish()` again did nothing at all because the run already counted as finished.

Cleanup now runs in the `finally`, with each step guarded so a cleanup failure
cannot hide the original error.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test asserting that when the finishing step raises, the cleanup still
runs and the run is not left in a state where finishing again silently does
nothing.

Confirmed it fails without the fix.
