### PR TITLE
fix(sandbox): allow GPU sandboxes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -18,3 +18,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `Api.{create,update}_automation()` now raise `UnsupportedError` instead of `CommError` when the server doesn't support the given automation (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12194)
 - The message format used to communicate between internal processes has slightly changed. If you use `wandb beta core`, restart the service after upgrading `wandb`, as some operations may fail if the SDK and service versions differ. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12374)
+- `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -68,17 +68,15 @@ def test_sandbox_wrapper_rejects_default_placement_overrides(field: str) -> None
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
-def test_sandbox_wrapper_rejects_gpu_resources(resources) -> None:
-    with pytest.raises(UsageError, match="CPU and memory resources"):
-        wandb_sandbox.Sandbox(resources=resources)
+def test_sandbox_wrapper_allows_gpu_resources(resources) -> None:
+    wandb_sandbox.Sandbox(resources=resources)
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
-def test_sandbox_wrapper_rejects_default_gpu_resources(resources) -> None:
+def test_sandbox_wrapper_allows_default_gpu_resources(resources) -> None:
     defaults = cwsandbox.SandboxDefaults(resources=resources)
 
-    with pytest.raises(UsageError, match="CPU and memory resources"):
-        wandb_sandbox.Sandbox(defaults=defaults)
+    wandb_sandbox.Sandbox(defaults=defaults)
 
 
 @pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
@@ -123,17 +121,15 @@ def test_sandbox_session_rejects_positional_default_placement_overrides(
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
-def test_sandbox_session_rejects_gpu_resources(resources) -> None:
+def test_sandbox_session_allows_gpu_resources(resources) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match="CPU and memory resources"):
-        session.sandbox(resources=resources)
+    session.sandbox(resources=resources)
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
-def test_sandbox_session_rejects_default_gpu_resources(resources) -> None:
-    with pytest.raises(UsageError, match="CPU and memory resources"):
-        wandb_sandbox.Session(defaults={"resources": resources})
+def test_sandbox_session_allows_default_gpu_resources(resources) -> None:
+    wandb_sandbox.Session(defaults={"resources": resources})
 
 
 @pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
@@ -159,11 +155,10 @@ def test_sandbox_session_function_rejects_placement_overrides(field: str) -> Non
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
-def test_sandbox_session_function_rejects_gpu_resources(resources) -> None:
+def test_sandbox_session_function_allows_gpu_resources(resources) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match="CPU and memory resources"):
-        session.function(resources=resources)
+    session.function(resources=resources)
 
 
 @pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
-from cwsandbox import NetworkOptions, RemoteFunction, ResourceOptions, SandboxDefaults
+from cwsandbox import NetworkOptions, RemoteFunction, SandboxDefaults
 from cwsandbox import Sandbox as _BaseSandbox
 from cwsandbox import Session as _BaseSession
 
@@ -34,32 +34,6 @@ def _reject_placement_override_kwargs(kwargs: Mapping[str, Any]) -> None:
         raise _placement_override_error(blocked)
 
 
-def _resources_include_gpu(
-    resources: ResourceOptions | Mapping[str, Any] | None,
-) -> bool:
-    if resources is None:
-        return False
-
-    if isinstance(resources, Mapping):
-        gpu = resources.get("gpu")
-        return gpu is not None and gpu != {}
-
-    if isinstance(resources, ResourceOptions):
-        return resources.gpu is not None
-
-    return False
-
-
-def _reject_gpu_resources(
-    resources: ResourceOptions | Mapping[str, Any] | None,
-) -> None:
-    if _resources_include_gpu(resources):
-        raise UsageError(
-            "W&B Serverless currently supports only CPU and memory resources. "
-            "Remove resources.gpu."
-        )
-
-
 def _reject_unsupported_egress_mode(
     network: NetworkOptions | Mapping[str, Any] | None,
 ) -> None:
@@ -83,7 +57,6 @@ def _reject_unsupported_egress_mode(
 
 def _reject_invalid_kwargs(kwargs: Mapping[str, Any]) -> None:
     _reject_placement_override_kwargs(kwargs)
-    _reject_gpu_resources(kwargs.get("resources"))
     _reject_unsupported_egress_mode(kwargs.get("network"))
 
 
@@ -138,13 +111,6 @@ def _reject_invalid_defaults(
 
     if blocked:
         raise _placement_override_error(blocked)
-
-    resources = (
-        defaults.get("resources")
-        if isinstance(defaults, Mapping)
-        else getattr(defaults, "resources", None)
-    )
-    _reject_gpu_resources(resources)
 
     network = (
         defaults.get("network")


### PR DESCRIPTION
Description
-----------
Allow setting GPU resources from the SDK for serverless sandboxes 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
Updated unit tests
