### PR TITLE
security: keep API key out of the process list when running docker commands

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -65,3 +65,4 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 ## Security
 
 - Debug logs no longer contain CoreWeave cluster credentials (@dmitryduev in https://github.com/wandb/wandb/pull/12385)
+- `wandb docker` and `wandb docker-run` no longer pass your API key on the command line, where other users of the same machine could read it (@dmitryduev in https://github.com/wandb/wandb/pull/12443)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -36,7 +36,7 @@ def docker(request, mocker, monkeypatch):
 
     def new_call(command, **kwargs):
         if command[0] == "docker":
-            return docker(command)
+            return docker(command, **kwargs)
         else:
             return old_call(command, **kwargs)
 
@@ -118,13 +118,14 @@ def test_docker_run_digest(runner, docker, monkeypatch):
             "docker",
             "run",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "-e",
             f"WANDB_DOCKER={DOCKER_SHA}",
             "--runtime",
             "nvidia",
             f"{DOCKER_SHA}",
-        ]
+        ],
+        env=mock.ANY,
     )
 
 
@@ -136,11 +137,12 @@ def test_docker_run_bad_image(runner, docker, monkeypatch):
             "docker",
             "run",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "--runtime",
             "nvidia",
             "wandb///foo$",
-        ]
+        ],
+        env=mock.ANY,
     )
 
 
@@ -153,13 +155,14 @@ def test_docker_run_no_nvidia(runner, docker, monkeypatch):
             "docker",
             "run",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "-e",
             "WANDB_DOCKER=wandb/deepo@sha256:abc123",
             "-v",
             "cool:/cool",
             "rad",
-        ]
+        ],
+        env=mock.ANY,
     )
 
 
@@ -173,7 +176,7 @@ def test_docker_run_nvidia(runner, docker):
             "docker",
             "run",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "-e",
             "WANDB_DOCKER=wandb/deepo@sha256:abc123",
             "--runtime",
@@ -183,8 +186,28 @@ def test_docker_run_nvidia(runner, docker):
             "rad",
             "/bin/bash",
             "cool",
-        ]
+        ],
+        env=mock.ANY,
     )
+
+
+def test_docker_run_api_key_not_in_args(runner, docker, mocker, monkeypatch):
+    mocker.patch(
+        "wandb.apis.InternalApi.api_key",
+        new_callable=mocker.PropertyMock,
+        return_value="fake-api-key",
+    )
+    monkeypatch.setenv("DOCKER_HOST", "tcp://localhost:2375")
+
+    result = runner.invoke(cli.docker_run, ["rad"])
+
+    assert result.exit_code == 0
+    command = docker.call_args.args[0]
+    assert "WANDB_API_KEY" in command
+    assert not any("fake-api-key" in arg for arg in command)
+    env = docker.call_args.kwargs["env"]
+    assert env["WANDB_API_KEY"] == "fake-api-key"
+    assert env["DOCKER_HOST"] == "tcp://localhost:2375"
 
 
 def test_docker(runner, docker):
@@ -208,11 +231,12 @@ def test_docker(runner, docker):
                 "-w",
                 "/app",
                 "-e",
-                "WANDB_API_KEY=test",
+                "WANDB_API_KEY",
                 "-it",
                 "test",
                 "/bin/bash",
-            ]
+            ],
+            env=mock.ANY,
         )
         assert result.exit_code == 0
 
@@ -238,11 +262,12 @@ def test_docker_basic(runner, docker, git_repo):
             "-w",
             "/app",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "-it",
             "test:abc123",
             "/bin/bash",
-        ]
+        ],
+        env=mock.ANY,
     )
     assert result.exit_code == 0
 
@@ -267,11 +292,12 @@ def test_docker_sha(runner, docker):
             "-w",
             "/app",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "-it",
             "test@sha256:abc123",
             "/bin/bash",
-        ]
+        ],
+        env=mock.ANY,
     )
     assert result.exit_code == 0
 
@@ -292,11 +318,12 @@ def test_docker_no_dir(runner, docker):
             "--entrypoint",
             "/wandb-entrypoint.sh",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "-it",
             "test:abc123",
             "/bin/bash",
-        ]
+        ],
+        env=mock.ANY,
     )
     assert result.exit_code == 0
 
@@ -325,12 +352,13 @@ def test_docker_no_interactive_custom_command(runner, docker, git_repo):
             "-w",
             "/app",
             "-e",
-            "WANDB_API_KEY=test",
+            "WANDB_API_KEY",
             "test:abc123",
             "/bin/bash",
             "-c",
             "python foo.py",
-        ]
+        ],
+        env=mock.ANY,
     )
     assert result.exit_code == 0
 
@@ -356,7 +384,7 @@ def test_docker_jupyter(runner, docker):
                 "-w",
                 "/app",
                 "-e",
-                "WANDB_API_KEY=test",
+                "WANDB_API_KEY",
                 "-e",
                 "WANDB_ENSURE_JUPYTER=1",
                 "-p",
@@ -368,7 +396,8 @@ def test_docker_jupyter(runner, docker):
                     "jupyter lab --no-browser --ip=0.0.0.0 --allow-root "
                     "--NotebookApp.token= --notebook-dir /app"
                 ),
-            ]
+            ],
+            env=mock.ANY,
         )
         assert result.exit_code == 0
 
@@ -394,16 +423,37 @@ def test_docker_args(runner, docker):
                 "-w",
                 "/app",
                 "-e",
-                "WANDB_API_KEY=test",
+                "WANDB_API_KEY",
                 "test",
                 "-v",
                 "/tmp:/tmp",
                 "-it",
                 "wandb/deepo:all-cpu",
                 "/bin/bash",
-            ]
+            ],
+            env=mock.ANY,
         )
         assert result.exit_code == 0
+
+
+def test_docker_api_key_not_in_args(runner, docker, mocker, monkeypatch):
+    mocker.patch(
+        "wandb.apis.InternalApi.api_key",
+        new_callable=mocker.PropertyMock,
+        return_value="fake-api-key",
+    )
+    monkeypatch.setenv("DOCKER_HOST", "tcp://localhost:2375")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli.docker, ["test"], input="n")
+
+    assert result.exit_code == 0
+    command = docker.call_args.args[0]
+    assert "WANDB_API_KEY" in command
+    assert not any("fake-api-key" in arg for arg in command)
+    env = docker.call_args.kwargs["env"]
+    assert env["WANDB_API_KEY"] == "fake-api-key"
+    assert env["DOCKER_HOST"] == "tcp://localhost:2375"
 
 
 def test_docker_digest(runner, docker):
@@ -435,7 +485,8 @@ def test_local_default(runner, docker, local_settings):
                 f"LOCAL_USERNAME={user}",
                 "-d",
                 "wandb/local",
-            ]
+            ],
+            stdout=subprocess.DEVNULL,
         )
 
 
@@ -460,7 +511,8 @@ def test_local_custom_port(runner, docker, local_settings):
             f"LOCAL_USERNAME={user}",
             "-d",
             "wandb/local",
-        ]
+        ],
+        stdout=subprocess.DEVNULL,
     )
 
 
@@ -487,7 +539,8 @@ def test_local_custom_env(runner, docker, local_settings):
             "FOO=bar",
             "-d",
             "wandb/local",
-        ]
+        ],
+        stdout=subprocess.DEVNULL,
     )
 
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -2539,13 +2539,15 @@ def docker_run(ctx, docker_run_args):
         wandb.termlog(
             "Couldn't detect image argument, running command without the WANDB_DOCKER env variable"
         )
+    env = dict(os.environ)
     if api.api_key:
-        args = ["-e", f"WANDB_API_KEY={api.api_key}"] + args
+        args = ["-e", "WANDB_API_KEY"] + args
+        env["WANDB_API_KEY"] = api.api_key
     else:
         wandb.termlog(
             "Not logged in, run `wandb login` from the host machine to enable result logging"
         )
-    subprocess.call(["docker", "run"] + args)
+    subprocess.call(["docker", "run"] + args, env=env)
 
 
 @cli.command(context_settings=RUN_CONTEXT)
@@ -2677,8 +2679,10 @@ def docker(
     if not no_dir:
         #  TODO: We should default to the working directory if defined
         command.extend(["-v", cwd + ":" + dir, "-w", dir])
+    env = dict(os.environ)
     if api.api_key:
-        command.extend(["-e", f"WANDB_API_KEY={api.api_key}"])
+        command.extend(["-e", "WANDB_API_KEY"])
+        env["WANDB_API_KEY"] = api.api_key
     else:
         wandb.termlog(
             "Couldn't find WANDB_API_KEY, run `wandb login` to enable streaming metrics"
@@ -2695,7 +2699,7 @@ def docker(
             command.extend(["-e", f"WANDB_COMMAND={cmd}"])
         command.extend(["-it", image, shell])
         wandb.termlog("Launching docker container \U0001f6a2")
-    subprocess.call(command)
+    subprocess.call(command, env=env)
 
 
 @cli.command(


### PR DESCRIPTION
Description
-----------

`wandb docker` and `wandb docker-run` passed your API key as a command line argument to `docker`, so any other user on the same machine could read it from the process list for as long as the container ran 😱 🙀 😱 🙀 