### PR TITLE
fix: wandb sync syncs the remaining runs when one run cannot be read

### DIFF
--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -137,6 +137,10 @@ func (op *RunSyncOperation) Do(
 
 // initAndPlan inits all syncers and returns the order in which to run them.
 //
+// Syncers that fail to initialize, such as for an unreadable .wandb file, are
+// reported to the user and left out of the plan. An error is only returned if
+// the operation is cancelled.
+//
 // The return value is a map from run paths to lists of syncers.
 // Different paths can be synced independently, but all syncers for the same
 // path must run in order. This happens when syncing multiple resumed
@@ -153,7 +157,14 @@ func (op *RunSyncOperation) initAndPlan(
 	for _, syncer := range op.syncers {
 		info, err := syncer.Init(ctx)
 		if err != nil {
-			return nil, err
+			// Don't report every remaining file if the operation is over.
+			if ctx.Err() != nil {
+				return nil, err
+			}
+
+			LogSyncFailure(op.logger, err)
+			op.printer.Errorf("%s", ToUserText(err))
+			continue
 		}
 
 		runPath := info.Path()


### PR DESCRIPTION
Description
-----------

One unreadable run directory stopped `wandb sync` entirely, so a user recovering a directory of offline runs after a crash saw a single error and got nothing synced.