### PR TITLE
fix(sandbox): update CLI list for cwsandbox v1

### DIFF
--- a/wandb/cli/beta_sandbox.py
+++ b/wandb/cli/beta_sandbox.py
@@ -82,7 +82,7 @@ def sandbox() -> None:
 @click.option(
     "--all",
     "-a",
-    "include_stopped",
+    "show_terminated",
     is_flag=True,
     default=False,
     help="Include stopped sandboxes in results.",
@@ -100,7 +100,7 @@ def sandbox() -> None:
 )
 def list_sandboxes(
     status: str | None,
-    include_stopped: bool,
+    show_terminated: bool,
     tags: tuple[str, ...],
     output_format: str,
 ) -> None:
@@ -121,7 +121,7 @@ def list_sandboxes(
     sandboxes = Sandbox.list(
         tags=list(tags) if tags else None,
         status=status,
-        include_stopped=include_stopped,
+        show_terminated=show_terminated,
     ).result()
 
     if output_format == "json":


### PR DESCRIPTION
Description
-----------

The sandbox CLI still passed the removed `include_stopped` keyword to `Sandbox.list()`, causing `wandb beta sandbox ls` to fail with cwsandbox v1. This was observed in [the Sandbox E2E run](https://github.com/wandb/wb-sandboxes-tests-e2e/actions/runs/32076709213).

This PR maps `--all` to the v1 `show_terminated` argument.

- [x] `CHANGELOG.unreleased.md` is not applicable for this compatibility correction

Testing
-------

- Confirmed `Sandbox.list()` uses `show_terminated` with the run-compatible `cwsandbox==1.1.1`
- `python -m pytest -q -c /dev/null --noconftest tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py` (6 passed)
- File-scoped checks passed