### PR TITLE
fix(sdk): stop repeating the server feature query on every check

### DIFF
--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -651,6 +651,17 @@ def test_server_feature_checks(
         assert result == expected_result
 
 
+@pytest.mark.usefixtures("patch_apikey", "patch_prompt")
+def test_server_feature_checks_reuse_one_query(mock_service_api_with_enabled_features):
+    """Repeated feature checks reuse the features fetched by the first one."""
+    api = internal.InternalApi()
+
+    assert api._server_supports(ServerFeature.LARGE_FILENAMES) is True
+    assert api._server_supports(ServerFeature.ARTIFACT_TAGS) is False
+
+    assert mock_service_api_with_enabled_features.execute_graphql.call_count == 1
+
+
 def test_construct_use_artifact_query_with_every_field(mocker: MockerFixture):
     # Create mock internal API instance
     api = internal.InternalApi()

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -554,6 +554,9 @@ class Api:
         # NOTE: Avoid caching via `@cached_property`, due to undocumented
         # locking behavior before Python 3.12.
         # See: https://github.com/python/cpython/issues/87634
+        if self._server_features_cache is not None:
+            return self._server_features_cache
+
         query = SERVER_FEATURES_QUERY_GQL
         try:
             response = self.execute(query)


### PR DESCRIPTION
Description
-----------

The check for which features a server supports saved its answer but never read
it back, so every check made a fresh network round trip. The docstring already
describes it as cached. The guard was dropped in an earlier change and is
restored here.

Impact is small in practice, since the one path that repeats the check adds a
small query to a much larger file download, but the code was not doing what it
says.

- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable
(Not applicable: no user-visible behavior change.)

Testing
-------

Added a test asserting two checks on the same object issue one query.

Confirmed it fails without the fix. No changelog entry: the extra query is not
something a user would notice.
