### PR TITLE
refactor: settings HTTP header methods

### DIFF
--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -27,7 +27,6 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"github.com/wandb/wandb/core/internal/api"
-	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/httplayers"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/version"
@@ -426,25 +425,15 @@ func newOTLPHTTPClient(
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.Proxy = clients.ProxyFn(
-		wandbSettings.GetHTTPProxy(),
-		wandbSettings.GetHTTPSProxy(),
-	)
+	transport.Proxy = wandbSettings.GetProxyFn()
+	transport.ProxyConnectHeader = wandbSettings.GetProxyConnectHeader()
 	if wandbSettings.IsInsecureDisableSSL() {
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
 	}
 
-	extraHeaders := make(http.Header, len(wandbSettings.GetExtraHTTPHeaders()))
-	for key, value := range wandbSettings.GetExtraHTTPHeaders() {
-		extraHeaders.Set(key, value)
-	}
-	if header := extraHeaders.Get("Proxy-Authorization"); header != "" {
-		transport.ProxyConnectHeader = http.Header{
-			"Proxy-Authorization": []string{header},
-		}
-	}
+	extraHeaders := wandbSettings.GetExtraHTTPHeaders()
 
 	client := &http.Client{
 		Timeout: defaultTimeout,

--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -4,6 +4,7 @@ package api
 import (
 	"crypto/tls"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"time"
@@ -87,7 +88,7 @@ type ClientOptions struct {
 	// of the request URL.
 	//
 	// Request headers take precedence.
-	ExtraHeaders map[string]string
+	ExtraHeaders http.Header
 
 	// Allows the client to peek at the network traffic, can perform any action
 	// on the request and response. Need to make sure that the response body is
@@ -106,6 +107,13 @@ type ClientOptions struct {
 	//
 	// If Proxy is nil or returns a nil *URL, no proxy will be used.
 	Proxy func(*http.Request) (*url.URL, error)
+
+	// ProxyConnectHeader configures headers sent to proxies during CONNECT
+	// requests.
+	//
+	// This is often set to a Proxy-Authorization header, which is used to
+	// authenticate with a proxy (separately from the target server).
+	ProxyConnectHeader http.Header
 
 	// Whether to disable SSL certificate verification.
 	//
@@ -153,19 +161,9 @@ func NewClient(opts ClientOptions) RetryableClient {
 		slog.LevelDebug,
 	)
 
-	// Set the Proxy function on the HTTP client.
 	transport := &http.Transport{
-		Proxy: opts.Proxy,
-	}
-	// Set the "Proxy-Authorization" header for the CONNECT requests
-	// to the proxy server if the header is present in the extra headers.
-	//
-	// It is necessary if the proxy server uses TLS for the connection
-	// and requires authentication using a scheme other than "Basic".
-	if header := opts.ExtraHeaders["Proxy-Authorization"]; header != "" {
-		transport.ProxyConnectHeader = http.Header{
-			"Proxy-Authorization": []string{header},
-		}
+		Proxy:              opts.Proxy,
+		ProxyConnectHeader: opts.ProxyConnectHeader,
 	}
 
 	if opts.InsecureDisableSSL {
@@ -176,9 +174,7 @@ func NewClient(opts ClientOptions) RetryableClient {
 
 	extraHeaders := make(http.Header, len(opts.ExtraHeaders)+1)
 	extraHeaders.Set("User-Agent", "wandb-core")
-	for header, value := range opts.ExtraHeaders {
-		extraHeaders.Set(header, value)
-	}
+	maps.Copy(extraHeaders, opts.ExtraHeaders)
 
 	wandbOnlyLayers := httplayers.LimitTo(opts.BaseURL, httplayers.Concat(
 		opts.CredentialProvider,

--- a/core/internal/api/api_test.go
+++ b/core/internal/api/api_test.go
@@ -30,8 +30,8 @@ func TestDo(t *testing.T) {
 		ApiKey:  &wrapperspb.StringValue{Value: "test_api_key"},
 	})
 	client := newClient(t, settings, api.ClientOptions{
-		ExtraHeaders: map[string]string{
-			"ClientHeader": "xyz",
+		ExtraHeaders: http.Header{
+			"ClientHeader": []string{"xyz"},
 		},
 	})
 
@@ -116,15 +116,15 @@ func TestDo_ExtraHeaders(t *testing.T) {
 	testCases := []struct {
 		name           string
 		path           string
-		extraHeaders   map[string]string
+		extraHeaders   http.Header
 		requestHeaders map[string]string
 		wantHeaders    map[string]string
 	}{
 		{
 			name: "ToWandb",
 			path: "/wandb/xyz",
-			extraHeaders: map[string]string{
-				"X-EXTRA-HEADER": "xyz",
+			extraHeaders: http.Header{
+				"X-EXTRA-HEADER": []string{"xyz"},
 			},
 			wantHeaders: map[string]string{
 				"Authorization":  "Basic YXBpOnRlc3RfYXBpX2tleQ==",
@@ -135,8 +135,8 @@ func TestDo_ExtraHeaders(t *testing.T) {
 		{
 			name: "NotToWandb",
 			path: "/notwandb/xyz",
-			extraHeaders: map[string]string{
-				"X-EXTRA-HEADER": "xyz",
+			extraHeaders: http.Header{
+				"X-EXTRA-HEADER": []string{"xyz"},
 			},
 			wantHeaders: map[string]string{
 				"Authorization":  "", // not set
@@ -227,11 +227,14 @@ func TestNewClientWithProxy(t *testing.T) {
 		RetryWaitMin:    1 * time.Second,
 		RetryWaitMax:    5 * time.Second,
 		NonRetryTimeout: api.DefaultNonRetryTimeout,
-		ExtraHeaders: map[string]string{
-			"Proxy-Authorization": "Basic dXNlcjpwYXNz",
+		ExtraHeaders: http.Header{
+			"Proxy-Authorization": []string{"Basic dXNlcjpwYXNz"},
 		},
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return proxyParsedURL, nil
+		},
+		ProxyConnectHeader: http.Header{
+			"Proxy-Authorization": []string{"Basic dXNlcjpwYXNz"},
 		},
 
 		CredentialProvider: credentialProvider,

--- a/core/internal/api/credentials.go
+++ b/core/internal/api/credentials.go
@@ -79,14 +79,17 @@ func NewCredentialProvider(
 		// The exchange must not use a credential provider: supplying its
 		// credentials is what it is being used to make possible.
 		exchangeClient := NewClient(ClientOptions{
-			BaseURL:            baseURL,
-			RetryMax:           TokenExchangeRetryMax,
-			RetryWaitMin:       tokenExchangeRetryWaitMin,
-			RetryWaitMax:       tokenExchangeRetryWaitMax,
-			RetryPolicy:        TokenExchangeRetryPolicy,
-			NonRetryTimeout:    tokenExchangeAttemptTimeout,
-			ExtraHeaders:       s.GetExtraHTTPHeaders(),
-			Proxy:              clients.ProxyFn(s.GetHTTPProxy(), s.GetHTTPSProxy()),
+			BaseURL:         baseURL,
+			RetryMax:        TokenExchangeRetryMax,
+			RetryWaitMin:    tokenExchangeRetryWaitMin,
+			RetryWaitMax:    tokenExchangeRetryWaitMax,
+			RetryPolicy:     TokenExchangeRetryPolicy,
+			NonRetryTimeout: tokenExchangeAttemptTimeout,
+			ExtraHeaders:    s.GetExtraHTTPHeaders(),
+
+			Proxy:              s.GetProxyFn(),
+			ProxyConnectHeader: s.GetProxyConnectHeader(),
+
 			InsecureDisableSSL: s.IsInsecureDisableSSL(),
 			CredentialProvider: NoopCredentialProvider{},
 			Logger:             logger,

--- a/core/internal/api/gql_client.go
+++ b/core/internal/api/gql_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/http"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -19,7 +20,7 @@ func NewGQLClient(
 	logger *slog.Logger,
 	peeker Peeker,
 	s *settings.Settings,
-	extraHeaders map[string]string,
+	extraHeaders http.Header,
 ) graphql.Client {
 	// TODO: This is used for the service account feature to associate the run
 	// with the specified user. Note that we are using environment variables
@@ -32,10 +33,9 @@ func NewGQLClient(
 	// We should consider using the settings object here. But we need to make
 	// sure that the username setting is populated correctly. Leaving this as is
 	// for now just to avoid breakage in the service account feature.
-	graphqlHeaders := map[string]string{
-		"X-WANDB-USERNAME":   s.GetUserName(),
-		"X-WANDB-USER-EMAIL": s.GetEmail(),
-	}
+	graphqlHeaders := make(http.Header, len(extraHeaders)+2)
+	graphqlHeaders.Set("X-WANDB-USERNAME", s.GetUserName())
+	graphqlHeaders.Set("X-WANDB-USER-EMAIL", s.GetEmail())
 	maps.Copy(graphqlHeaders, extraHeaders)
 
 	opts := ClientOptions{
@@ -47,10 +47,10 @@ func NewGQLClient(
 		NonRetryTimeout: DefaultNonRetryTimeout,
 		ExtraHeaders:    graphqlHeaders,
 		NetworkPeeker:   peeker,
-		Proxy: clients.ProxyFn(
-			s.GetHTTPProxy(),
-			s.GetHTTPSProxy(),
-		),
+
+		Proxy:              s.GetProxyFn(),
+		ProxyConnectHeader: s.GetProxyConnectHeader(),
+
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 		CredentialProvider: credentialProvider,
 		Logger:             logger,

--- a/core/internal/settings/settings.go
+++ b/core/internal/settings/settings.go
@@ -2,12 +2,15 @@
 package settings
 
 import (
+	"net/http"
+	"net/url"
 	"path/filepath"
 	"sync"
 	"time"
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/wandb/wandb/core/internal/clients"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -223,8 +226,17 @@ func (s *Settings) IsFileStreamGzipEnabled() bool {
 }
 
 // Additional headers to add to all outgoing HTTP requests.
-func (s *Settings) GetExtraHTTPHeaders() map[string]string {
-	return s.Proto.XExtraHttpHeaders.GetValue()
+func (s *Settings) GetExtraHTTPHeaders() http.Header {
+	extraHeaders := s.Proto.XExtraHttpHeaders.GetValue()
+	if len(extraHeaders) == 0 {
+		return nil
+	}
+
+	h := make(http.Header, len(extraHeaders))
+	for key, value := range extraHeaders {
+		h.Set(key, value)
+	}
+	return h
 }
 
 // Maximum number of retries for filestream operations.
@@ -303,14 +315,27 @@ func (s *Settings) GetGraphQLTimeout() time.Duration {
 		s.Proto.XGraphqlTimeoutSeconds.GetValue())
 }
 
-// Custom proxy for http requests to W&B.
-func (s *Settings) GetHTTPProxy() string {
-	return s.Proto.HttpProxy.GetValue()
+// Custom proxy for HTTP and HTTPS requests to W&B.
+func (s *Settings) GetProxyFn() func(*http.Request) (*url.URL, error) {
+	return clients.ProxyFn(
+		s.Proto.HttpProxy.GetValue(),
+		s.Proto.HttpsProxy.GetValue(),
+	)
 }
 
-// Custom proxy for https requests to W&B.
-func (s *Settings) GetHTTPSProxy() string {
-	return s.Proto.HttpsProxy.GetValue()
+// Header to send on CONNECT requests to proxies, generally for authorization.
+func (s *Settings) GetProxyConnectHeader() http.Header {
+	authHeaderKey := http.CanonicalHeaderKey("Proxy-Authorization")
+
+	for key, value := range s.Proto.XExtraHttpHeaders.GetValue() {
+		if http.CanonicalHeaderKey(key) == authHeaderKey && value != "" {
+			h := http.Header{}
+			h.Set(authHeaderKey, value)
+			return h
+		}
+	}
+
+	return nil
 }
 
 // Whether to disable SSL verification.

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -5,6 +5,7 @@ package stream
 import (
 	"fmt"
 	"maps"
+	"net/http"
 	"net/url"
 
 	"github.com/Khan/genqlient/graphql"
@@ -74,20 +75,20 @@ func NewGraphQLClient(
 		return nil
 	}
 
-	extraHeaders := make(map[string]string)
+	extraHeaders := http.Header{}
 	maps.Copy(extraHeaders, s.GetExtraHTTPHeaders())
 
 	// This header is used to indicate to the backend that the run is in shared
 	// mode to prevent a race condition when two UpsertRun requests are made
 	// simultaneously for the same run ID in shared mode.
 	if s.IsSharedMode() {
-		extraHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
-		extraHeaders["X-WANDB-CLIENT-ID"] = string(clientID)
+		extraHeaders.Set("X-WANDB-USE-ASYNC-FILESTREAM", "true")
+		extraHeaders.Set("X-WANDB-CLIENT-ID", string(clientID))
 	}
 	// When enabled, this header instructs the backend to compute the derived summary
 	// using history updates, instead of relying on the SDK to calculate and send it.
 	if s.IsEnableServerSideDerivedSummary() {
-		extraHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
+		extraHeaders.Set("X-WANDB-SERVER-SIDE-DERIVED-SUMMARY", "true")
 	}
 
 	return api.NewGQLClient(
@@ -115,14 +116,14 @@ func NewFileStream(
 		return nil
 	}
 
-	fileStreamHeaders := map[string]string{}
+	fileStreamHeaders := http.Header{}
 	maps.Copy(fileStreamHeaders, s.GetExtraHTTPHeaders())
 	if s.IsSharedMode() {
-		fileStreamHeaders["X-WANDB-USE-ASYNC-FILESTREAM"] = "true"
-		fileStreamHeaders["X-WANDB-ASYNC-CLIENT-ID"] = string(clientID)
+		fileStreamHeaders.Set("X-WANDB-USE-ASYNC-FILESTREAM", "true")
+		fileStreamHeaders.Set("X-WANDB-ASYNC-CLIENT-ID", string(clientID))
 	}
 	if s.IsEnableServerSideDerivedSummary() {
-		fileStreamHeaders["X-WANDB-SERVER-SIDE-DERIVED-SUMMARY"] = "true"
+		fileStreamHeaders.Set("X-WANDB-SERVER-SIDE-DERIVED-SUMMARY", "true")
 	}
 
 	opts := api.ClientOptions{
@@ -134,10 +135,10 @@ func NewFileStream(
 		NonRetryTimeout: filestream.DefaultNonRetryTimeout,
 		ExtraHeaders:    fileStreamHeaders,
 		NetworkPeeker:   peeker,
-		Proxy: clients.ProxyFn(
-			s.GetHTTPProxy(),
-			s.GetHTTPSProxy(),
-		),
+
+		Proxy:              s.GetProxyFn(),
+		ProxyConnectHeader: s.GetProxyConnectHeader(),
+
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 		CredentialProvider: credentialProvider,
 		Logger:             logger.Logger,
@@ -190,10 +191,8 @@ func NewFileTransferManager(
 		RetryWaitMax:    filetransfer.DefaultRetryWaitMax,
 		NonRetryTimeout: filetransfer.DefaultNonRetryTimeout,
 
-		Proxy: clients.ProxyFn(
-			s.GetHTTPProxy(),
-			s.GetHTTPSProxy(),
-		),
+		Proxy:              s.GetProxyFn(),
+		ProxyConnectHeader: s.GetProxyConnectHeader(),
 
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/wandb/wandb/core/internal/api"
-	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/featurechecker"
 	"github.com/wandb/wandb/core/internal/filetransfer"
 	"github.com/wandb/wandb/core/internal/observability"
@@ -140,10 +139,8 @@ func newFileTransferClient(
 		RetryWaitMax:    filetransfer.DefaultRetryWaitMax,
 		NonRetryTimeout: filetransfer.DefaultNonRetryTimeout,
 
-		Proxy: clients.ProxyFn(
-			s.GetHTTPProxy(),
-			s.GetHTTPSProxy(),
-		),
+		Proxy:              s.GetProxyFn(),
+		ProxyConnectHeader: s.GetProxyConnectHeader(),
 
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 		ExtraHeaders:       s.GetExtraHTTPHeaders(),

--- a/core/pkg/artifacts/downloader.go
+++ b/core/pkg/artifacts/downloader.go
@@ -43,7 +43,7 @@ type ArtifactDownloader struct {
 	// HTTP client for downloading manifest json.
 	httpClient   *retryablehttp.Client
 	logger       *observability.CoreLogger
-	extraHeaders map[string]string
+	extraHeaders http.Header
 }
 
 func NewArtifactDownloader(
@@ -51,7 +51,7 @@ func NewArtifactDownloader(
 	graphQLClient graphql.Client,
 	downloadManager filetransfer.FileTransferManager,
 	logger *observability.CoreLogger,
-	extraHeaders map[string]string,
+	extraHeaders http.Header,
 	artifactID string,
 	downloadRoot string,
 	allowMissingReferences bool,
@@ -126,11 +126,7 @@ func (ad *ArtifactDownloader) downloadManifestFromURL(
 	if err != nil {
 		return Manifest{}, fmt.Errorf("create request failed: %v", err)
 	}
-
-	// Apply extra headers
-	for k, v := range ad.extraHeaders {
-		req.Header.Set(k, v)
-	}
+	maps.Copy(req.Header, ad.extraHeaders)
 
 	resp, err := ad.httpClient.Do(req)
 	if err != nil {

--- a/core/pkg/artifacts/downloader_test.go
+++ b/core/pkg/artifacts/downloader_test.go
@@ -90,7 +90,7 @@ func getFakeArtifactDownloader(
 		gqlClient,
 		ftm,
 		observabilitytest.NewTestLogger(t),
-		map[string]string{},
+		http.Header{},
 		fakeArtifactID,
 		"",
 		false,
@@ -142,14 +142,14 @@ func TestDownload(t *testing.T) {
 func verifyHeadersInRequest(
 	t *testing.T,
 	r *http.Request,
-	expectedHeaders map[string]string,
+	expectedHeaders http.Header,
 ) {
 	t.Helper()
 	for key, expectedValue := range expectedHeaders {
 		assert.Equal(
 			t,
 			expectedValue,
-			r.Header.Get(key),
+			r.Header.Values(key),
 			"Header %s should have value %s",
 			key,
 			expectedValue,
@@ -170,10 +170,9 @@ func TestGetArtifactManifest_WithExtraHeaders(t *testing.T) {
 		}
 	}`
 
-	extraHeaders := map[string]string{
-		"X-Custom-Header-1": "value1",
-		"X-Custom-Header-2": "value2",
-	}
+	extraHeaders := http.Header{}
+	extraHeaders.Set("X-Custom-Header-1", "value1")
+	extraHeaders.Set("X-Custom-Header-2", "value2")
 
 	// Create HTTP test server that verifies headers and returns manifest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Makes `settings.GetExtraHTTPHeaders()` return `http.Header`, replaces `GetHTTPProxy()` and `GetHTTPSProxy()` by `GetProxyFn()`, and adds `GetProxyConnectHeader()`.