### PR TITLE
fix(artifacts): stop a download that skips the cache from affecting later downloads

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -61,6 +61,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - `wandb login` no longer removes or corrupts credentials belonging to other machines in your `.netrc` file (@dmitryduev in https://github.com/wandb/wandb/pull/12386)
 - Log messages captured from Python loggers no longer add blank lines to a run's logs (@dmitryduev in https://github.com/wandb/wandb/pull/12387)
 - `del run.summary[key]` now removes metrics that were logged as nested values, which it previously ignored (@dmitryduev in https://github.com/wandb/wandb/pull/12389)
+- `artifact.download(skip_cache=True)` no longer silently keeps a pre-existing file that has the right size but the wrong contents, such as a file from an older version of the artifact. Previously, the wrong file was also remembered as correct, so re-downloading did not replace it either (@dmitryduev in https://github.com/wandb/wandb/pull/12445)
 
 ## Security
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -62,6 +62,7 @@ The `wandb sync --clean` command now exits with code 1 and prints a hint to use 
 - Log messages captured from Python loggers no longer add blank lines to a run's logs (@dmitryduev in https://github.com/wandb/wandb/pull/12387)
 - `del run.summary[key]` now removes metrics that were logged as nested values, which it previously ignored (@dmitryduev in https://github.com/wandb/wandb/pull/12389)
 - `artifact.download(skip_cache=True)` no longer silently keeps a pre-existing file that has the right size but the wrong contents, such as a file from an older version of the artifact. Previously, the wrong file was also remembered as correct, so re-downloading did not replace it either (@dmitryduev in https://github.com/wandb/wandb/pull/12445)
+- Downloading an artifact with `skip_cache=True` no longer changes where later downloads in the same process are written (@dmitryduev in https://github.com/wandb/wandb/pull/12446)
 
 ## Security
 

--- a/core/internal/runsync/runsyncoperation.go
+++ b/core/internal/runsync/runsyncoperation.go
@@ -137,6 +137,10 @@ func (op *RunSyncOperation) Do(
 
 // initAndPlan inits all syncers and returns the order in which to run them.
 //
+// Syncers that fail to initialize, such as for an unreadable .wandb file, are
+// reported to the user and left out of the plan. An error is only returned if
+// the operation is cancelled.
+//
 // The return value is a map from run paths to lists of syncers.
 // Different paths can be synced independently, but all syncers for the same
 // path must run in order. This happens when syncing multiple resumed
@@ -153,7 +157,14 @@ func (op *RunSyncOperation) initAndPlan(
 	for _, syncer := range op.syncers {
 		info, err := syncer.Init(ctx)
 		if err != nil {
-			return nil, err
+			// Don't report every remaining file if the operation is over.
+			if ctx.Err() != nil {
+				return nil, err
+			}
+
+			LogSyncFailure(op.logger, err)
+			op.printer.Errorf("%s", ToUserText(err))
+			continue
 		}
 
 		runPath := info.Path()

--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -125,6 +125,15 @@ def test_check_md5_obj_path_override(artifact_file_cache):
     assert exists is False
 
 
+def test_check_md5_obj_path_override_is_never_a_hit(artifact_file_cache, tmp_path):
+    dest_path = tmp_path / "dest.txt"
+    dest_path.write_text("EXAMPLE")  # Same size as "example", different contents.
+
+    artifact_file_cache._override_cache_path = dest_path
+    _, exists, _ = artifact_file_cache.check_md5_obj_path(example_digest, 7)
+    assert exists is False
+
+
 def test_check_etag_obj_path_points_to_opener_dst(artifact_file_cache):
     path, _, opener = artifact_file_cache.check_etag_obj_path(
         "http://my/url", "abc", 10
@@ -143,6 +152,16 @@ def test_check_etag_obj_path_override(artifact_file_cache):
     artifact_file_cache._override_cache_path = override_path
     path, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", 2)
     assert path == override_path
+    assert exists is False
+
+
+def test_check_etag_obj_path_override_is_never_a_hit(artifact_file_cache, tmp_path):
+    size = 123
+    dest_path = tmp_path / "dest.txt"
+    dest_path.write_text(size * "b")
+
+    artifact_file_cache._override_cache_path = dest_path
+    _, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", size)
     assert exists is False
 
 

--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -11,7 +11,10 @@ from pydantic import ValidationError
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest import mark, raises
 from wandb.sdk.artifacts.artifact import Artifact
-from wandb.sdk.artifacts.artifact_file_cache import ArtifactFileCache
+from wandb.sdk.artifacts.artifact_file_cache import (
+    ArtifactFileCache,
+    get_artifact_file_cache,
+)
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.artifacts.storage_handler import StorageHandler, _BaseStorageHandler
@@ -84,9 +87,8 @@ def test_opener_works_across_filesystem_boundaries(
     assert excinfo.value.args[0] == errno.EXDEV
 
     # Now simulate skipping the cache
-    artifact_file_cache._override_cache_path = dest_path
     override_path, _, override_opener = artifact_file_cache.check_md5_obj_path(
-        example_digest, 7
+        example_digest, 7, override_path=dest_path
     )
 
     with override_opener() as f:
@@ -119,8 +121,9 @@ def test_check_md5_obj_path(artifact_file_cache):
 def test_check_md5_obj_path_override(artifact_file_cache):
     md5 = md5_string("hi")
     override_path = os.path.join(artifact_file_cache._cache_dir, "override.cache")
-    artifact_file_cache._override_cache_path = override_path
-    path, exists, _ = artifact_file_cache.check_md5_obj_path(md5, 2)
+    path, exists, _ = artifact_file_cache.check_md5_obj_path(
+        md5, 2, override_path=override_path
+    )
     assert path == override_path
     assert exists is False
 
@@ -129,9 +132,21 @@ def test_check_md5_obj_path_override_is_never_a_hit(artifact_file_cache, tmp_pat
     dest_path = tmp_path / "dest.txt"
     dest_path.write_text("EXAMPLE")  # Same size as "example", different contents.
 
-    artifact_file_cache._override_cache_path = dest_path
-    _, exists, _ = artifact_file_cache.check_md5_obj_path(example_digest, 7)
+    _, exists, _ = artifact_file_cache.check_md5_obj_path(
+        example_digest, 7, override_path=dest_path
+    )
     assert exists is False
+
+
+def test_check_md5_obj_path_override_does_not_persist(artifact_file_cache):
+    md5 = md5_string("hi")
+    override_path = os.path.join(artifact_file_cache._cache_dir, "override.cache")
+    artifact_file_cache.check_md5_obj_path(md5, 2, override_path=override_path)
+
+    # A later, unrelated lookup on the same (process-wide) cache must be unaffected.
+    assert get_artifact_file_cache() is artifact_file_cache
+    path, _, _ = get_artifact_file_cache().check_md5_obj_path(md5, 2)
+    assert path != override_path
 
 
 def test_check_etag_obj_path_points_to_opener_dst(artifact_file_cache):
@@ -149,8 +164,9 @@ def test_check_etag_obj_path_points_to_opener_dst(artifact_file_cache):
 
 def test_check_etag_obj_path_override(artifact_file_cache):
     override_path = os.path.join(artifact_file_cache._cache_dir, "override.cache")
-    artifact_file_cache._override_cache_path = override_path
-    path, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", 2)
+    path, exists, _ = artifact_file_cache.check_etag_obj_path(
+        "http://my/url", "abc", 2, override_path=override_path
+    )
     assert path == override_path
     assert exists is False
 
@@ -160,8 +176,9 @@ def test_check_etag_obj_path_override_is_never_a_hit(artifact_file_cache, tmp_pa
     dest_path = tmp_path / "dest.txt"
     dest_path.write_text(size * "b")
 
-    artifact_file_cache._override_cache_path = dest_path
-    _, exists, _ = artifact_file_cache.check_etag_obj_path("http://my/url", "abc", size)
+    _, exists, _ = artifact_file_cache.check_etag_obj_path(
+        "http://my/url", "abc", size, override_path=dest_path
+    )
     assert exists is False
 
 

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -30,6 +30,7 @@ from wandb.sdk.artifacts.storage_policies._multipart import (
     should_multipart_download,
 )
 from wandb.sdk.artifacts.storage_policies.wandb_storage_policy import WandbStoragePolicy
+from wandb.sdk.lib.hashutil import md5_string
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -485,6 +486,33 @@ def test_cache_write_failure_is_ignored(
 
     captured = capsys.readouterr()
     assert "Failed to cache" in captured.err
+
+
+@responses.activate()
+def test_skip_cache_download_does_not_affect_later_downloads(
+    artifact_file_cache: ArtifactFileCache, tmp_path: Path
+):
+    responses.get("https://wandb.test/first", body=b"first")
+    responses.get("https://wandb.test/second", body=b"second")
+
+    artifact = Artifact("test-artifact", type="dataset")
+
+    first = ArtifactManifestEntry(path="first", digest=md5_string("first"), size=5)
+    first._download_url = "https://wandb.test/first"
+    second = ArtifactManifestEntry(path="second", digest=md5_string("second"), size=6)
+    second._download_url = "https://wandb.test/second"
+
+    dest_path = tmp_path / "downloads" / "first"
+    skipped_path = WandbStoragePolicy().load_file(
+        artifact, first, dest_path=str(dest_path)
+    )
+    assert Path(skipped_path) == dest_path
+
+    # The next download uses the same process-wide cache and must be unaffected.
+    cached_path = Path(WandbStoragePolicy().load_file(artifact, second))
+    assert cached_path.is_relative_to(artifact_file_cache._obj_dir)
+    assert cached_path.read_text() == "second"
+    assert dest_path.read_text() == "first"
 
 
 def test_artifact_manifest_length():

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -92,7 +92,9 @@ class ArtifactFileCache:
         self, path: Path, size: int, skip_cache: bool = False
     ) -> tuple[FilePathStr, bool, Opener]:
         opener = self._opener(path, size, skip_cache=skip_cache)
-        hit = path.is_file() and path.stat().st_size == size
+        # When skipping the cache, `path` is the caller's destination file, whose
+        # size tells us nothing about whether its contents are what we want.
+        hit = not skip_cache and path.is_file() and path.stat().st_size == size
         return FilePathStr(path), hit, opener
 
     def cleanup(

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -52,15 +52,13 @@ class ArtifactFileCache:
         # [1] https://stackoverflow.com/questions/10541760/can-i-set-the-umask-for-tempfile-namedtemporaryfile-in-python
         self._sys_umask = _get_sys_umask_threadsafe()
 
-        self._override_cache_path: StrPath | None = None
-
     def check_md5_obj_path(
-        self, b64_md5: B64MD5, size: int
+        self, b64_md5: B64MD5, size: int, override_path: StrPath | None = None
     ) -> tuple[FilePathStr, bool, Opener]:
         # Check if we're using vs skipping the cache
-        if self._override_cache_path is not None:
+        if override_path is not None:
             skip_cache = True
-            path = Path(self._override_cache_path)
+            path = Path(override_path)
         else:
             skip_cache = False
             hex_md5 = b64_to_hex_id(b64_md5)
@@ -74,11 +72,12 @@ class ArtifactFileCache:
         url: URIStr,
         etag: ETag,
         size: int,
+        override_path: StrPath | None = None,
     ) -> tuple[FilePathStr, bool, Opener]:
         # Check if we're using vs skipping the cache
-        if self._override_cache_path is not None:
+        if override_path is not None:
             skip_cache = True
-            path = Path(self._override_cache_path)
+            path = Path(override_path)
         else:
             skip_cache = False
             hexhash = hashlib.sha256(

--- a/wandb/sdk/artifacts/storage_handler.py
+++ b/wandb/sdk/artifacts/storage_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Final
 
-from wandb.sdk.lib.paths import FilePathStr, URIStr
+from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 
 if TYPE_CHECKING:
     from urllib.parse import ParseResult
@@ -22,12 +22,14 @@ class _BaseStorageHandler(ABC):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         """Load a file or directory given the corresponding index entry.
 
         Args:
             manifest_entry: The index entry to load
             local: Whether to load the file locally or not
+            dest_path: If given, the path to load the file into, skipping the cache
 
         Returns:
             A path to the file represented by `index_entry`

--- a/wandb/sdk/artifacts/storage_handlers/azure_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/azure_handler.py
@@ -40,6 +40,7 @@ class AzureHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         assert manifest_entry.ref is not None
         if not local:
@@ -49,6 +50,7 @@ class AzureHandler(StorageHandler):
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),
             manifest_entry.size or 0,
+            override_path=dest_path,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/gcs_handler.py
@@ -87,6 +87,7 @@ class GCSHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         if (ref_uri := manifest_entry.ref) is None:
             raise ValueError("Missing reference path/URI on artifact manifest entry")
@@ -97,7 +98,10 @@ class GCSHandler(StorageHandler):
         expected_size = manifest_entry.size
 
         path, hit, cache_open = self._cache.check_etag_obj_path(
-            url=ref_uri, etag=expected_digest, size=expected_size or 0
+            url=ref_uri,
+            etag=expected_digest,
+            size=expected_size or 0,
+            override_path=dest_path,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_handlers/http_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/http_handler.py
@@ -77,6 +77,7 @@ class HTTPHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         if (ref_url := manifest_entry.ref) is None:
             raise ValueError("Missing URL on artifact manifest entry")
@@ -86,7 +87,10 @@ class HTTPHandler(StorageHandler):
         expected_digest = manifest_entry.digest
 
         path, hit, cache_open = self._cache.check_etag_obj_path(
-            url=ref_url, etag=expected_digest, size=manifest_entry.size or 0
+            url=ref_url,
+            etag=expected_digest,
+            size=manifest_entry.size or 0,
+            override_path=dest_path,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/local_file_handler.py
@@ -54,6 +54,7 @@ class LocalFileHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         if (ref_uri := manifest_entry.ref) is None:
             raise ValueError(f"Cannot add path with no ref: {manifest_entry.path}")
@@ -66,7 +67,9 @@ class LocalFileHandler(StorageHandler):
         expected_digest = manifest_entry.digest
 
         path, hit, cache_open = self._cache.check_md5_obj_path(
-            b64_md5=expected_digest, size=manifest_entry.size or 0
+            b64_md5=expected_digest,
+            size=manifest_entry.size or 0,
+            override_path=dest_path,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_handlers/multi_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/multi_handler.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from wandb.sdk.artifacts.storage_handler import StorageHandler, _BaseStorageHandler
-from wandb.sdk.lib.paths import FilePathStr, URIStr
+from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 
 if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
@@ -38,10 +38,11 @@ class MultiHandler(_BaseStorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         assert manifest_entry.ref is not None
         handler = self._get_handler(manifest_entry.ref)
-        return handler.load_path(manifest_entry, local=local)
+        return handler.load_path(manifest_entry, local=local, dest_path=dest_path)
 
     def store_path(
         self,

--- a/wandb/sdk/artifacts/storage_handlers/s3_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/s3_handler.py
@@ -89,6 +89,7 @@ class S3Handler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         if not local:
             assert manifest_entry.ref is not None
@@ -100,6 +101,7 @@ class S3Handler(StorageHandler):
             URIStr(manifest_entry.ref),
             ETag(manifest_entry.digest),
             manifest_entry.size or 0,
+            override_path=dest_path,
         )
         if hit:
             return path

--- a/wandb/sdk/artifacts/storage_handlers/tracking_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/tracking_handler.py
@@ -37,6 +37,7 @@ class TrackingHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         if local:
             # Likely a user error. The tracking handler is

--- a/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_artifact_handler.py
@@ -10,6 +10,7 @@ from wandb.apis import PublicApi
 from wandb.sdk.artifacts.artifact_file_cache import get_artifact_file_cache
 from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
 from wandb.sdk.artifacts.storage_handler import StorageHandler
+from wandb.sdk.lib.filesystem import copy_or_overwrite_changed
 from wandb.sdk.lib.hashutil import b64_to_hex_id, hex_to_b64_id
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 
@@ -45,6 +46,7 @@ class WBArtifactHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         """Load the file in the specified artifact given its corresponding entry.
 
@@ -52,6 +54,7 @@ class WBArtifactHandler(StorageHandler):
 
         Args:
             manifest_entry (ArtifactManifestEntry): The index entry to load
+            dest_path (StrPath): If given, the path to copy the downloaded file to
 
         Returns:
             (os.PathLike): A path to the file represented by `index_entry`
@@ -72,6 +75,10 @@ class WBArtifactHandler(StorageHandler):
         link_target_path: URIStr | FilePathStr
         if local:
             link_target_path = dep_artifact.get_entry(artifact_file_path).download()
+            if dest_path is not None:
+                link_target_path = FilePathStr(
+                    copy_or_overwrite_changed(link_target_path, dest_path)
+                )
         else:
             link_target_path = dep_artifact.get_entry(artifact_file_path).ref_target()
         return link_target_path

--- a/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
+++ b/wandb/sdk/artifacts/storage_handlers/wb_local_artifact_handler.py
@@ -35,6 +35,7 @@ class WBLocalArtifactHandler(StorageHandler):
         self,
         manifest_entry: ArtifactManifestEntry,
         local: bool = False,
+        dest_path: StrPath | None = None,
     ) -> URIStr | FilePathStr:
         raise NotImplementedError(
             "Should not be loading a path for an artifact entry with unresolved client id."

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -128,12 +128,10 @@ class WandbStoragePolicy(StoragePolicy):
         """
         from requests import HTTPError
 
-        if dest_path is not None:
-            self._cache._override_cache_path = dest_path
-
         path, hit, cache_open = self._cache.check_md5_obj_path(
             manifest_entry.digest,
             size=manifest_entry.size or 0,
+            override_path=dest_path,
         )
         if hit:
             return path
@@ -216,10 +214,7 @@ class WandbStoragePolicy(StoragePolicy):
         dest_path: str | None = None,
     ) -> FilePathStr | URIStr:
         assert manifest_entry.ref is not None
-        used_handler = self._handler._get_handler(manifest_entry.ref)
-        if hasattr(used_handler, "_cache") and (dest_path is not None):
-            used_handler._cache._override_cache_path = dest_path
-        return self._handler.load_path(manifest_entry, local)
+        return self._handler.load_path(manifest_entry, local, dest_path=dest_path)
 
     def _file_url(self, artifact: Artifact, entry: ArtifactManifestEntry) -> str:
         api = self._api


### PR DESCRIPTION
Description
-----------

One artifact download with `skip_cache=True` changed where every later download in the same process was written. Afterwards, ordinary downloads overwrote the file from the earlier download, bypassed the cache entirely, and could return the wrong contents when sizes happened to match. Within a single download, the 32 worker threads could also write one file's contents to another file's destination.

The destination was passed by assigning it to a field on the process-wide cache object, which was never reset and never locked. It is now passed as an argument.

The storage handler interface gains that argument, which is why the change reaches every handler, though each one only threads a single parameter through.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
