### PR TITLE
fix: resume keeps console and system metrics filestream offsets

### DIFF
--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -684,9 +684,10 @@ func (upserter *RunUpserter) lockedUpdateFromUpsert(
 	upserter.params.SweepID = nullify.ZeroIfNil(bucket.GetSweepName())
 
 	if lineCount := nullify.ZeroIfNil(bucket.GetHistoryLineCount()); lineCount > 0 {
-		upserter.params.FileStreamOffset = filestream.FileStreamOffsetMap{
-			filestream.HistoryChunk: lineCount,
+		if upserter.params.FileStreamOffset == nil {
+			upserter.params.FileStreamOffset = make(filestream.FileStreamOffsetMap)
 		}
+		upserter.params.FileStreamOffset[filestream.HistoryChunk] = lineCount
 	}
 
 	if project := bucket.GetProject(); project == nil {

--- a/core/internal/runupserter/runupserter_test.go
+++ b/core/internal/runupserter/runupserter_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/wandb/wandb/core/internal/featurechecker"
+	"github.com/wandb/wandb/core/internal/filestream"
 	"github.com/wandb/wandb/core/internal/gqlmock"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
 	"github.com/wandb/wandb/core/internal/runsyncstate"
@@ -311,6 +312,57 @@ func TestResume_ReusesSyncStateStartingStep(t *testing.T) {
 	// already uploaded more history, the pre-initialized value wins so that
 	// re-syncing doesn't shift steps forward.
 	assert.EqualValues(t, 6, run.StartingStep)
+}
+
+func TestResume_KeepsEventsAndOutputFileStreamOffsets(t *testing.T) {
+	mockClient := gqlmock.NewMockClient()
+	mockClient.StubMatchOnce(gqlmock.WithOpName("RunResumeStatus"), `{
+		"model": {
+			"bucket": {
+				"name": "run",
+				"id": "storage-id",
+				"historyLineCount": 3,
+				"eventsLineCount": 13,
+				"logLineCount": 15,
+				"historyTail": "[]",
+				"summaryMetrics": "{}",
+				"config": "{}",
+				"eventsTail": "[]",
+				"wandbConfig": "{\"t\": 1}"
+			}
+		}
+	}`)
+	mockClient.StubMatchOnce(gqlmock.WithOpName("UpsertBucket"), `{
+		"upsertBucket": {
+			"bucket": {
+				"id": "storage ID",
+				"name": "run ID",
+				"displayName": "display name",
+				"sweepName": "sweep ID",
+				"project": {
+					"name": "project name",
+					"entity": {"name": "entity name"}
+				},
+				"historyLineCount": 5
+			}
+		}
+	}`)
+
+	params := testParams(t)
+	params.GraphqlClientOrNil = mockClient
+	params.Settings = settings.From(&spb.Settings{Resume: wrapperspb.String("allow")})
+
+	upserter, err := runupserter.InitRun(runRecord(&spb.RunRecord{RunId: "run"}), params)
+	require.NoError(t, err)
+	defer upserter.Finish()
+
+	assert.Equal(t,
+		filestream.FileStreamOffsetMap{
+			filestream.HistoryChunk: 5,
+			filestream.EventsChunk:  13,
+			filestream.OutputChunk:  15,
+		},
+		upserter.FileStreamOffsets())
 }
 
 func TestNewRun_InitializesSyncStateStartingStep(t *testing.T) {


### PR DESCRIPTION
Description
-----------
When a run resumes, we send the `RunResumeStatus` GraphQL query; the server's reply includes historyLineCount, eventsLineCount, and logLineCount, i.e. how many lines of each filestream "file" (wandb-history.jsonl, wandb-events.jsonl, output.log) it has already ingested. Those become the starting offsets:

- `core/internal/runbranch/resume.go::processAllOffsets` turns the three counts into `params.FileStreamOffset`
- In `core/internal/stream/sender.go` those are passed to `fileStream.Start()` at run start

But between the resume query and filestream start, the response to the first `UpsertBucket` also reports a history line count, and `runupserter.go` replaced the entire recovered map with just {HistoryChunk: n}. 

(Corollary: the server has to have counted the previous session's lines by resume time, but counts materialize asynchronously, ~2-4s on a quiet day on SaaS (from some fiddling), so a resume within that window can still collide. Nothing the SDK can do about that.)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable
