### PR TITLE
fix(sdk): keep notebook code saving working after a failed wandb.init()

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -65,3 +65,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Logging images with segmentation masks or bounding boxes no longer re-sends the entire run configuration for every image, which could make the local run files many times larger than needed (@dmitryduev in https://github.com/wandb/wandb/pull/12406)
 - Interrupting `run.finish()`, such as with Ctrl-C, now cleans up the run properly; afterwards the run could not be finished again and its log file stayed open (@dmitryduev in https://github.com/wandb/wandb/pull/12407)
 - Logging a list of images no longer reads every image file from disk a second time (@dmitryduev in https://github.com/wandb/wandb/pull/12408)
+- After a failed `wandb.init()` in a notebook, later runs in the same session again save your notebook code and pause between cells (@dmitryduev in https://github.com/wandb/wandb/pull/12409)

--- a/tests/unit_tests/test_wandb_init.py
+++ b/tests/unit_tests/test_wandb_init.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 import wandb
+import wandb.jupyter
 
 
 def test_no_root_dir_access__uses_temp_dir(tmp_path, monkeypatch):
@@ -117,3 +118,70 @@ def test_temp_dir_cleanup_on_exit(tmp_path, monkeypatch):
     assert len(new_items) == 0, (
         f"New items detected in temp directory after run.finish() and wandb.teardown(): {[f['path'] for f in new_items]}."
     )
+
+
+class _FakeIPythonEvents:
+    def __init__(self):
+        self.registered = []
+        self.register_count = 0
+
+    def register(self, name, func):
+        self.register_count += 1
+        self.registered.append((name, func))
+
+    def unregister(self, name, func):
+        self.registered.remove((name, func))
+
+
+class _FakeIPythonDisplayPublisher:
+    def publish(self, data, metadata=None, **kwargs):
+        pass
+
+
+class _FakeIPythonShell:
+    def __init__(self):
+        self.events = _FakeIPythonEvents()
+        self.display_pub = _FakeIPythonDisplayPublisher()
+        self.execution_count = 1
+        self.history_manager = None
+
+
+def test_failed_init_unpatches_ipython(monkeypatch):
+    shell = _FakeIPythonShell()
+    original_publish = shell.display_pub.publish
+
+    class FakeNotebook:
+        def __init__(self, settings):
+            self.settings = settings
+            self.shell = shell
+
+        def save_ipynb(self):
+            return True
+
+        def save_history(self, run):
+            pass
+
+        def save_display(self, execution_count, data):
+            pass
+
+    def failing_init(self, *args, **kwargs):
+        raise RuntimeError("init failed")
+
+    monkeypatch.setattr("wandb.sdk.lib.ipython.in_jupyter", lambda: True)
+    monkeypatch.setattr(wandb.jupyter, "notebook_metadata", lambda silent: {})
+    monkeypatch.setattr(wandb.jupyter, "Notebook", FakeNotebook)
+    monkeypatch.setattr(
+        "wandb.sdk.wandb_init._WandbInit.init",
+        failing_init,
+    )
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError):
+            wandb.init(mode="offline")
+
+        assert not hasattr(shell.display_pub, "_orig_publish")
+        assert shell.display_pub.publish == original_publish
+        assert shell.events.registered == []
+
+    # Each attempt must be able to register its own hooks again.
+    assert shell.events.register_count == 4

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -629,10 +629,10 @@ class _WandbInit:
         if self.run:
             self.notebook.save_history(self.run)
 
-        if self.notebook.save_ipynb():
-            assert self.run is not None
-            res = self.run.log_code(root=None)
-            self._logger.info("saved code and history: %s", res)
+            if self.notebook.save_ipynb():
+                res = self.run.log_code(root=None)
+                self._logger.info("saved code and history: %s", res)
+
         self._logger.info("cleaning up jupyter logic")
 
         ipython = self.notebook.shell
@@ -1181,6 +1181,21 @@ def try_create_root_dir(settings: Settings) -> None:
     os.makedirs(settings.root_dir, exist_ok=True)
 
 
+def _teardown_failed_init(wi: _WandbInit | None) -> None:
+    """Undo the changes made by an unsuccessful `wandb.init()`.
+
+    Cleanup errors are logged and dropped so that they cannot hide the error
+    that caused `wandb.init()` to fail.
+    """
+    if wi is None:
+        return
+
+    try:
+        wi.teardown()
+    except Exception as e:
+        wi._logger.exception("error tearing down wandb.init()", exc_info=e)
+
+
 def init(  # noqa: C901
     entity: str | None = None,
     project: str | None = None,
@@ -1454,6 +1469,7 @@ def init(  # noqa: C901
         init_telemetry.feature.set_init_config = True
 
     wl: wandb_setup._WandbSetup | None = None
+    wi: _WandbInit | None = None
 
     try:
         wl = wandb_setup.singleton()
@@ -1537,10 +1553,12 @@ def init(  # noqa: C901
         if wl:
             wl._get_logger().warning("interrupted", exc_info=e)
 
+        _teardown_failed_init(wi)
         raise
 
     except Exception as e:
         if wl:
             wl._get_logger().exception("error in wandb.init()", exc_info=e)
 
+        _teardown_failed_init(wi)
         get_sentry().reraise(e)


### PR DESCRIPTION
Description
-----------

One failed `wandb.init()` in a notebook quietly degraded every later run in that
session. Setting up the notebook integration happens before the step that can
fail, and nothing undid it, so the display hook stayed installed. The guard that
decides whether to install it checks whether it is already there, so later
successful runs skipped installing their own hooks. Those runs then stopped
saving notebook code and session history, and stopped pausing between cells,
which inflates their runtime and system metrics. None of it is visible to the
user.

There was already a cleanup routine for this, whose docstring says it runs on
failed attempts, but nothing called it; the only caller was removed in an
earlier refactor. The failure paths now call it.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added a test asserting the notebook integration is undone after a failed
`wandb.init()`, so a later init installs its own hooks again.

Confirmed it fails without the fix.
