### PR TITLE
fix(sdk): avoid re-reading image files from disk when logging a list of images

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -64,3 +64,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Uploading console output is much faster for runs that print many lines (@dmitryduev in https://github.com/wandb/wandb/pull/12405)
 - Logging images with segmentation masks or bounding boxes no longer re-sends the entire run configuration for every image, which could make the local run files many times larger than needed (@dmitryduev in https://github.com/wandb/wandb/pull/12406)
 - Interrupting `run.finish()`, such as with Ctrl-C, now cleans up the run properly; afterwards the run could not be finished again and its log file stayed open (@dmitryduev in https://github.com/wandb/wandb/pull/12407)
+- Logging a list of images no longer reads every image file from disk a second time (@dmitryduev in https://github.com/wandb/wandb/pull/12408)

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -348,6 +348,31 @@ def test_image_seq_to_json(
 
 
 @pytest.mark.usefixtures("patch_max_cli_version")
+def test_image_seq_to_json_does_not_reopen_files(
+    mock_run,
+    image,
+    monkeypatch,
+):
+    run = mock_run()
+    wb_images = [wandb.Image(image) for _ in range(3)]
+    for i, wb_image in enumerate(wb_images):
+        wb_image.bind_to_run(run, "test", 0, i)
+
+    opened_paths = []
+    original_open = Image.open
+
+    def counting_open(fp, *args, **kwargs):
+        opened_paths.append(fp)
+        return original_open(fp, *args, **kwargs)
+
+    monkeypatch.setattr(Image, "open", counting_open)
+    meta = wandb.Image.seq_to_json(wb_images, run, "test", 0)
+
+    assert opened_paths == []
+    assert (meta["width"], meta["height"]) == (28, 28)
+
+
+@pytest.mark.usefixtures("patch_max_cli_version")
 def test_max_images(mock_run):
     run = mock_run()
     large_image = np.random.randint(255, size=(10, 10))

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -673,11 +673,17 @@ class Image(BatchableMedia):
                 )
 
         num_images_to_log = len(seq)
-        width, height = seq[0].image.size  # type: ignore
+
+        def image_dimensions(image: Image) -> tuple[int, int]:
+            if image._width is not None and image._height is not None:
+                return image._width, image._height
+            return image.image.size  # type: ignore
+
+        width, height = image_dimensions(seq[0])
         format = jsons[0]["format"]
 
         def size_equals_image(image: Image) -> bool:
-            img_width, img_height = image.image.size  # type: ignore
+            img_width, img_height = image_dimensions(image)
             return img_width == width and img_height == height
 
         sizes_match = all(size_equals_image(img) for img in seq)


### PR DESCRIPTION
Description
-----------

Logging a list of images read every image file from disk and decoded it in full,
only to read its width and height, which were already recorded when the image
was created. It also kept the decoded pixels in memory. The single-image path
already used the recorded values; only the list path did not.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test asserting that serializing a list of images does not reopen the
files.

Confirmed it fails without the fix.
