### PR TITLE
fix: sync runs that changed their name, tags, or notes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -52,3 +52,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` validates api keys prior to saving to the `.netrc` file (@jacobromero in https://github.com/wandb/wandb/pull/12347)
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
+- `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)

--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -36,6 +36,7 @@ type RunReader struct {
 	updates     *RunSyncUpdates // modifications to make to records
 	live        bool            // "live" mode retries EOFs
 
+	seenRun  bool // whether we've processed a run record yet
 	seenExit bool // whether we've processed an exit record yet
 
 	logger       *observability.CoreLogger
@@ -159,7 +160,12 @@ func (r *RunReader) ProcessTransactionLog(ctx context.Context) (err error) {
 				return err
 			}
 
-		case record.GetRun() != nil:
+		// Only the first Run record initializes the run and gets a response.
+		// Later Run records, such as from changing the run's name, tags or
+		// notes, are updates and are handled like most other records.
+		case record.GetRun() != nil && !r.seenRun:
+			r.seenRun = true
+
 			// Fail early if initializing the run (UpsertBucket) fails.
 			err := r.waitForRunRecord(ctx, record)
 			if err != nil {

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -131,7 +131,8 @@ func exitRecord(code int32) *spb.Record {
 func isExitRecord(code int32) gomock.Matcher {
 	return gomock.Cond(
 		func(val any) bool {
-			return val.(*spb.Record).GetExit().ExitCode == code
+			exit := val.(*spb.Record).GetExit()
+			return exit != nil && exit.ExitCode == code
 		},
 	)
 }
@@ -277,59 +278,46 @@ func Test_ParsesInitFailure(t *testing.T) {
 }
 
 func Test_LaterRunRecordsDontWaitForResponse(t *testing.T) {
-	testCases := []struct {
-		Name   string
-		Update *spb.RunRecord
-	}{
-		{"DisplayName", &spb.RunRecord{DisplayName: "new name"}},
-		{"Tags", &spb.RunRecord{Tags: []string{"new tag"}}},
-		{"Notes", &spb.RunRecord{Notes: "new notes"}},
-	}
+	x := setup(t)
+	wandbFileWithRecords(t,
+		x.TransactionLog,
+		&spb.Record{
+			Num:        1,
+			RecordType: &spb.Record_Run{Run: &spb.RunRecord{}},
+		},
+		&spb.Record{
+			Num: 2,
+			RecordType: &spb.Record_Run{Run: &spb.RunRecord{
+				DisplayName: "new name",
+				Tags:        []string{"new tag"},
+				Notes:       "new notes",
+			}},
+		},
+		exitRecord(0),
+	)
+	runWork := &testWork{ID: 1}
+	runStartWork := &testWork{ID: 2}
+	runUpdateWork := &testWork{ID: 3}
+	exitWork := &testWork{ID: 4}
+	gomock.InOrder(
+		x.MockRecordParser.EXPECT().Parse(isRecordWithNumber(1)).Return(runWork),
+		x.MockRecordParser.EXPECT().Parse(isRunStartRequest()).Return(runStartWork),
+		x.MockRecordParser.EXPECT().Parse(isRecordWithNumber(2)).Return(runUpdateWork),
+		x.MockRecordParser.EXPECT().Parse(isExitRecord(0)).Return(exitWork),
+	)
+	// Only the first Run record and the Exit record get a response.
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
 
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			x := setup(t)
-			wandbFileWithRecords(t,
-				x.TransactionLog,
-				&spb.Record{
-					Num:        1,
-					RecordType: &spb.Record_Run{Run: &spb.RunRecord{}},
-				},
-				&spb.Record{
-					Num:        2,
-					RecordType: &spb.Record_Run{Run: tc.Update},
-				},
-				exitRecord(0),
-			)
-			runWork := &testWork{ID: 1}
-			runStartWork := &testWork{ID: 2}
-			runUpdateWork := &testWork{ID: 3}
-			exitWork := &testWork{ID: 4}
-			gomock.InOrder(
-				x.MockRecordParser.EXPECT().Parse(isRecordWithNumber(1)).Return(runWork),
-				x.MockRecordParser.EXPECT().Parse(isRunStartRequest()).Return(runStartWork),
-				x.MockRecordParser.EXPECT().Parse(isRecordWithNumber(2)).Return(runUpdateWork),
-				x.MockRecordParser.EXPECT().Parse(isExitRecord(0)).Return(exitWork),
-			)
-			// Only the first Run record and the Exit record get a response.
-			x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
-			x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
+	err := x.RunReader.ProcessTransactionLog(t.Context())
+	require.NoError(t, err)
 
-			// Fail instead of hanging forever if a response is awaited.
-			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-			defer cancel()
-
-			err := x.RunReader.ProcessTransactionLog(ctx)
-			require.NoError(t, err)
-
-			allWork := x.FakeRunWork.AllWork()
-			require.Len(t, allWork, 4)
-			assert.Equal(t,
-				[]runwork.WorkImpl{runWork, runStartWork, runUpdateWork, exitWork},
-				x.FakeRunWork.AllWorkImpls())
-			assert.Nil(t, allWork[2].Request)
-		})
-	}
+	allWork := x.FakeRunWork.AllWork()
+	require.Len(t, allWork, 4)
+	assert.Equal(t,
+		[]runwork.WorkImpl{runWork, runStartWork, runUpdateWork, exitWork},
+		x.FakeRunWork.AllWorkImpls())
+	assert.Nil(t, allWork[2].Request)
 }
 
 func Test_CreatesRunStartRequest(t *testing.T) {

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -276,6 +276,62 @@ func Test_ParsesInitFailure(t *testing.T) {
 	}
 }
 
+func Test_LaterRunRecordsDontWaitForResponse(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Update *spb.RunRecord
+	}{
+		{"DisplayName", &spb.RunRecord{DisplayName: "new name"}},
+		{"Tags", &spb.RunRecord{Tags: []string{"new tag"}}},
+		{"Notes", &spb.RunRecord{Notes: "new notes"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			x := setup(t)
+			wandbFileWithRecords(t,
+				x.TransactionLog,
+				&spb.Record{
+					Num:        1,
+					RecordType: &spb.Record_Run{Run: &spb.RunRecord{}},
+				},
+				&spb.Record{
+					Num:        2,
+					RecordType: &spb.Record_Run{Run: tc.Update},
+				},
+				exitRecord(0),
+			)
+			runWork := &testWork{ID: 1}
+			runStartWork := &testWork{ID: 2}
+			runUpdateWork := &testWork{ID: 3}
+			exitWork := &testWork{ID: 4}
+			gomock.InOrder(
+				x.MockRecordParser.EXPECT().Parse(isRecordWithNumber(1)).Return(runWork),
+				x.MockRecordParser.EXPECT().Parse(isRunStartRequest()).Return(runStartWork),
+				x.MockRecordParser.EXPECT().Parse(isRecordWithNumber(2)).Return(runUpdateWork),
+				x.MockRecordParser.EXPECT().Parse(isExitRecord(0)).Return(exitWork),
+			)
+			// Only the first Run record and the Exit record get a response.
+			x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
+			x.FakeRunWork.QueueResponse(&spb.ServerResponse{})
+
+			// Fail instead of hanging forever if a response is awaited.
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+
+			err := x.RunReader.ProcessTransactionLog(ctx)
+			require.NoError(t, err)
+
+			allWork := x.FakeRunWork.AllWork()
+			require.Len(t, allWork, 4)
+			assert.Equal(t,
+				[]runwork.WorkImpl{runWork, runStartWork, runUpdateWork, exitWork},
+				x.FakeRunWork.AllWorkImpls())
+			assert.Nil(t, allWork[2].Request)
+		})
+	}
+}
+
 func Test_CreatesRunStartRequest(t *testing.T) {
 	x := setup(t)
 	wandbFileWithRecords(t,

--- a/tests/system_tests/test_core/test_offline_sync_beta.py
+++ b/tests/system_tests/test_core/test_offline_sync_beta.py
@@ -187,6 +187,7 @@ def test_syncs_run(
         run.log({"test_sync": 321})
         run.save(test_file, base_path=test_file.parent)
         run.summary["test_sync_summary"] = "test summary"
+        run.notes = "test note"
 
     result = runner.invoke(cli.beta, f"sync {run.sync_dir}")
 


### PR DESCRIPTION
Description
-----------

For a run that produces more than one `RunRecord` (by setting `run.name`, `run.tags` or `run.notes` after starting), e.g. like this:

```python
import wandb

with wandb.init(mode="offline") as run:
    run.log({"x": 1})
    run.notes = "mah note"
```

`wandb sync` currently hangs forever. The reader now waits only for the first run record and forwards later ones as ordinary work, so name, tag and note changes still reach the server.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Just try the script above on main.

Note
----

Supersedes #12380, which GitHub auto-marked as merged into a feature branch during a stack reorder.
