### PR TITLE
fix(sdk): renumber unparsable step values instead of adding a duplicate step entry

### DIFF
--- a/core/internal/stream/historystep_test.go
+++ b/core/internal/stream/historystep_test.go
@@ -1,6 +1,7 @@
 package stream_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,6 +118,38 @@ func TestHistoryStepTracker_RewritesStepBelowStartingStep(t *testing.T) {
 	x.Tracker.ApplyHistoryStep(history)
 
 	assert.Equal(t, "2", history.Item[1].ValueJson)
+}
+
+func TestHistoryStepTracker_RenumberUnparseableExplicitStep(t *testing.T) {
+	x := makeHistoryStepTracker(t, false /*shared*/, false /*serverSideDerivedSummary*/)
+
+	badValues := []string{
+		`"5"`,
+		"5.5",
+		"null",
+		"true",
+		`{"a":1}`,
+		"[1]",
+	}
+	for i, value := range badValues {
+		history := &spb.HistoryRecord{
+			Item: []*spb.HistoryItem{{
+				NestedKey: []string{"_step"},
+				ValueJson: value,
+			}},
+		}
+		x.Tracker.Process(history, 0)
+
+		assert.Equal(t, strconv.Itoa(i), historyStepValue(history), "row %d", i)
+		stepItems := 0
+		for _, item := range history.Item {
+			if item.GetKey() == "_step" ||
+				(len(item.GetNestedKey()) == 1 && item.GetNestedKey()[0] == "_step") {
+				stepItems++
+			}
+		}
+		assert.Equal(t, 1, stepItems, "row %d must have exactly one _step item", i)
+	}
 }
 
 func TestHistoryStepTracker_OfflineResumedSegmentRewritesSteps(t *testing.T) {


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>