### PR TITLE
refactor: rename httplayers.ExtraHeaders to DefaultHeaders

### DIFF
--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -441,7 +441,7 @@ func newOTLPHTTPClient(
 	client.Transport = httplayers.WrapRoundTripper(
 		transport,
 		httplayers.Concat(
-			httplayers.ExtraHeaders(extraHeaders),
+			httplayers.DefaultHeaders(extraHeaders),
 			credentialProvider,
 		),
 	)

--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -170,7 +170,7 @@ func newRoundTripper(opts ClientOptions) http.RoundTripper {
 
 	return httplayers.WrapRoundTripper(transport, httplayers.Concat(
 		// Add the User-Agent header only if it's not set by a preceding layer.
-		httplayers.ExtraHeaders(userAgentHeader),
+		httplayers.DefaultHeaders(userAgentHeader),
 		opts.PreRetryLayers,
 	))
 }

--- a/core/internal/api/api_test.go
+++ b/core/internal/api/api_test.go
@@ -21,7 +21,7 @@ func TestDo(t *testing.T) {
 	defer server.Close()
 
 	client := api.NewClient(api.ClientOptions{
-		PreRetryLayers: httplayers.ExtraHeaders(http.Header{
+		PreRetryLayers: httplayers.DefaultHeaders(http.Header{
 			"ClientHeader": []string{"xyz"},
 		}),
 	})

--- a/core/internal/api/credentials.go
+++ b/core/internal/api/credentials.go
@@ -86,7 +86,7 @@ func NewCredentialProvider(
 			InsecureDisableSSL: s.IsInsecureDisableSSL(),
 			Logger:             logger,
 
-			PreRetryLayers: httplayers.ExtraHeaders(s.GetExtraHTTPHeaders()),
+			PreRetryLayers: httplayers.DefaultHeaders(s.GetExtraHTTPHeaders()),
 		})
 
 		return NewOAuth2CredentialProvider(

--- a/core/internal/api/gql_client.go
+++ b/core/internal/api/gql_client.go
@@ -51,7 +51,7 @@ func NewGQLClient(
 		Logger:             logger,
 		PreRetryLayers: httplayers.Concat(
 			NetworkPeeker(peeker),
-			httplayers.ExtraHeaders(graphqlHeaders),
+			httplayers.DefaultHeaders(graphqlHeaders),
 			httplayers.LimitTo(baseURL, credentialProvider),
 		),
 	}

--- a/core/internal/httplayers/headers.go
+++ b/core/internal/httplayers/headers.go
@@ -2,19 +2,17 @@ package httplayers
 
 import "net/http"
 
-// ExtraHeaders adds default headers to every request.
-//
-// Headers already present on the request are preserved.
-func ExtraHeaders(headers http.Header) HTTPWrapper {
-	return extraHeaders{headers}
+// DefaultHeaders sets headers not present on a request to default values.
+func DefaultHeaders(headers http.Header) HTTPWrapper {
+	return defaultHeaders{headers}
 }
 
-type extraHeaders struct {
+type defaultHeaders struct {
 	headers http.Header
 }
 
 // WrapHTTP implements HTTPWrapper.WrapHTTP.
-func (h extraHeaders) WrapHTTP(send HTTPDoFunc) HTTPDoFunc {
+func (h defaultHeaders) WrapHTTP(send HTTPDoFunc) HTTPDoFunc {
 	if len(h.headers) == 0 {
 		return send
 	}

--- a/core/internal/httplayers/headers_test.go
+++ b/core/internal/httplayers/headers_test.go
@@ -24,7 +24,7 @@ func TestExtraHeaders_AddsMissingHeaders(t *testing.T) {
 	require.NoError(t, err)
 	req.Header = nil
 
-	wrapped := httplayers.ExtraHeaders(newHeader(map[string]string{
+	wrapped := httplayers.DefaultHeaders(newHeader(map[string]string{
 		"X-EXTRA-HEADER": "extra-header-value",
 	})).WrapHTTP(func(req *http.Request) (*http.Response, error) {
 		assert.Equal(t, "extra-header-value", req.Header.Get("X-EXTRA-HEADER"))
@@ -41,7 +41,7 @@ func TestExtraHeaders_PreservesExistingHeaders(t *testing.T) {
 	req.Header.Set("Authorization", "request-authorization")
 	req.Header.Set("NOT-CASE-SENSITIVE", "request-value")
 
-	wrapped := httplayers.ExtraHeaders(newHeader(map[string]string{
+	wrapped := httplayers.DefaultHeaders(newHeader(map[string]string{
 		"Authorization":      "extra-authorization-value",
 		"X-EXTRA-HEADER":     "extra-header-value",
 		"not-case-sensitive": "extra-value",

--- a/core/internal/httplayers/httplayers_test.go
+++ b/core/internal/httplayers/httplayers_test.go
@@ -25,12 +25,12 @@ func TestConcat(t *testing.T) {
 
 	wrapper := httplayers.Concat(
 		nil, // test that nils are safely ignored
-		httplayers.ExtraHeaders(http.Header{
+		httplayers.DefaultHeaders(http.Header{
 			http.CanonicalHeaderKey("x-test1"): []string{"inner1"},
 			http.CanonicalHeaderKey("x-test2"): []string{"inner2"},
 		}),
 		nil,
-		httplayers.ExtraHeaders(http.Header{
+		httplayers.DefaultHeaders(http.Header{
 			http.CanonicalHeaderKey("x-test2"): []string{"outer2"},
 			http.CanonicalHeaderKey("x-test3"): []string{"outer3"},
 		}),

--- a/core/internal/stream/stream_init.go
+++ b/core/internal/stream/stream_init.go
@@ -140,7 +140,7 @@ func NewFileStream(
 
 		PreRetryLayers: httplayers.Concat(
 			api.NetworkPeeker(peeker),
-			httplayers.ExtraHeaders(fileStreamHeaders),
+			httplayers.DefaultHeaders(fileStreamHeaders),
 			httplayers.LimitTo(baseURL, httplayers.Concat(
 				credentialProvider,
 				api.ResponseBasedRateLimiter(),
@@ -199,7 +199,7 @@ func NewFileTransferManager(
 
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 
-		PreRetryLayers: httplayers.ExtraHeaders(s.GetExtraHTTPHeaders()),
+		PreRetryLayers: httplayers.DefaultHeaders(s.GetExtraHTTPHeaders()),
 	}
 
 	if retryMax := s.GetFileTransferMaxRetries(); retryMax > 0 {

--- a/core/internal/wbapi/wbapi.go
+++ b/core/internal/wbapi/wbapi.go
@@ -145,7 +145,7 @@ func newFileTransferClient(
 		InsecureDisableSSL: s.IsInsecureDisableSSL(),
 
 		PreRetryLayers: httplayers.Concat(
-			httplayers.ExtraHeaders(s.GetExtraHTTPHeaders()),
+			httplayers.DefaultHeaders(s.GetExtraHTTPHeaders()),
 			httplayers.LimitTo(baseURL, credentialProvider),
 		),
 	}


### PR DESCRIPTION
PR #11620 changed the semantics of `ExtraHeaders` but left the name, and I got tripped up by it when thinking through the precedence of headers in `api.NewClient`.