### PR TITLE
fix: stop wandb clean from deleting runs newer than the age limit

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -54,3 +54,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
+- `wandb clean` no longer deletes runs created less than an hour ago, which it removed despite the 24 hour age limit it reported using (@dmitryduev in https://github.com/wandb/wandb/pull/12381)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -54,4 +54,3 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - The `global_step` metric created when syncing TensorBoard files is no longer prefixed, like `train/global_step`, so that it is easier to compare training and validation metrics (@timoffex in https://github.com/wandb/wandb/pull/12372)
 - The TensorBoard integration now produces fewer W&B steps by merging data for the same `global_step` into one W&B step when possible (@timoffex in https://github.com/wandb/wandb/pull/12414)
 - `wandb sync` no longer hangs on a run that set its name, tags, or notes after starting (@dmitryduev in https://github.com/wandb/wandb/pull/12380)
-- `wandb clean` no longer deletes runs created less than an hour ago, which it removed despite the 24 hour age limit it reported using (@dmitryduev in https://github.com/wandb/wandb/pull/12381)

--- a/tests/unit_tests/test_wandb_clean.py
+++ b/tests/unit_tests/test_wandb_clean.py
@@ -82,6 +82,42 @@ def test_counts_skipped_runs(wandb_dir: pathlib.Path, runner: CliRunner):
     ]
 
 
+@pytest.mark.usefixtures("now_20260805_3pm")
+def test_skips_runs_created_within_the_hour(
+    wandb_dir: pathlib.Path,
+    runner: CliRunner,
+):
+    wb = wandb_dir / "wandb"
+    online_run = wb / "run-20260805_143000-online"
+    offline_run = wb / "offline-run-20260805_143000-offline"
+    _mkrun(online_run)
+    _mkrun(offline_run, synced=True)
+
+    result = runner.invoke(clean.clean, ["--force"])
+
+    assert result.exit_code == 0
+    assert online_run.exists()
+    assert offline_run.exists()
+    assert result.output.splitlines() == [
+        "wandb: Skipping 2 run(s) created fewer than 24 hours ago.",
+        "wandb: Found no runs to clean up.",
+    ]
+
+
+@pytest.mark.usefixtures("now_20260805_3pm")
+def test_cleans_run_without_valid_timestamp(
+    wandb_dir: pathlib.Path,
+    runner: CliRunner,
+):
+    run = wandb_dir / "wandb" / "run-notatimestamp-abc"
+    _mkrun(run)
+
+    result = runner.invoke(clean.clean, ["--force"])
+
+    assert result.exit_code == 0
+    assert not run.exists()
+
+
 def test_finds_synced_runs(wandb_dir: pathlib.Path, runner: CliRunner):
     wb = wandb_dir / "wandb"
     _mkrun(wb / "offline-run-20260101_010101-1")

--- a/tests/unit_tests/test_wandb_clean.py
+++ b/tests/unit_tests/test_wandb_clean.py
@@ -104,20 +104,6 @@ def test_skips_runs_created_within_the_hour(
     ]
 
 
-@pytest.mark.usefixtures("now_20260805_3pm")
-def test_cleans_run_without_valid_timestamp(
-    wandb_dir: pathlib.Path,
-    runner: CliRunner,
-):
-    run = wandb_dir / "wandb" / "run-notatimestamp-abc"
-    _mkrun(run)
-
-    result = runner.invoke(clean.clean, ["--force"])
-
-    assert result.exit_code == 0
-    assert not run.exists()
-
-
 def test_finds_synced_runs(wandb_dir: pathlib.Path, runner: CliRunner):
     wb = wandb_dir / "wandb"
     _mkrun(wb / "offline-run-20260101_010101-1")

--- a/wandb/cli/clean.py
+++ b/wandb/cli/clean.py
@@ -179,7 +179,8 @@ def _select_runs_to_clean(
             term.termwarn(f"Not a directory: {online_run}")
             continue
 
-        if (age := _run_age_hours(now, online_run.name)) and age < min_hours:
+        age = _run_age_hours(now, online_run.name)
+        if age is not None and age < min_hours:
             result.skipped_too_new += 1
             continue
 
@@ -195,7 +196,8 @@ def _select_runs_to_clean(
             result.skipped_unsynced += 1
             continue
 
-        if (age := _run_age_hours(now, offline_run.name)) and age < min_hours:
+        age = _run_age_hours(now, offline_run.name)
+        if age is not None and age < min_hours:
             result.skipped_too_new += 1
             continue
 


### PR DESCRIPTION
Description
-----------

`wandb clean` deleted runs created less than an hour ago, while printing that it was skipping runs newer than the age limit. These are the runs most likely to still be active.

The age guard tested the run age for truthiness, and the age is a whole number of hours, so a run under an hour old had an age of 0 and fell straight through the guard.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Note
----

Supersedes #12381, which GitHub auto-marked as merged into a feature branch during a stack reorder.
