### PR TITLE
fix(sdk): exit quietly when the service process has already stopped

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -66,3 +66,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Interrupting `run.finish()`, such as with Ctrl-C, now cleans up the run properly; afterwards the run could not be finished again and its log file stayed open (@dmitryduev in https://github.com/wandb/wandb/pull/12407)
 - Logging a list of images no longer reads every image file from disk a second time (@dmitryduev in https://github.com/wandb/wandb/pull/12408)
 - After a failed `wandb.init()` in a notebook, later runs in the same session again save your notebook code and pause between cells (@dmitryduev in https://github.com/wandb/wandb/pull/12409)
+- Exiting a program no longer prints an error when the process that uploads data has already stopped (@dmitryduev in https://github.com/wandb/wandb/pull/12410)

--- a/tests/unit_tests/test_lib/test_service_connection.py
+++ b/tests/unit_tests/test_lib/test_service_connection.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from wandb.sdk.lib import asyncio_manager
+from wandb.sdk.lib.service import service_connection
+
+
+@pytest.fixture(autouse=True)
+def stub_finalizer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent the connection from starting a finalizer thread."""
+    monkeypatch.setattr(service_connection, "ServiceFinalizer", MagicMock())
+
+
+def make_connection(
+    asyncer: MagicMock,
+    proc: MagicMock,
+) -> service_connection.ServiceConnection:
+    return service_connection.ServiceConnection(
+        asyncer=asyncer,
+        client=MagicMock(),
+        proc=proc,
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionResetError("the service process is gone"),
+        asyncio_manager.ForkedError("this is a forked process"),
+    ],
+)
+def test_teardown_does_not_raise_if_publish_fails(error: Exception):
+    asyncer = MagicMock()
+    asyncer.run.side_effect = error
+    proc = MagicMock()
+
+    exit_code = make_connection(asyncer, proc).teardown(0)
+
+    assert exit_code is None
+    proc.kill.assert_not_called()
+    proc.join.assert_not_called()
+
+
+def test_teardown_returns_service_exit_code():
+    asyncer = MagicMock()
+    proc = MagicMock()
+    proc.join.return_value = 3
+
+    assert make_connection(asyncer, proc).teardown(0) == 3

--- a/wandb/sdk/lib/service/service_connection.py
+++ b/wandb/sdk/lib/service/service_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import logging
 import pathlib
 from collections.abc import Callable
 
@@ -17,6 +18,8 @@ from wandb.sdk.mailbox.mailbox_handle import MailboxHandle
 from . import service_process, service_token
 from .service_client import ServiceClient
 from .service_finalizer import ServiceFinalizer
+
+_logger = logging.getLogger(__name__)
 
 
 class WandbAttachFailedError(Exception):
@@ -355,11 +358,12 @@ class ServiceConnection:
         the service process, send a teardown message and wait for it to shut
         down.
 
-        This may only be called once.
+        This may only be called once. It does not raise if the service process
+        cannot be reached.
 
         Returns:
             The exit code of the service process, or None if the process was
-            not owned by this connection.
+            not owned by this connection or could not be shut down.
         """
         if self._torn_down:
             raise AssertionError("Already torn down.")
@@ -385,6 +389,13 @@ class ServiceConnection:
             await self._client.close()
 
         self._finalizer.close()
-        self._asyncer.run(publish_teardown_and_close)
+
+        try:
+            self._asyncer.run(publish_teardown_and_close)
+        except Exception:
+            # The process may already be gone, or we may be in a fork that
+            # doesn't own it, in which case it must be left running.
+            _logger.exception("Failed to shut down the service process.")
+            return None
 
         return self._proc.join()

--- a/wandb/sdk/wandb_setup.py
+++ b/wandb/sdk/wandb_setup.py
@@ -370,7 +370,10 @@ class _WandbSetup:
         else:
             internal_exit_code = None
 
-        self._asyncer.join()
+        try:
+            self._asyncer.join()
+        except asyncio_manager.ForkedError:
+            self._logger.info("Not joining the asyncio thread in a forked process.")
 
         if internal_exit_code not in (None, 0):
             sys.exit(internal_exit_code)


### PR DESCRIPTION
Description
-----------

Exiting a program printed `Exception ignored in atexit callback` and a traceback
when the process that uploads data had already stopped, and skipped waiting for
that process. The same error escaped the public `wandb.teardown()`, which the
sweep agent calls in its loop, so a stopped uploader could knock the agent out
of its loop. It also happened after a plain `os.fork()` with a perfectly healthy
uploader, because the child inherits the exit hook.

The shutdown message is now sent inside a guard that logs and returns, which is
already the documented result for "this process does not own the uploader".

Worth flagging for review: the obvious version of this fix is unsafe and is not
what this does. Killing the process on failure would, in the forked-child case,
kill the *parent's* live uploader and destroy its run, and waiting for it
unconditionally can deadlock against the uploader's own parent-process
watchdog.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Added `tests/unit_tests/test_lib/test_service_connection.py`, which did not
exist, with cases for a connection error and for the fork error, asserting
teardown returns rather than raising and that the process is never killed.

Confirmed they fail without the fix.
