### PR TITLE
docs(sdk): update wandb sweep cli

### DIFF
--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1025,7 +1025,8 @@ def _parse_sync_replace_tags(replace_tags: str) -> dict[str, str] | None:
 @click.option(
     "--update",
     default=None,
-    help="Update an existing sweep configuration. Pass the sweep ID.",
+    help="""Update the configuration of a sweep while it is still
+    pending, before any run has started. Pass the sweep ID.""",
 )
 @click.option(
     "--stop",
@@ -1105,9 +1106,7 @@ def sweep(
 
         $ wandb sweep -p foobar -e team-awesome sweep_config.yaml
 
-    To update sweep abcd1234 with a new configuration from sweep_config.yaml.
-    This is useful for changing the parameters or search strategy of an
-    active sweep:
+    To update sweep abcd1234 with a new configuration from sweep_config.yaml:
 
         $ wandb sweep --update abcd1234 sweep_config.yaml
 


### PR DESCRIPTION
Description
-----------

- Removes incorrect statement from `wandb sweep` example docstring that stated you can use this flag on active sweeps.
- Updates the `--update` flag itself to clarify that it works for pending/runs that have not started.

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes: https://github.com/wandb/wandb/issues/12415
- Fixes: https://coreweave.atlassian.net/browse/DOCS-3077

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
