### PR TITLE
chore: fix the docstring for dynamic text's `set_text()`

### DIFF
--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -393,8 +393,8 @@ class DynamicBlock:
 
         Args:
             text: The text to put in the block, with lines separated
-                by \n characters. The text should not end in \n unless
-                a blank line at the end of the block is desired.
+                by \n characters. A single \n at the end is ignored; to include
+                a blank line at the end, the text must end with \n\n.
             prefix: Whether to include the "wandb:" prefix.
         """
         with _dynamic_text_lock:

--- a/wandb/sdk/lib/printer.py
+++ b/wandb/sdk/lib/printer.py
@@ -265,8 +265,8 @@ class DynamicText(abc.ABC):
 
         Args:
             text: The text to put in the block, with lines separated
-                by \n characters. The text should not end in \n unless
-                a blank line at the end of the block is desired.
+                by \n characters. A single \n at the end is ignored; to include
+                a blank line at the end, the text must end with \n\n.
                 May include styled output from methods on the Printer
                 that created this.
         """


### PR DESCRIPTION
Discovered while adding ANSI-aware line-wrapping to `set_text()`.

```
"abc\n".splitlines() == ["abc"]
```