### PR TITLE
chore: deprecate `wandb sync --sync-tensorboard`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,6 +34,10 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb.init()` now reports the error it was retrying (such as a network error) when it times out, instead of a generic timeout message. The `init_timeout` setting now also bounds the backend's retries during run initialization (@skhanna-cw in https://github.com/wandb/wandb/pull/12216)
 - `wandb.Api().create_run_queue()`, `wandb.Api().create_custom_chart()`, and `wandb.Api().upsert_run_queue()` now raise `WandbApiFailedError` when the operation fails on the backend. (@jacobromero in https://github.com/wandb/wandb/pull/12307)
 
+## Deprecated
+
+- `wandb sync --sync-tensorboard` is deprecated and will be removed in a later release (@timoffex in https://github.com/wandb/wandb/pull/12419)
+
 ## Removed
 
 - Releases no longer include 32-bit Windows (`win32`) wheels; use 64-bit Python on Windows (@dmitryduev in https://github.com/wandb/wandb/pull/12267)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,10 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb.Api().create_run_queue()`, `wandb.Api().create_custom_chart()`, and `wandb.Api().upsert_run_queue()` now raise `WandbApiFailedError` when the operation fails on the backend. (@jacobromero in https://github.com/wandb/wandb/pull/12307)
 - Paginated artifact and registry query methods (`Api.artifacts()`, `Api.artifact_collections()`, `Api.registries()`, `Registries.collections()`, `Registries.versions()`, `Collections.versions()`, `Registry.collections()`, `Registry.versions()`, `Project.collections()`) now perform client-side validation of pagination arguments before attempting to fetch any results (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12101)
 
+## Deprecated
+
+- `wandb sync --sync-tensorboard` is deprecated and will be removed in a later release (@timoffex in https://github.com/wandb/wandb/pull/12419)
+
 ## Removed
 
 - Releases no longer include 32-bit Windows (`win32`) wheels; use 64-bit Python on Windows (@dmitryduev in https://github.com/wandb/wandb/pull/12267)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -830,6 +830,8 @@ def sync(
         )
     if skip_console:
         wandb.termwarn("--skip-console is deprecated and will be removed.")
+    if sync_tensorboard:
+        wandb.termwarn("--sync-tensorboard is deprecated and will be removed.")
 
     # Fail if any beta options are provided in legacy mode.
     bad_options: list[str] = []


### PR DESCRIPTION
Deprecates `wandb sync --sync-tensorboard`.

Based on SaaS telemetry, it is barely used. I had PR #12371 to replace it, but decided to delay this until there's a better `run.sync_tensorboard()` implementation, and the effort that would require (maybe a week or two, then continued maintenance) isn't justified by the usage of this CLI. I'd be happy to work on it if people express interest!