### PR TITLE
fix(sandbox): support cwsandbox 1.0 network options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ launch = [
 models = ["cloudpickle"]
 workspaces = ["wandb-workspaces"]
 # cwsandbox requires Python >=3.11, so this extra is unavailable on 3.10.
-sandbox = ["cwsandbox[cli]>=0.27.0; python_version >= '3.11'"]
+sandbox = ["cwsandbox[cli]>=1.0.0; python_version >= '3.11'"]
 eval-table = [ # wandb.EvalTable support (private testing only)
     "weave>=0.52.41",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ launch = [
 models = ["cloudpickle"]
 workspaces = ["wandb-workspaces"]
 # cwsandbox requires Python >=3.11, so this extra is unavailable on 3.10.
-sandbox = ["cwsandbox[cli]>=0.20.0,<0.27; python_version >= '3.11'"]
+sandbox = ["cwsandbox[cli]>=0.27.0; python_version >= '3.11'"]
 eval-table = [ # wandb.EvalTable support (private testing only)
     "weave>=0.52.41",
 ]

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -154,7 +154,7 @@ cryptography==46.0.7
     #   msal
     #   pyjwt
     #   pyopenssl
-cwsandbox==0.27.0
+cwsandbox==1.0.0
     # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -154,7 +154,7 @@ cryptography==46.0.7
     #   msal
     #   pyjwt
     #   pyopenssl
-cwsandbox==0.26.0
+cwsandbox==0.27.0
     # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -163,7 +163,7 @@ cuda-pathfinder==1.5.6
     # via cuda-bindings
 cuda-toolkit==13.0.2
     # via torch
-cwsandbox==0.26.0
+cwsandbox==0.27.0
     # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -163,7 +163,7 @@ cuda-pathfinder==1.5.6
     # via cuda-bindings
 cuda-toolkit==13.0.2
     # via torch
-cwsandbox==0.27.0
+cwsandbox==1.0.0
     # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -164,7 +164,7 @@ cryptography==46.0.7
     #   msal
     #   pyjwt
     #   pyopenssl
-cwsandbox==0.26.0
+cwsandbox==0.27.0
     # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -164,7 +164,7 @@ cryptography==46.0.7
     #   msal
     #   pyjwt
     #   pyopenssl
-cwsandbox==0.27.0
+cwsandbox==1.0.0
     # via -r requirements/requirements_dev.txt
 cycler==0.12.1
     # via matplotlib

--- a/tests/system_tests/test_sandbox/test_auth.py
+++ b/tests/system_tests/test_sandbox/test_auth.py
@@ -16,8 +16,8 @@ class _FakeChannel:
 
 @dataclass
 class _SandboxStubCalls:
-    start: list[dict[str, object]] = field(default_factory=list)
-    stop: list[dict[str, object]] = field(default_factory=list)
+    create: list[dict[str, object]] = field(default_factory=list)
+    delete: list[dict[str, object]] = field(default_factory=list)
 
 
 def _patch_sandbox_stub(
@@ -29,41 +29,45 @@ def _patch_sandbox_stub(
         def __init__(self, channel) -> None:
             self._channel = channel
 
-        async def Start(self, request, timeout=None, metadata=None):  # noqa: N802
-            calls.start.append(
+        async def CreateSandbox(  # noqa: N802
+            self, request, timeout=None, metadata=None
+        ):
+            calls.create.append(
                 {
                     "request": request,
                     "timeout": timeout,
                     "metadata": metadata,
                 }
             )
-            return cwsandbox_sandbox.gateway_pb2.StartSandboxResponse(
+            return cwsandbox_sandbox.sandbox_pb2.Sandbox(
                 sandbox_id="sb-system-test",
-                service_address="",
-                exposed_ports=[],
-                applied_ingress_mode="",
-                applied_egress_mode="",
+                status=cwsandbox_sandbox.sandbox_pb2.SandboxStatus(
+                    state=cwsandbox_sandbox.sandbox_pb2.STATE_CREATING
+                ),
             )
 
-        async def Get(self, request, timeout=None, metadata=None):  # noqa: N802
+        async def GetSandbox(  # noqa: N802
+            self, request, timeout=None, metadata=None
+        ):
             _ = request, timeout, metadata
-            return cwsandbox_sandbox.gateway_pb2.GetSandboxResponse(
+            return cwsandbox_sandbox.sandbox_pb2.Sandbox(
                 sandbox_id="sb-system-test",
-                sandbox_status=cwsandbox_sandbox.gateway_pb2.SANDBOX_STATUS_COMPLETED,
+                status=cwsandbox_sandbox.sandbox_pb2.SandboxStatus(
+                    state=cwsandbox_sandbox.sandbox_pb2.STATE_COMPLETED
+                ),
             )
 
-        async def Stop(self, request, timeout=None, metadata=None):  # noqa: N802
-            calls.stop.append(
+        async def DeleteSandbox(  # noqa: N802
+            self, request, timeout=None, metadata=None
+        ):
+            calls.delete.append(
                 {
                     "request": request,
                     "timeout": timeout,
                     "metadata": metadata,
                 }
             )
-            return cwsandbox_sandbox.gateway_pb2.StopSandboxResponse(
-                success=True,
-                error_message="",
-            )
+            return cwsandbox_sandbox.sandbox_pb2.DeleteSandboxResponse()
 
     monkeypatch.setattr(
         cwsandbox_sandbox,
@@ -71,8 +75,8 @@ def _patch_sandbox_stub(
         lambda target, is_secure: _FakeChannel(),
     )
     monkeypatch.setattr(
-        cwsandbox_sandbox.gateway_pb2_grpc,
-        "GatewayServiceStub",
+        cwsandbox_sandbox.sandbox_pb2_grpc,
+        "SandboxServiceStub",
         _FakeSandboxStub,
     )
     return calls
@@ -108,10 +112,10 @@ def test_sandbox_run_uses_settings_entity_project(
         "x-project-name": "project-from-settings",
         **_client_version_headers(),
     }
-    assert len(calls.start) == 1
-    assert dict(calls.start[0]["metadata"]) == expected_headers
-    assert len(calls.stop) == 1
-    assert dict(calls.stop[0]["metadata"]) == expected_headers
+    assert len(calls.create) == 1
+    assert dict(calls.create[0]["metadata"]) == expected_headers
+    assert len(calls.delete) == 1
+    assert dict(calls.delete[0]["metadata"]) == expected_headers
 
 
 def test_sandbox_run_ignore_run_override(
@@ -129,10 +133,10 @@ def test_sandbox_run_ignore_run_override(
         "x-entity-id": user,
         **_client_version_headers(),
     }
-    assert len(calls.start) == 1
-    assert dict(calls.start[0]["metadata"]) == expected_headers
-    assert len(calls.stop) == 1
-    assert dict(calls.stop[0]["metadata"]) == expected_headers
+    assert len(calls.create) == 1
+    assert dict(calls.create[0]["metadata"]) == expected_headers
+    assert len(calls.delete) == 1
+    assert dict(calls.delete[0]["metadata"]) == expected_headers
 
 
 def test_sandbox_run_without_entity_or_project(
@@ -148,7 +152,7 @@ def test_sandbox_run_without_entity_or_project(
         assert sandbox.sandbox_id == "sb-system-test"
 
     expected_headers = {"x-wandb-api-key": user, **_client_version_headers()}
-    assert len(calls.start) == 1
-    assert dict(calls.start[0]["metadata"]) == expected_headers
-    assert len(calls.stop) == 1
-    assert dict(calls.stop[0]["metadata"]) == expected_headers
+    assert len(calls.create) == 1
+    assert dict(calls.create[0]["metadata"]) == expected_headers
+    assert len(calls.delete) == 1
+    assert dict(calls.delete[0]["metadata"]) == expected_headers

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -16,16 +16,12 @@ _GPU_RESOURCE_VALUES = (
     {"gpu": 1},
     {"requests": {"cpu": "1"}, "gpu": {"count": 1}},
 )
-_UNSUPPORTED_EGRESS_NETWORK_VALUES = (
-    cwsandbox.NetworkOptions(egress_mode="private"),
-    {"egress_mode": "private"},
-)
 _SUPPORTED_NETWORK_VALUES = (
-    cwsandbox.NetworkOptions(egress_mode="internet"),
-    cwsandbox.NetworkOptions(egress_mode="none"),
-    cwsandbox.NetworkOptions(ingress_mode="public", exposed_ports=(8080,)),
-    {"egress_mode": "internet"},
-    {"egress_mode": "none"},
+    cwsandbox.NetworkOptions(deny_egress=False),
+    cwsandbox.NetworkOptions(deny_egress=True),
+    cwsandbox.NetworkOptions(deny_ingress=True),
+    {"deny_egress": False},
+    {"deny_egress": True},
 )
 
 
@@ -61,10 +57,8 @@ def test_sandbox_wrapper_rejects_placement_overrides(field: str) -> None:
 
 @pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
 def test_sandbox_wrapper_rejects_default_placement_overrides(field: str) -> None:
-    defaults = cwsandbox.SandboxDefaults(**{field: ("placement-1",)})
-
     with pytest.raises(UsageError, match=f"selects the runner and profile.*{field}"):
-        wandb_sandbox.Sandbox(defaults=defaults)
+        wandb_sandbox.Sandbox(defaults={field: ("placement-1",)})
 
 
 @pytest.mark.parametrize("resources", _GPU_RESOURCE_VALUES)
@@ -79,23 +73,14 @@ def test_sandbox_wrapper_allows_default_gpu_resources(resources) -> None:
     wandb_sandbox.Sandbox(defaults=defaults)
 
 
-@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
-def test_sandbox_wrapper_rejects_unsupported_egress_modes(network) -> None:
-    with pytest.raises(UsageError, match="egress modes.*private"):
-        wandb_sandbox.Sandbox(network=network)
-
-
-@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
-def test_sandbox_wrapper_rejects_default_unsupported_egress_modes(network) -> None:
-    defaults = cwsandbox.SandboxDefaults(network=network)
-
-    with pytest.raises(UsageError, match="egress modes.*private"):
-        wandb_sandbox.Sandbox(defaults=defaults)
-
-
 @pytest.mark.parametrize("network", _SUPPORTED_NETWORK_VALUES)
 def test_sandbox_wrapper_allows_supported_network_options(network) -> None:
     wandb_sandbox.Sandbox(network=network)
+
+
+@pytest.mark.parametrize("network", _SUPPORTED_NETWORK_VALUES)
+def test_sandbox_wrapper_allows_default_supported_network_options(network) -> None:
+    wandb_sandbox.Sandbox(defaults={"network": network})
 
 
 @pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
@@ -132,18 +117,16 @@ def test_sandbox_session_allows_default_gpu_resources(resources) -> None:
     wandb_sandbox.Session(defaults={"resources": resources})
 
 
-@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
-def test_sandbox_session_rejects_unsupported_egress_modes(network) -> None:
+@pytest.mark.parametrize("network", _SUPPORTED_NETWORK_VALUES)
+def test_sandbox_session_allows_supported_network_options(network) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match="egress modes.*private"):
-        session.sandbox(network=network)
+    session.sandbox(network=network)
 
 
-@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
-def test_sandbox_session_rejects_default_unsupported_egress_modes(network) -> None:
-    with pytest.raises(UsageError, match="egress modes.*private"):
-        wandb_sandbox.Session(defaults={"network": network})
+@pytest.mark.parametrize("network", _SUPPORTED_NETWORK_VALUES)
+def test_sandbox_session_allows_default_supported_network_options(network) -> None:
+    wandb_sandbox.Session(defaults={"network": network})
 
 
 @pytest.mark.parametrize("field", _PLACEMENT_OVERRIDE_FIELDS)
@@ -161,12 +144,11 @@ def test_sandbox_session_function_allows_gpu_resources(resources) -> None:
     session.function(resources=resources)
 
 
-@pytest.mark.parametrize("network", _UNSUPPORTED_EGRESS_NETWORK_VALUES)
-def test_sandbox_session_function_rejects_unsupported_egress_modes(network) -> None:
+@pytest.mark.parametrize("network", _SUPPORTED_NETWORK_VALUES)
+def test_sandbox_session_function_allows_supported_network_options(network) -> None:
     session = wandb_sandbox.Session()
 
-    with pytest.raises(UsageError, match="egress modes.*private"):
-        session.function(network=network)
+    session.function(network=network)
 
 
 def test_sandbox_session_forwards_kwargs(

--- a/wandb/sandbox/_sandbox.py
+++ b/wandb/sandbox/_sandbox.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
-from cwsandbox import NetworkOptions, RemoteFunction, SandboxDefaults
+from cwsandbox import RemoteFunction, SandboxDefaults
 from cwsandbox import Sandbox as _BaseSandbox
 from cwsandbox import Session as _BaseSession
 
 from wandb.errors import UsageError
 
 _PLACEMENT_OVERRIDE_FIELDS = ("profile_ids", "profile_names", "runner_ids")
-_SUPPORTED_EGRESS_MODES = ("internet", "none")
 _SERVERLESS_DEFAULT_MAX_LIFETIME_SECONDS = 12 * 60 * 60
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -34,30 +33,8 @@ def _reject_placement_override_kwargs(kwargs: Mapping[str, Any]) -> None:
         raise _placement_override_error(blocked)
 
 
-def _reject_unsupported_egress_mode(
-    network: NetworkOptions | Mapping[str, Any] | None,
-) -> None:
-    if network is None:
-        return
-
-    if isinstance(network, Mapping):
-        egress_mode = network.get("egress_mode")
-    elif isinstance(network, NetworkOptions):
-        egress_mode = network.egress_mode
-    else:
-        return
-
-    if egress_mode is not None and egress_mode not in _SUPPORTED_EGRESS_MODES:
-        modes_display = ", ".join(_SUPPORTED_EGRESS_MODES)
-        raise UsageError(
-            "wandb.sandbox supports only egress modes "
-            f"({modes_display}). Got {egress_mode!r}."
-        )
-
-
 def _reject_invalid_kwargs(kwargs: Mapping[str, Any]) -> None:
     _reject_placement_override_kwargs(kwargs)
-    _reject_unsupported_egress_mode(kwargs.get("network"))
 
 
 def _with_serverless_max_lifetime_default(
@@ -111,13 +88,6 @@ def _reject_invalid_defaults(
 
     if blocked:
         raise _placement_override_error(blocked)
-
-    network = (
-        defaults.get("network")
-        if isinstance(defaults, Mapping)
-        else getattr(defaults, "network", None)
-    )
-    _reject_unsupported_egress_mode(network)
 
 
 class Sandbox(_BaseSandbox):


### PR DESCRIPTION
## Summary

- require cwsandbox 1.0.0 or newer for the sandbox extra and Python 3.13 CI environments
- remove the obsolete beta egress_mode policy check and cover the v1 deny_egress and deny_ingress options
- migrate the sandbox auth system-test fake from the removed beta GatewayService Start/Get/Stop API to the v1 SandboxService Create/Get/Delete API
- install the project sandbox extra from requirements_dev and the mypy session
- update only the cwsandbox pins in the Python 3.13 platform lockfiles; keep the existing uv compile commands unchanged

## Testing

- Python 3.13 sandbox unit tests with the cwsandbox 1.0.0 wheel: 80 passed
- package-wide mypy with cwsandbox 1.0.0: 590 source files passed
- all three sandbox auth system-test bodies exercised against the v1 fake transport
- ruff check and format
- commit and pre-push hooks