### PR TITLE
chore: use an autouse fixture to unpatch tensorboard in tests

### DIFF
--- a/tests/system_tests/test_functional/test_tensorboard/conftest.py
+++ b/tests/system_tests/test_functional/test_tensorboard/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+import wandb
+
+
+@pytest.fixture(autouse=True)
+def unpatch_tensorboard():
+    yield
+
+    # Undo any TensorBoard patching after every test in this directory
+    # to prevent order dependence.
+    wandb.tensorboard.unpatch()

--- a/tests/system_tests/test_functional/test_tensorboard/test_keras_tb_callback.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_keras_tb_callback.py
@@ -86,5 +86,3 @@ def test_tb_callback(wandb_backend_spy: WandbBackendSpy):
 
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
-
-    wandb.tensorboard.unpatch()

--- a/tests/system_tests/test_functional/test_tensorboard/test_tensorboardX.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_tensorboardX.py
@@ -18,8 +18,6 @@ def test_add_scalar(wandb_backend_spy):
         assert summary["global_step"] == 10
         assert summary["loss"] == 9 / 64
 
-    wandb.tensorboard.unpatch()
-
 
 def test_add_image(wandb_backend_spy):
     with wandb.init(sync_tensorboard=True) as run:
@@ -40,8 +38,6 @@ def test_add_image(wandb_backend_spy):
         assert summary["example"]["width"] == 28
         assert summary["example"]["height"] == 28
         assert summary["example"]["format"] == "png"
-
-    wandb.tensorboard.unpatch()
 
 
 def test_add_gif(wandb_backend_spy):
@@ -65,5 +61,3 @@ def test_add_gif(wandb_backend_spy):
         assert summary["example"]["width"] == 1
         assert summary["example"]["height"] == 1
         assert summary["example"]["format"] == "gif"
-
-    wandb.tensorboard.unpatch()

--- a/tests/system_tests/test_functional/test_tensorboard/test_tf_summary.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_tf_summary.py
@@ -62,8 +62,6 @@ def test_histogram(wandb_backend_spy):
         assert summary["activations"]["_type"] == "histogram"
         assert summary["initial_weights"]["_type"] == "histogram"
 
-    wandb.tensorboard.unpatch()
-
 
 def test_image(wandb_backend_spy):
     with wandb.init(sync_tensorboard=True) as run:
@@ -90,8 +88,6 @@ def test_image(wandb_backend_spy):
         assert summary["grayscale_image"]["height"] == 8
         assert summary["grayscale_image"]["format"] == "png"
 
-    wandb.tensorboard.unpatch()
-
 
 def test_batch_images(wandb_backend_spy):
     with wandb.init(sync_tensorboard=True) as run:
@@ -114,8 +110,6 @@ def test_batch_images(wandb_backend_spy):
         assert summary["Training data"]["count"] == 5
         for file_name in summary["Training data"]["filenames"]:
             assert os.path.exists(f"{run.dir}/{file_name}")
-
-    wandb.tensorboard.unpatch()
 
 
 def test_scalar(wandb_backend_spy):
@@ -141,8 +135,6 @@ def test_scalar(wandb_backend_spy):
             # So we use pytest.approx to compare the values.
             assert history[step]["loss"] == pytest.approx(scalars[step])
 
-    wandb.tensorboard.unpatch()
-
 
 def test_add_pr_curve(wandb_backend_spy):
     with wandb.init(sync_tensorboard=True) as run:
@@ -166,7 +158,6 @@ def test_add_pr_curve(wandb_backend_spy):
         assert (
             config["_wandb"]["value"]["visualize"]["test_pr/pr_curves"] == PR_CURVE_SPEC
         )
-    wandb.tensorboard.unpatch()
 
 
 def test_add_pr_curve_plugin(wandb_backend_spy):
@@ -198,8 +189,6 @@ def test_add_pr_curve_plugin(wandb_backend_spy):
         summary = snapshot.summary(run_id=run.id)
         assert summary["global_step"] == 0
         assert summary["test_pr/pr_curves"]["_type"] == "table-file"
-
-    wandb.tensorboard.unpatch()
 
 
 def test_compat_tensorboard(wandb_backend_spy):
@@ -241,8 +230,6 @@ def test_compat_tensorboard(wandb_backend_spy):
         history = snapshot.history(run_id=run.id)
         assert len(history) == 10
 
-    wandb.tensorboard.unpatch()
-
 
 def test_tb_sync_with_explicit_step_and_log(
     wandb_backend_spy,
@@ -274,5 +261,3 @@ def test_tb_sync_with_explicit_step_and_log(
 
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # sync_tensorboard
-
-    wandb.tensorboard.unpatch()

--- a/tests/system_tests/test_functional/test_tensorboard/test_torch_tb.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_torch_tb.py
@@ -31,8 +31,6 @@ def test_add_scalar(wandb_backend_spy):
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
 
-    wandb.tensorboard.unpatch()
-
 
 def test_add_scalars(wandb_backend_spy):
     """Test adding multiple scalars to TensorBoard and syncing it to W&B."""
@@ -57,8 +55,6 @@ def test_add_scalars(wandb_backend_spy):
 
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
-
-    wandb.tensorboard.unpatch()
 
 
 def test_add_image(wandb_backend_spy):
@@ -85,8 +81,6 @@ def test_add_image(wandb_backend_spy):
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
 
-    wandb.tensorboard.unpatch()
-
 
 def test_add_gif(wandb_backend_spy):
     with wandb.init(sync_tensorboard=True) as run, SummaryWriter() as writer:
@@ -108,8 +102,6 @@ def test_add_gif(wandb_backend_spy):
         assert summary["example"]["width"] == 1
         assert summary["example"]["height"] == 1
         assert summary["example"]["format"] == "gif"
-
-    wandb.tensorboard.unpatch()
 
 
 def test_add_images(wandb_backend_spy):
@@ -137,8 +129,6 @@ def test_add_images(wandb_backend_spy):
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
 
-    wandb.tensorboard.unpatch()
-
 
 def test_add_histogram(wandb_backend_spy):
     """Test adding a histogram to TensorBoard and syncing it to W&B."""
@@ -161,8 +151,6 @@ def test_add_histogram(wandb_backend_spy):
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
 
-    wandb.tensorboard.unpatch()
-
 
 @pytest.mark.skip(reason="old style TensorBoard not implemented")
 def test_add_pr_curve(wandb_backend_spy):
@@ -182,8 +170,6 @@ def test_add_pr_curve(wandb_backend_spy):
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
 
-    wandb.tensorboard.unpatch()
-
 
 def test_add_pr_curve_wandb_core(wandb_backend_spy):
     """Test adding a precision-recall curve to TensorBoard and syncing it to W&B."""
@@ -201,5 +187,3 @@ def test_add_pr_curve_wandb_core(wandb_backend_spy):
 
         telemetry = snapshot.telemetry(run_id=run.id)
         assert 35 in telemetry["3"]  # tensorboard_sync
-
-    wandb.tensorboard.unpatch()


### PR DESCRIPTION
Replaces the repeated `wandb.tensorboard.unpatch()` statements that were in most tests (not all of them!) with an autouse fixture.