### PR TITLE
chore: avoid double url.Error when using httplayers.WrapRoundTripper

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/google/wire v0.7.0
 	github.com/googleapis/gax-go/v2 v2.23.0
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/mattn/go-runewidth v0.0.27
@@ -128,7 +129,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.20 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/core/internal/httplayers/roundtripper.go
+++ b/core/internal/httplayers/roundtripper.go
@@ -1,6 +1,9 @@
 package httplayers
 
-import "net/http"
+import (
+	"net/http"
+	"net/url"
+)
 
 // WrapRoundTripper applies an HTTPWrapper to a RoundTripper.
 //
@@ -25,5 +28,18 @@ type wrappedRoundTripper struct {
 func (rt wrappedRoundTripper) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
-	return rt.fn(req)
+	resp, err := rt.fn(req)
+
+	// Unwrap url.Error, since http.Client.Do() will wrap this in a url.Error.
+	//
+	// HTTPDoFunc is meant to act like http.Client.Do(), so it's documented
+	// to return url.Error, but we're using it as a RoundTripper here, which
+	// isn't expected to return url.Error. Without unwrapping, errors look like:
+	//
+	// 	Post "https://api.wandb.ai/graphql": POST "https://api.wandb.ai/graphql": ...
+	if urlErr, ok := err.(*url.Error); ok {
+		err = urlErr.Err
+	}
+
+	return resp, err
 }

--- a/core/internal/httplayers/roundtripper_test.go
+++ b/core/internal/httplayers/roundtripper_test.go
@@ -1,0 +1,51 @@
+package httplayers_test
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/wandb/wandb/core/internal/httplayers"
+)
+
+type errorHTTPWrapper struct {
+	Err *url.Error
+}
+
+func (e errorHTTPWrapper) WrapHTTP(send HTTPDoFunc) HTTPDoFunc {
+	return func(req *http.Request) (*http.Response, error) {
+		return nil, e.Err
+	}
+}
+
+func TestWrapRoundTripper_UnwrapsURLError(t *testing.T) {
+	targetErr := errors.New("test error")
+	wrapper := errorHTTPWrapper{&url.Error{
+		Op:  http.MethodPost,
+		URL: "https://invalid",
+		Err: targetErr,
+	}}
+	client := cleanhttp.DefaultPooledClient()
+	client.Transport = WrapRoundTripper(
+		client.Transport,
+		wrapper,
+	)
+	request, err := http.NewRequest(
+		http.MethodPost,
+		"https://invalid",
+		http.NoBody,
+	)
+	require.NoError(t, err)
+
+	_, err = client.Do(request)
+
+	// Without unwrapping, the `Post "https://..."` part is doubled.
+	assert.Equal(t,
+		`Post "https://invalid": test error`,
+		err.Error())
+}


### PR DESCRIPTION
I was puzzling over the screenshot in https://coreweave.atlassian.net/browse/WB-38375 and realized that this is the cause of the verbose message. We should also change `credentials.go` to return a more concise error.