### PR TITLE
chore: update periodic export time for opentelemetry records

### DIFF
--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -33,10 +33,18 @@ import (
 )
 
 const (
-	defaultExportIntervalMs = 500
-	defaultTimeout          = 1 * time.Second
-	metricsPath             = "/sdk/otel/v1/metrics"
-	logsPath                = "/sdk/otel/v1/logs"
+	// defaultExportInterval is the interval at which metrics and logs are sent to the backend.
+	defaultExportInterval = 60 * time.Second
+
+	// defaultExportTimeout is the total time allowed for an export to complete.
+	// It includes the time to collect and send metric/log records.
+	defaultExportTimeout = 5 * time.Second
+
+	// httpClientTimeout is the timeout for HTTP requests to the backend.
+	httpClientTimeout = 10 * time.Second
+
+	metricsPath = "/sdk/otel/v1/metrics"
+	logsPath    = "/sdk/otel/v1/logs"
 )
 
 // ConfigureOTelErrorHandler routes OpenTelemetry SDK errors to the core logger.
@@ -436,7 +444,7 @@ func newOTLPHTTPClient(
 	extraHeaders := wandbSettings.GetExtraHTTPHeaders()
 
 	client := &http.Client{
-		Timeout: defaultTimeout,
+		Timeout: httpClientTimeout,
 	}
 	client.Transport = httplayers.WrapRoundTripper(
 		transport,
@@ -508,7 +516,8 @@ func (o *OpenTelemetryProxy) setupMetrics(
 		metric.WithResource(res),
 		metric.WithReader(
 			metric.NewPeriodicReader(exporter,
-				metric.WithInterval(defaultExportIntervalMs*time.Millisecond),
+				metric.WithInterval(defaultExportInterval),
+				metric.WithTimeout(defaultExportTimeout),
 			),
 		),
 	), nil
@@ -534,7 +543,12 @@ func (o *OpenTelemetryProxy) setupLogs(
 
 	return otellog.NewLoggerProvider(
 		otellog.WithResource(res),
-		otellog.WithProcessor(otellog.NewBatchProcessor(exporter)),
+		otellog.WithProcessor(
+			otellog.NewBatchProcessor(exporter,
+				otellog.WithExportInterval(defaultExportInterval),
+				otellog.WithExportTimeout(defaultExportTimeout),
+			),
+		),
 	), nil
 }
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

Tunes the default export interval and timeout values for open telemetry data, which matches the opentelemetry default of 60 seconds. This will reduce the number of calls to the backend, and consequently reduce how fast metrics appear in Datadog.
This will not affect the shutdown time of the SDK since at shutdown data is force flushed to datadog.


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
