### PR TITLE
chore: probe for opentelemetry proxy api prior to telemetry startup

### DIFF
--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -705,7 +705,7 @@ func checkServerSupportsOpenTelemetryProxy(
 	if wandbSettings.IsInsecureDisableSSL() {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
-	httpClient := &http.Client{Timeout: defaultTimeout, Transport: transport}
+	httpClient := &http.Client{Timeout: httpClientTimeout, Transport: transport}
 
 	url := wandbSettings.GetBaseURL() + metricsPath
 	req, err := http.NewRequestWithContext(

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -395,6 +395,11 @@ func NewOpenTelemetryProxy(
 		return nil
 	}
 
+	if !checkServerSupportsOpenTelemetryProxy(ctx, wandbSettings) {
+		slog.Debug("analytics: server does not support OpenTelemetry proxy, disabling telemetry")
+		return nil
+	}
+
 	httpClient, err := newOTLPHTTPClient(wandbSettings)
 	if err != nil {
 		slog.Debug(
@@ -686,4 +691,42 @@ func toOTelAttrs(attrs map[string]string) otelmetric.MeasurementOption {
 		kvs = append(kvs, attribute.String(k, v))
 	}
 	return otelmetric.WithAttributes(kvs...)
+}
+
+// checkServerSupportsOpenTelemetryProxy probes the W&B OpenTelemetry proxy
+// endpoint to determine whether the server exposes it.
+func checkServerSupportsOpenTelemetryProxy(
+	ctx context.Context,
+	wandbSettings *settings.Settings,
+) bool {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = wandbSettings.GetProxyFn()
+	transport.ProxyConnectHeader = wandbSettings.GetProxyConnectHeader()
+	if wandbSettings.IsInsecureDisableSSL() {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	httpClient := &http.Client{Timeout: defaultTimeout, Transport: transport}
+
+	url := wandbSettings.GetBaseURL() + metricsPath
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		url,
+		http.NoBody,
+	)
+	if err != nil {
+		return false
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Depending on the server configuration, it may respond with a
+	// 404 Not Found or a 405 Method Not Allowed when it does not support
+	// the proxy API.
+	return resp.StatusCode != http.StatusMethodNotAllowed &&
+		resp.StatusCode != http.StatusNotFound
 }

--- a/core/internal/analytics/opentelemetryproxy_test.go
+++ b/core/internal/analytics/opentelemetryproxy_test.go
@@ -327,8 +327,14 @@ func TestTelemetryRecorder_SendsAPIKeyAuth(t *testing.T) {
 	require.NoError(t, proxy.Shutdown(context.Background()))
 
 	requests := proxy.Requests()
-	require.NotEmpty(t, requests, "expected at least one OTLP export request")
+	assert.Greater(t, len(requests), 1, "expected at least two requests")
 	for _, req := range requests {
+		// The capability probe sent during proxy construction is intentionally
+		// unauthenticated and carries no body.
+		// Only OTLP export requests must include the API key.
+		if req.ContentLength == 0 {
+			continue
+		}
 		assert.Equal(
 			t,
 			"Basic YXBpOnRlc3QtYXBpLWtleQ==",

--- a/core/internal/analyticstest/opentelemetryproxy.go
+++ b/core/internal/analyticstest/opentelemetryproxy.go
@@ -44,6 +44,7 @@ type Request struct {
 	Authorization string
 	Headers       http.Header
 	URLHost       string
+	ContentLength int64
 }
 
 // OpenTelemetryProxyTest is an OpenTelemetry proxy and test OTLP collector.
@@ -196,6 +197,7 @@ func (s *OpenTelemetryProxyTest) addRequest(request *http.Request) {
 		Authorization: request.Header.Get("Authorization"),
 		Headers:       request.Header.Clone(),
 		URLHost:       request.URL.Host,
+		ContentLength: request.ContentLength,
 	})
 }
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

To avoid having servers log 405 (method not allowed errors) when trying to send OpenTelemetry records to servers which do not support it, this change adds a simple probe to check the response for the opentelemetry api. When the api is present we get a 401 (unauthorized), as expected since we do not attach auth check.  
  
When the api is not present we get either a 404, or 405 error since the api is not found or not allowed depending on the backend setup (SaaS vs dedicated)

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

How was this PR tested?

tested a beta_history_scan which generates an opentelemetry metric record against https://api.wandb.ai verified no metric showed up.  
Also added some temporary logging that the server will fall back to a default false value when no present

```
"analytics: checkServerSupportsOpenTelemetryProxy","status":404,"host":"api.wandb.ai"
```

Tested against an local server with the feature flag deployed

```
"analytics: checkServerSupportsOpenTelemetryProxy","status":401,"host":"api.wandb.ai"
```

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->