### PR TITLE
refactor: generalize ANSI shortening to ANSI wrapping

### DIFF
--- a/tests/unit_tests/test_term_ansi.py
+++ b/tests/unit_tests/test_term_ansi.py
@@ -1,0 +1,97 @@
+from wandb.errors.ansi import wrap_ansi
+
+
+def test_wrap_ansi__wraps_printable_text():
+    text = "0123456789abcdefghij"
+
+    assert list(wrap_ansi(text, width=10, max_lines=2)) == [
+        "0123456789",
+        "abcdefghij",
+    ]
+    assert list(wrap_ansi(text + "x", width=10, max_lines=2)) == [
+        "0123456789",
+        "abcdefg...",
+    ]
+
+
+def test_wrap_ansi__includes_all_ansi():
+    # The style reset sequence must be included even when the text inside
+    # is truncated, or else the style will apply to later printed text.
+    text = "\x1b[31mthis text is red \x1b[34mand this is blue\x1b[0m"
+
+    result = list(wrap_ansi(text, width=10, max_lines=1))
+
+    assert result == ["\x1b[31mthis te...\x1b[34m\x1b[0m"]
+
+
+def test_wrap_ansi__exact_with_ansi_at_end():
+    # Exactly 10 printable characters.
+    #               0123456789
+    text = "\x1b[31m10 are red\x1b[0m"
+
+    result = list(wrap_ansi(text, width=10, max_lines=1))
+
+    assert result == ["\x1b[31m10 are red\x1b[0m"]
+
+
+def test_wrap_ansi__slightly_over_with_ansi_at_end():
+    # Exactly 11 printable characters.
+    #               0123456789       A
+    text = "\x1b[31m11 are red\x1b[0m!"
+
+    result = list(wrap_ansi(text, width=10, max_lines=1))
+
+    assert result == ["\x1b[31m11 are ...\x1b[0m"]
+
+
+def test_wrap_ansi__ellipsis_styling():
+    # Exactly 12 printable characters.
+    #               0123456               789AB
+    # "not red" in red, then " text" in blue
+    text = "\x1b[31mnot red\x1b[34m text\x1b[0m"
+
+    result = list(wrap_ansi(text, width=10, max_lines=1))
+
+    # The ellipsis is styled blue because the first character
+    # it replaces is blue. It would be fine to make it red as well;
+    # this just happens to be simpler to implement.
+    assert result == ["\x1b[31mnot red\x1b[34m...\x1b[0m"]
+
+
+def test_wrap_ansi__just_ansi():
+    text = "\x1b[0m"
+
+    result = list(wrap_ansi(text, width=10, max_lines=1))
+
+    assert result == ["\x1b[0m"]
+
+
+def test_wrap_ansi__short_width():
+    text = "\x1b[31mred text\x1b[0m"
+
+    result = list(wrap_ansi(text, width=1, max_lines=2))
+
+    # The lines should not have more than 1 printable character in this
+    # extreme case. The choice for the ellipsis character is not important.
+    assert result == [
+        "\x1b[31mr",
+        ".\x1b[0m",
+    ]
+
+
+def test_wrap_ansi__no_width():
+    result = list(wrap_ansi("\x1b[0msome text", width=0, max_lines=10))
+
+    assert result == ["\x1b[0m"]
+
+
+def test_wrap_ansi__empty_text():
+    result = list(wrap_ansi("", width=10, max_lines=1))
+
+    assert result == [""]
+
+
+def test_wrap_ansi__zero_max_lines():
+    result = list(wrap_ansi("", width=10, max_lines=0))
+
+    assert result == []

--- a/wandb/errors/ansi.py
+++ b/wandb/errors/ansi.py
@@ -1,0 +1,146 @@
+"""Handling for ANSI sequences."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Generator
+
+_MULTI_ANSI_RE = re.compile("(\x1b\\[(K|.*?m))+")
+"""Regexp that greedily matches one or more SGR ANSI sequences."""
+
+
+def wrap_ansi(text: str, *, width: int, max_lines: int) -> Generator[str]:
+    """Wrap the ANSI-containing text to fit into the given width.
+
+    For this purpose, "ANSI sequences" refers to "SGR" ANSI sequences,
+    basically text styling. This matches the logic `click` uses to strip
+    ANSI sequences.
+
+    All ANSI sequences in the text are preserved and appear at the end of the
+    last line even on truncation, in case they contain style reset commands.
+
+    All characters outside of ANSI sequences in the text are assumed to take
+    up 1 column in the terminal. Wide characters, like emoji or east-Asian
+    text, will break the output. Likewise, text must not contain any control
+    characters like newlines or carriage returns.
+
+    Args:
+        text: Text without newlines but possibly containing ANSI sequences.
+        width: The maximum printed length of each returned line.
+        max_lines: The maximum number of lines to emit. If the text does not
+            fit on this many lines, an ellipsis is emitted at the end.
+
+    Yields:
+        Wrapped lines. The lines do not end with newline characters.
+        Unless max_lines is zero, at least one line is yielded.
+    """
+    if max_lines <= 0:
+        return
+
+    # If the text is empty, output an empty line.
+    #
+    # Given zero width, output a single zero-width line with any ANSI sequences
+    # from the text to avoid spam. We don't really care about this edge case
+    # anyway. Could happen if `width` is the result of a calculation.
+    if not text or width < 1:
+        yield "".join(
+            text[ansi_start:ansi_end]
+            for ansi_start, ansi_end in _AnsiCursor(text).remaining_ansi_runs()
+        )
+        return
+
+    cursor = _AnsiCursor(text)
+
+    for line_idx in range(max_lines):
+        if cursor.index >= len(text):
+            return
+
+        line_start = cursor.index
+
+        # If we're not on the last line, just grab up to `width` characters.
+        if line_idx < max_lines - 1:
+            cursor.forward(width)
+            yield text[line_start : cursor.index]
+            continue
+
+        # On the last line, first save the truncation position for an ellipsis.
+        ellipsis_len = min(3, width)
+        cursor.forward(width - ellipsis_len)
+
+        ellipsis_index = cursor.index
+        ansi_after_ellipsis = cursor.remaining_ansi_runs()
+
+        cursor.forward(ellipsis_len)
+
+        # If the remaining text fits on this final line, return it.
+        if cursor.index == len(text):
+            yield text[line_start:]
+            return
+
+        # Otherwise, truncate and add an ellipsis.
+        line_parts: list[str] = []
+        line_parts.append(text[line_start:ellipsis_index])
+        line_parts.append("." * ellipsis_len)
+        line_parts.extend(text[start:end] for start, end in ansi_after_ellipsis)
+
+        yield "".join(line_parts)
+        return
+
+
+class _AnsiCursor:
+    """An ANSI-aware index into a string."""
+
+    def __init__(self, text: str) -> None:
+        self._text_len = len(text)
+        self._ansi_runs: list[tuple[int, int]] = [
+            (match.start(0), match.end(0))  #
+            for match in _MULTI_ANSI_RE.finditer(text)
+        ]
+        """Start and end indices of all ANSI runs in the text, in order."""
+
+        self._ansi_before_cursor = 0
+        """Count of ANSI runs before the current cursor position.
+
+        This is also the index of the ANSI run after the cursor, if any.
+        """
+
+        self._index = 0
+        """The cursor's index into the text.
+
+        Never in the middle of an ANSI sequence.
+        """
+
+    @property
+    def index(self) -> int:
+        """The index in the string corresponding to the cursor position."""
+        return self._index
+
+    def remaining_ansi_runs(self) -> list[tuple[int, int]]:
+        """Returns (start, end) indices of all ANSI runs after the cursor."""
+        return self._ansi_runs[self._ansi_before_cursor :]
+
+    def forward(self, count: int) -> None:
+        """Move the cursor forward by `count` printable characters.
+
+        If the cursor lands on a run of ANSI codes, the index will be set to
+        after the run. In particular, if there are `count` or fewer printable
+        characters remaining, the index becomes the length of the string.
+        """
+        while count > 0 and self._index < self._text_len:
+            # No ANSI runs after the cursor, so just jump forward.
+            if self._ansi_before_cursor >= len(self._ansi_runs):
+                self._index = min(self._index + count, self._text_len)
+                return
+
+            next_ansi = self._ansi_runs[self._ansi_before_cursor]
+            count_to_next_ansi = next_ansi[0] - self._index
+
+            # Enough characters before the next ANSI run, so just jump forward.
+            if count < count_to_next_ansi:
+                self._index += count
+                return
+
+            # Jump to the end of the next ANSI run, then continue.
+            count -= count_to_next_ansi
+            self._index = next_ansi[1]
+            self._ansi_before_cursor += 1

--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
-import re
 import shutil
 import sys
 import threading
@@ -22,6 +21,8 @@ from collections.abc import Generator
 from typing import TYPE_CHECKING, Protocol
 
 import click
+
+from wandb.errors.ansi import wrap_ansi
 
 if TYPE_CHECKING:
     import wandb
@@ -434,10 +435,10 @@ class DynamicBlock:
         The lock must be held.
         """
         if self._lines_to_print:
-            # Trim lines before printing. This is crucial because the \x1b[Am
-            # (cursor up) sequence used when clearing the text moves up by one
-            # visual line, and the terminal may be wrapping long lines onto
-            # multiple visual lines.
+            # Wrap and trim lines before printing. This is crucial because the
+            # \x1b[Am (cursor up) sequence used when clearing the text moves up
+            # by one visual line, and the terminal may be wrapping long lines
+            # onto multiple visual lines.
             #
             # There is no ANSI escape sequence that moves the cursor up by one
             # "physical" line instead. Note that the user may resize their
@@ -445,8 +446,9 @@ class DynamicBlock:
             term_width = _shutil_get_terminal_width()
             click.echo(
                 "\n".join(
-                    _ansi_shorten(line, term_width)  #
+                    wrapped
                     for line in self._lines_to_print
+                    for wrapped in wrap_ansi(line, width=term_width, max_lines=1)
                 ),
                 file=sys.stderr,
             )
@@ -461,38 +463,6 @@ def _shutil_get_terminal_width() -> int:
     """
     columns, _ = shutil.get_terminal_size()
     return columns
-
-
-_ANSI_RE = re.compile("\x1b\\[(K|.*?m)")
-
-
-def _ansi_shorten(text: str, width: int) -> str:
-    """Shorten text potentially containing ANSI sequences to fit a width."""
-    first_ansi = _ANSI_RE.search(text)
-
-    if not first_ansi:
-        return _raw_shorten(text, width)
-
-    if first_ansi.start() > width - 3:
-        return _raw_shorten(text[: first_ansi.start()], width)
-
-    return text[: first_ansi.end()] + _ansi_shorten(
-        text[first_ansi.end() :],
-        # Key part: the ANSI sequence doesn't reduce the remaining width.
-        width - first_ansi.start(),
-    )
-
-
-def _raw_shorten(text: str, width: int) -> str:
-    """Shorten text to fit a width, replacing the end with "...".
-
-    Unlike textwrap.shorten(), this does not drop whitespace or do anything
-    smart.
-    """
-    if len(text) <= width:
-        return text
-
-    return text[: width - 3] + "..."
 
 
 def _log(


### PR DESCRIPTION
Replaces the ANSI-aware shortening logic in `term.py`, used for dynamic text, by a more general ANSI-aware wrapping function. The wrapping functionality is used in the follow-up PR.

Needed for WB-38375.

The original shortening logic had a subtle bug (that we would have never hit) where it could chop off some final characters in a string if they came after an ANSI sequence that started close to the terminal width. For example, in this case the visual length of the string fits within the width, but the end gets chopped without an ellipsis:

```
>>> import wandb
>>> from wandb.errors.term import _ansi_shorten
>>> _ansi_shorten("\x1b[31mred text\x1b[0m!", width=9)
'\x1b[31mred text'
```

The new implementation does it correctly and also avoids chopping off the style reset sequence:

```
>>> import wandb
>>> from wandb.errors.ansi import wrap_ansi
>>> list(wrap_ansi("\x1b[31mred text\x1b[0m!", width=9, max_lines=1))
['\x1b[31mred text\x1b[0m!']
>>> list(wrap_ansi("\x1b[31mred text\x1b[0m!!", width=9, max_lines=1))
['\x1b[31mred te...\x1b[0m']
```

The new approach also tries avoid copying strings unnecessarily or redoing regex searches. It does a single regex scan and does the rest with index arithmetic, using `join()` just once when truncating. It's not important, but it feels nice to do it this way. Recursion like for `_ansi_shorten` is simpler, but can get a little gross with the edge cases above (a shortcut is possible if we use the Unicode ellipsis character … instead of `...`, but I like the index approach better anyway, and some terminals/fonts might not support … correctly).

I also considered adding a dependency on `rich`, which has a `Live` object and ANSI-awareness, but it doesn't seem to have a way to simultaneously wrap and truncate text, and an implementation of `dynamic_text()` using `Live` may not be much simpler than what we currently have.