### PR TITLE
feat: allow error statuses to wrap to 2 lines

### DIFF
--- a/tests/unit_tests/test_term.py
+++ b/tests/unit_tests/test_term.py
@@ -98,18 +98,24 @@ def test_static_and_dynamic_text(emulated_terminal):
         ]
 
 
-def test_truncates_dynamic_text(emulated_terminal, monkeypatch):
+def test_wraps_and_truncates_dynamic_text(emulated_terminal, monkeypatch):
     # Pretend the terminal is very narrow.
-    columns = len("wandb: this should fit")
-    monkeypatch.setattr(term, "_shutil_get_terminal_width", lambda: columns)
+    monkeypatch.setattr(term, "_shutil_get_terminal_width", lambda: 16)
     with term.dynamic_text() as text:
         assert text
         emulated_terminal.reset_capsys()
 
-        text.set_text("this should fit")
-        assert emulated_terminal.read_stderr() == ["wandb: this should fit"]
-        text.set_text("but not this line")
-        assert emulated_terminal.read_stderr() == ["wandb: but not this..."]
+        text.set_text("this line fits these rows")
+        assert emulated_terminal.read_stderr() == [
+            "wandb: this line",
+            " fits these rows",
+        ]
+
+        text.set_text("this line fits these rows?")
+        assert emulated_terminal.read_stderr() == [
+            "wandb: this line",
+            " fits these r...",
+        ]
 
 
 @pytest.fixture

--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -31,6 +31,11 @@ LOG_STRING = click.style("wandb", fg="blue", bold=True)
 ERROR_STRING = click.style("ERROR", bg="red", fg="green")
 WARN_STRING = click.style("WARNING", fg="yellow")
 
+# Some error statuses during wandb.init()/run.finish() just barely don't fit on
+# one line and are difficult to shorten. Let them wrap across 2 lines to make it
+# more likely that important info is visible.
+_DYNAMIC_TEXT_WRAP_MAX_LINES = 2
+
 _silent: bool = False
 """If true, _logger is used instead of printing to stderr."""
 
@@ -389,23 +394,18 @@ class DynamicBlock:
         self._lines_to_print: list[str] = []
         self._num_lines_printed = 0
 
-    def set_text(self, text: str, prefix: bool = True) -> None:
+    def set_text(self, text: str) -> None:
         r"""Replace the text in this block.
 
         Args:
             text: The text to put in the block, with lines separated
                 by \n characters. A single \n at the end is ignored; to include
                 a blank line at the end, the text must end with \n\n.
-            prefix: Whether to include the "wandb:" prefix.
         """
         with _dynamic_text_lock:
-            self._lines_to_print = text.splitlines()
-
-            if prefix:
-                self._lines_to_print = [
-                    f"{LOG_STRING}: {line}" for line in self._lines_to_print
-                ]
-
+            self._lines_to_print = [
+                f"{LOG_STRING}: {line}" for line in text.splitlines()
+            ]
             _l_rerender_dynamic_blocks()
 
     def _l_clear(self) -> None:
@@ -434,26 +434,31 @@ class DynamicBlock:
 
         The lock must be held.
         """
-        if self._lines_to_print:
-            # Wrap and trim lines before printing. This is crucial because the
-            # \x1b[Am (cursor up) sequence used when clearing the text moves up
-            # by one visual line, and the terminal may be wrapping long lines
-            # onto multiple visual lines.
-            #
-            # There is no ANSI escape sequence that moves the cursor up by one
-            # "physical" line instead. Note that the user may resize their
-            # terminal.
-            term_width = _shutil_get_terminal_width()
-            click.echo(
-                "\n".join(
-                    wrapped
-                    for line in self._lines_to_print
-                    for wrapped in wrap_ansi(line, width=term_width, max_lines=1)
-                ),
-                file=sys.stderr,
-            )
+        if not self._lines_to_print:
+            return
 
-        self._num_lines_printed += len(self._lines_to_print)
+        # Wrap and trim lines before printing. This is crucial because the
+        # \x1b[Am (cursor up) sequence used when clearing the text moves up
+        # by one visual line, and the terminal may be wrapping long lines
+        # onto multiple visual lines.
+        #
+        # There is no ANSI escape sequence that moves the cursor up by one
+        # "physical" line instead. Note that the user may resize their
+        # terminal.
+        term_width = _shutil_get_terminal_width()
+
+        printed_lines = [
+            wrapped
+            for line in self._lines_to_print
+            for wrapped in wrap_ansi(
+                line,
+                width=term_width,
+                max_lines=_DYNAMIC_TEXT_WRAP_MAX_LINES,
+            )
+        ]
+
+        click.echo("\n".join(printed_lines), file=sys.stderr)
+        self._num_lines_printed += len(printed_lines)
 
 
 def _shutil_get_terminal_width() -> int:


### PR DESCRIPTION
Uses the new ANSI wrapping function in #12469 to wrap dynamic text to 2 lines before truncating instead of truncating to fit a single line.

Fixes WB-38375.

![Screenshot 2026-08-14 at 1.40.45 PM.png](https://app.graphite.com/user-attachments/assets/0499e8db-68d9-40f7-877e-1437c24f8de7.png)

For the above screenshot, I made HTTP 400 retryable in `credentials.go` and used an invalid JWT. Maybe it's not the best example because it doesn't manage to show more details of the error, but I did use an unrealistically narrow terminal.

I initially tried adding the `wandb: ` prefix to each wrapped line, but that resets the styling (the gray error text becomes white). Wrapping without a prefix affects vertical alignment, but it also shows more text, so I'd say it is worth it.

I didn't make it configurable because I see little use for configuring it at the moment.