### PR TITLE
chore: remove wandb.tensorboard.log()

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,6 +28,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 - `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)
 - Registry search methods (`Api.registries()`, `.collections()`, `.versions()`) now validate filter field names, rejecting unsupported field names. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12182)
 
+### Removed
+
+- Removed `wandb.tensorboard.log()` / `wandb.tensorflow.log()` (@timoffex in https://github.com/wandb/wandb/pull/12423)
+
 ### Fixed
 
 - `Artifact.new_file` now works for artifacts uploaded with `wandb sync` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12437)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -37,6 +37,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 ## Removed
 
 - Releases no longer include 32-bit Windows (`win32`) wheels; use 64-bit Python on Windows (@dmitryduev in https://github.com/wandb/wandb/pull/12267)
+- Removed `wandb.tensorboard.log()` (@timoffex in https://github.com/wandb/wandb/pull/12423)
 
 ## Fixed
 

--- a/core/pkg/service_go_proto/wandb_telemetry.pb.go
+++ b/core/pkg/service_go_proto/wandb_telemetry.pb.go
@@ -1035,15 +1035,18 @@ type Feature struct {
 	SetRunTags          bool                   `protobuf:"varint,18,opt,name=set_run_tags,json=setRunTags,proto3" json:"set_run_tags,omitempty"`                            // user sets run name via wandb.run.tags = ...
 	SetConfigItem       bool                   `protobuf:"varint,19,opt,name=set_config_item,json=setConfigItem,proto3" json:"set_config_item,omitempty"`                   // users set key in run config via run.config.key
 	// or run.config["key"]
-	Launch                   bool `protobuf:"varint,20,opt,name=launch,proto3" json:"launch,omitempty"`                                                                         // run is created through wandb launch
-	TorchProfilerTrace       bool `protobuf:"varint,21,opt,name=torch_profiler_trace,json=torchProfilerTrace,proto3" json:"torch_profiler_trace,omitempty"`                     // wandb.profiler.torch_trace_handler() called
-	Sb3                      bool `protobuf:"varint,22,opt,name=sb3,proto3" json:"sb3,omitempty"`                                                                               // Using stable_baselines3 integration
-	InitReturnRun            bool `protobuf:"varint,24,opt,name=init_return_run,json=initReturnRun,proto3" json:"init_return_run,omitempty"`                                    // wandb.init() called in the same process returning previous run
-	LightgbmWandbCallback    bool `protobuf:"varint,25,opt,name=lightgbm_wandb_callback,json=lightgbmWandbCallback,proto3" json:"lightgbm_wandb_callback,omitempty"`            // lightgbm callback used
-	LightgbmLogSummary       bool `protobuf:"varint,26,opt,name=lightgbm_log_summary,json=lightgbmLogSummary,proto3" json:"lightgbm_log_summary,omitempty"`                     // lightgbm log summary used
-	CatboostWandbCallback    bool `protobuf:"varint,27,opt,name=catboost_wandb_callback,json=catboostWandbCallback,proto3" json:"catboost_wandb_callback,omitempty"`            // catboost callback used
-	CatboostLogSummary       bool `protobuf:"varint,28,opt,name=catboost_log_summary,json=catboostLogSummary,proto3" json:"catboost_log_summary,omitempty"`                     // catboost log summary used
-	TensorboardLog           bool `protobuf:"varint,29,opt,name=tensorboard_log,json=tensorboardLog,proto3" json:"tensorboard_log,omitempty"`                                   // wandb.tensorflow.log or wandb.tensorboard.log used
+	Launch                bool `protobuf:"varint,20,opt,name=launch,proto3" json:"launch,omitempty"`                                                              // run is created through wandb launch
+	TorchProfilerTrace    bool `protobuf:"varint,21,opt,name=torch_profiler_trace,json=torchProfilerTrace,proto3" json:"torch_profiler_trace,omitempty"`          // wandb.profiler.torch_trace_handler() called
+	Sb3                   bool `protobuf:"varint,22,opt,name=sb3,proto3" json:"sb3,omitempty"`                                                                    // Using stable_baselines3 integration
+	InitReturnRun         bool `protobuf:"varint,24,opt,name=init_return_run,json=initReturnRun,proto3" json:"init_return_run,omitempty"`                         // wandb.init() called in the same process returning previous run
+	LightgbmWandbCallback bool `protobuf:"varint,25,opt,name=lightgbm_wandb_callback,json=lightgbmWandbCallback,proto3" json:"lightgbm_wandb_callback,omitempty"` // lightgbm callback used
+	LightgbmLogSummary    bool `protobuf:"varint,26,opt,name=lightgbm_log_summary,json=lightgbmLogSummary,proto3" json:"lightgbm_log_summary,omitempty"`          // lightgbm log summary used
+	CatboostWandbCallback bool `protobuf:"varint,27,opt,name=catboost_wandb_callback,json=catboostWandbCallback,proto3" json:"catboost_wandb_callback,omitempty"` // catboost callback used
+	CatboostLogSummary    bool `protobuf:"varint,28,opt,name=catboost_log_summary,json=catboostLogSummary,proto3" json:"catboost_log_summary,omitempty"`          // catboost log summary used
+	// wandb.tensorflow.log or wandb.tensorboard.log used, in an old SDK.
+	//
+	// These functions have been removed.
+	TensorboardLog           bool `protobuf:"varint,29,opt,name=tensorboard_log,json=tensorboardLog,proto3" json:"tensorboard_log,omitempty"`
 	EstimatorHook            bool `protobuf:"varint,30,opt,name=estimator_hook,json=estimatorHook,proto3" json:"estimator_hook,omitempty"`                                      // wandb.tensorflow.WandbHook used
 	XgboostWandbCallback     bool `protobuf:"varint,31,opt,name=xgboost_wandb_callback,json=xgboostWandbCallback,proto3" json:"xgboost_wandb_callback,omitempty"`               // xgboost callback used
 	XgboostOldWandbCallback  bool `protobuf:"varint,32,opt,name=xgboost_old_wandb_callback,json=xgboostOldWandbCallback,proto3" json:"xgboost_old_wandb_callback,omitempty"`    // xgboost old callback used (to be depreciated)

--- a/tests/system_tests/test_functional/test_tensorboard/test_wandb_tb_log.py
+++ b/tests/system_tests/test_functional/test_tensorboard/test_wandb_tb_log.py
@@ -1,69 +1,9 @@
-"""Tests for wandb.tensorboard.log and wandb.tensorboard.WandbHook."""
+"""Tests for wandb.tensorflow.WandbHook."""
 
 import pytest
 import tensorflow as tf
 import wandb
 from tensorboard.compat.proto import summary_pb2
-
-
-def test_wandb_tf_log(wandb_backend_spy, assets_path):
-    with wandb.init(sync_tensorboard=True) as run:
-        summary_pb = open(assets_path("wandb_tensorflow_summary.pb"), "rb").read()
-        wandb.tensorboard.log(summary_pb)
-
-    with wandb_backend_spy.freeze() as snapshot:
-        assert len(snapshot.run_ids()) == 1
-
-        summary = snapshot.summary(run_id=run.id)
-        for tag in [
-            "layer1/activations",
-            "layer1/biases/summaries/histogram",
-            "layer1/weights/summaries/histogram",
-            "layer2/Wx_plus_b/pre_activations",
-            "layer2/activations",
-            "layer2/biases/summaries/histogram",
-            "layer2/weights/summaries/histogram",
-            "layer1/Wx_plus_b/pre_activations",
-        ]:
-            assert summary[tag]["_type"] == "histogram"
-
-        for tag, value in [
-            ("accuracy_1", 0.8799999952316284),
-            ("cross_entropy_1", 0.37727174162864685),
-            ("dropout/dropout_keep_probability", 0.8999999761581421),
-            ("layer1/biases/summaries/max", 0.12949132919311523),
-            ("layer1/biases/summaries/mean", 0.10085226595401764),
-            ("layer1/biases/summaries/min", 0.0768924281001091),
-            ("layer1/biases/summaries/stddev_1", 0.01017912570387125),
-            ("layer1/weights/summaries/max", 0.22247056663036346),
-            ("layer1/weights/summaries/mean", 0.00014527945313602686),
-            ("layer1/weights/summaries/min", -0.22323597967624664),
-            ("layer1/weights/summaries/stddev_1", 0.08832632750272751),
-            ("layer2/biases/summaries/max", 0.11211398988962173),
-            ("layer2/biases/summaries/mean", 0.09975100308656693),
-            ("layer2/biases/summaries/min", 0.0904880091547966),
-            ("layer2/biases/summaries/stddev_1", 0.006791393272578716),
-            ("layer2/weights/summaries/max", 0.21537037193775177),
-            ("layer2/weights/summaries/mean", -0.0023455708287656307),
-            ("layer2/weights/summaries/min", -0.22206202149391174),
-            ("layer2/weights/summaries/stddev_1", 0.08973880857229233),
-        ]:
-            assert summary[tag] == value
-
-        assert summary["input_reshape_input_image"]["_type"] == "images/separated"
-        assert summary["input_reshape_input_image"]["count"] == 10
-
-        telemetry = snapshot.telemetry(run_id=run.id)
-        assert 29 in telemetry["3"]  # wandb.tensorflow.log
-
-
-def test_no_init_error(assets_path):
-    with pytest.raises(
-        wandb.Error,
-        match=r"You must call `wandb.init\(\)` before calling `wandb.tensorflow.log`",
-    ):
-        summary_pb = open(assets_path("wandb_tensorflow_summary.pb"), "rb").read()
-        wandb.tensorboard.log(summary_pb)
 
 
 @pytest.mark.skipif(tf.__version__ >= "2.16.0", reason="tf.estimator is not supported")

--- a/wandb/integration/tensorboard/__init__.py
+++ b/wandb/integration/tensorboard/__init__.py
@@ -1,10 +1,9 @@
 """wandb integration tensorboard module."""
 
-from .log import _log, log, reset_state, tf_summary_to_dict
+from .log import _log, reset_state, tf_summary_to_dict
 from .monkeypatch import patch, unpatch
 
 __all__ = [
     "patch",
     "unpatch",
-    "log",
 ]

--- a/wandb/integration/tensorboard/log.py
+++ b/wandb/integration/tensorboard/log.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 import wandb
 import wandb.util
-from wandb.sdk.lib import telemetry
 
 if TYPE_CHECKING:
     import numpy as np
@@ -339,15 +338,3 @@ def _log(
             wandb.run._log(log_dict, commit=False)
     else:
         history._row_update(log_dict)
-
-
-def log(tf_summary_str_or_pb: Any, step: int = 0, namespace: str = "") -> None:
-    if wandb.run is None:
-        raise wandb.Error(
-            "You must call `wandb.init()` before calling `wandb.tensorflow.log`"
-        )
-
-    with telemetry.context() as tel:
-        tel.feature.tensorboard_log = True
-
-    _log(tf_summary_str_or_pb, namespace=namespace, step=step)

--- a/wandb/integration/tensorflow/__init__.py
+++ b/wandb/integration/tensorflow/__init__.py
@@ -1,5 +1,3 @@
 """api."""
 
-from wandb.integration.tensorboard import log
-
 from .estimator_hook import WandbHook

--- a/wandb/proto/wandb_telemetry.proto
+++ b/wandb/proto/wandb_telemetry.proto
@@ -157,15 +157,20 @@ message Feature {
   bool set_run_tags = 18;           // user sets run name via wandb.run.tags = ...
   bool set_config_item = 19;        // users set key in run config via run.config.key
   // or run.config["key"]
-  bool launch = 20;                       // run is created through wandb launch
-  bool torch_profiler_trace = 21;         // wandb.profiler.torch_trace_handler() called
-  bool sb3 = 22;                          // Using stable_baselines3 integration
-  bool init_return_run = 24;              // wandb.init() called in the same process returning previous run
-  bool lightgbm_wandb_callback = 25;      // lightgbm callback used
-  bool lightgbm_log_summary = 26;         // lightgbm log summary used
-  bool catboost_wandb_callback = 27;      // catboost callback used
-  bool catboost_log_summary = 28;         // catboost log summary used
-  bool tensorboard_log = 29;              // wandb.tensorflow.log or wandb.tensorboard.log used
+  bool launch = 20;                   // run is created through wandb launch
+  bool torch_profiler_trace = 21;     // wandb.profiler.torch_trace_handler() called
+  bool sb3 = 22;                      // Using stable_baselines3 integration
+  bool init_return_run = 24;          // wandb.init() called in the same process returning previous run
+  bool lightgbm_wandb_callback = 25;  // lightgbm callback used
+  bool lightgbm_log_summary = 26;     // lightgbm log summary used
+  bool catboost_wandb_callback = 27;  // catboost callback used
+  bool catboost_log_summary = 28;     // catboost log summary used
+
+  // wandb.tensorflow.log or wandb.tensorboard.log used, in an old SDK.
+  //
+  // These functions have been removed.
+  bool tensorboard_log = 29;
+
   bool estimator_hook = 30;               // wandb.tensorflow.WandbHook used
   bool xgboost_wandb_callback = 31;       // xgboost callback used
   bool xgboost_old_wandb_callback = 32;   // xgboost old callback used (to be depreciated)

--- a/xpu/src/wandb_internal.rs
+++ b/xpu/src/wandb_internal.rs
@@ -345,7 +345,9 @@ pub struct Feature {
     /// catboost log summary used
     #[prost(bool, tag = "28")]
     pub catboost_log_summary: bool,
-    /// wandb.tensorflow.log or wandb.tensorboard.log used
+    /// wandb.tensorflow.log or wandb.tensorboard.log used, in an old SDK.
+    ///
+    /// These functions have been removed.
     #[prost(bool, tag = "29")]
     pub tensorboard_log: bool,
     /// wandb.tensorflow.WandbHook used


### PR DESCRIPTION
Removes `wandb.tensorboard.log()`, which appears unused based on telemetry. I checked for uses in our codebase by searching for `wandb\.tensor(board|flow)\.log` and Python import statements that include "tensorboard" or "tensorflow".