### PR TITLE
feat(artifacts): expose when registry versions were linked

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,7 +20,8 @@ Section headings should be at level 3 (e.g. `### Added`).
 - The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
 - The automations API now supports creating and editing automations whose scope is a `Registry` object (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10867)
 - Press `g` in LEET to draw guides behind line charts: a dotted background or horizontal lines aligned with the axis ticks. The choice is saved and can also be set with `chart_guides` in `wandb leet config`. (@dmitryduev in https://github.com/wandb/wandb/pull/12463)
-- Registry API version queries (`Api.registries().versions()`, `Api.registries().collections().versions()`, `Registry.versions()`, `Registry.collections().versions()`) now accept an optional `order` string as a keyword argument for organizations with advanced search (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12489)
+- Registry API version queries (`Api.registries().versions()`, `Api.registries().collections().versions()`, `Registry.versions()`, `Registry.collections().versions()`) now accept an optional `order` string as a keyword argument for organizations with advanced search. The API supports ordering versions by `created_at`, `artifact_size`, and `linked_at` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12489)
+- Added `Artifact.linked_at` which returns when the version was linked to the relevant portfolio. This is valid only for linked versions, and for source artifacts returns `None` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12490)
 
 ### Changed
 

--- a/tests/system_tests/test_artifacts/test_artifact_public_api.py
+++ b/tests/system_tests/test_artifacts/test_artifact_public_api.py
@@ -718,6 +718,7 @@ def test_fetch_registry_artifact(
         },
         version_index=1,
         aliases=[{"id": "PLACEHOLDER", "alias": "my-alias"}],
+        created_at="PLACEHOLDER",
     ).model_dump()
 
     mock_empty_rsp_data = {"data": {"project": {}}}

--- a/tests/system_tests/test_artifacts/test_link_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_link_artifacts.py
@@ -167,6 +167,7 @@ def test_linked_artifacts_field(user, api):
         assert len(linked_artifacts) == len(link_collections)
         for linked in linked_artifacts:
             assert linked.is_link is True
+            assert linked.linked_at is not None
             assert linked.linked_artifacts == []
             assert linked.source_artifact.qualified_name == artifact.qualified_name
             assert linked.collection.name in link_collections

--- a/tests/system_tests/test_artifacts/test_misc2.py
+++ b/tests/system_tests/test_artifacts/test_misc2.py
@@ -74,6 +74,7 @@ def test_lazy_artifact_passthrough(user):
             "file_count",
             "created_at",
             "updated_at",
+            "linked_at",
         ]
 
         # These setters should be valid both before and after logging

--- a/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
+++ b/tests/system_tests/test_registries/test_registry_artifacts_public_api.py
@@ -80,6 +80,7 @@ def mock_membership_fragment_data(
             },
         },
         versionIndex=1,
+        createdAt="PLACEHOLDER",
         aliases=[
             {"id": "PLACEHOLDER", "alias": "my-alias"},
         ],

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -424,6 +424,7 @@ def test_invalid_artifact_name(invalid_name):
         "file_count",  # Probably doesn't need to be restricted, but is today.
         "created_at",
         "updated_at",
+        "linked_at",
     ],
 )
 def test_unlogged_artifact_property_errors(property):

--- a/tests/unit_tests/test_registries/test_utils.py
+++ b/tests/unit_tests/test_registries/test_utils.py
@@ -253,6 +253,8 @@ def test_versions_rejects_order_for_basic_search(
         ("created_at", "+artifact_created_at"),
         ("-created_at", "-artifact_created_at"),
         ("-artifact_created_at", "-artifact_created_at"),
+        ("linked_at", "+acm_created_at"),
+        ("-acm_created_at", "-acm_created_at"),
         ("artifact_size", "+artifact_size"),
         (None, None),
     ],

--- a/tools/graphql_codegen/artifacts/artifacts.graphql
+++ b/tools/graphql_codegen/artifacts/artifacts.graphql
@@ -70,6 +70,7 @@ fragment ArtifactMembershipFragment on ArtifactCollectionMembership {
   __typename
   id
   versionIndex
+  createdAt
   aliases {
     ...ArtifactAliasFragment
   }
@@ -173,6 +174,7 @@ query FetchLinkedArtifacts($artifactID: ID!) {
       edges {
         node {
           versionIndex
+          createdAt
           aliases {
             ...ArtifactAliasFragment
           }

--- a/wandb/apis/public/registries/_utils.py
+++ b/wandb/apis/public/registries/_utils.py
@@ -128,6 +128,7 @@ This is relevant for VERSION filters passed to:
 ADVANCED_VERSIONS_ORDER_FIELDS = (
     SearchField("artifact_created_at", aliases=["created_at"]),
     SearchField("artifact_size"),
+    SearchField("acm_created_at", aliases=["linked_at"]),
 )
 """Defines allowed Versions order fields for "advanced" search.
 

--- a/wandb/apis/public/registries/registries_search.py
+++ b/wandb/apis/public/registries/registries_search.py
@@ -295,7 +295,7 @@ class Registries(RelayPaginator["RegistryFragment", "Registry"]):
         Args:
             filter: Optional mapping of filters to apply to the artifact versions query.
             order: Optional string to specify the order of the results.
-                Order can be `created_at` or `artifact_size`.
+                Order can be `created_at`, `artifact_size`, or `linked_at`.
                 If prefixed with '+', sorts ascending (default).
                 If prefixed with '-', sorts descending.
             per_page: The number of results to fetch per page.
@@ -437,7 +437,7 @@ class Collections(
         Args:
             filter: Optional mapping of filters to apply to the artifact versions query.
             order: Optional string to specify the order of the results.
-                Order can be `created_at` or `artifact_size`.
+                Order can be `created_at`, `artifact_size`, or `linked_at`.
                 If prefixed with '+', sorts ascending (default).
                 If prefixed with '-', sorts descending.
             per_page: The number of results to fetch per page.

--- a/wandb/apis/public/registries/registry.py
+++ b/wandb/apis/public/registries/registry.py
@@ -241,7 +241,7 @@ class Registry:
         Args:
             filter: Optional mapping of filters to apply to the artifact versions query.
             order: Optional string to specify the order of the results.
-                Order can be `created_at` or `artifact_size`.
+                Order can be `created_at`, `artifact_size`, or `linked_at`.
                 If prefixed with '+', sorts ascending (default).
                 If prefixed with '-', sorts descending.
             per_page: The number of results to fetch per page.

--- a/wandb/sdk/artifacts/_generated/fetch_linked_artifacts.py
+++ b/wandb/sdk/artifacts/_generated/fetch_linked_artifacts.py
@@ -30,6 +30,7 @@ class FetchLinkedArtifactsArtifactArtifactMembershipsEdges(GQLResult):
 
 class FetchLinkedArtifactsArtifactArtifactMembershipsEdgesNode(GQLResult):
     version_index: int | None = Field(alias="versionIndex")
+    created_at: str = Field(alias="createdAt")
     aliases: list[ArtifactAliasFragment]
     artifact_collection: CollectionInfoFragment | None = Field(
         alias="artifactCollection"

--- a/wandb/sdk/artifacts/_generated/fragments.py
+++ b/wandb/sdk/artifacts/_generated/fragments.py
@@ -109,6 +109,7 @@ class ArtifactMembershipFragment(GQLResult):
     )
     id: GQLId
     version_index: int | None = Field(alias="versionIndex")
+    created_at: str = Field(alias="createdAt")
     aliases: list[ArtifactAliasFragment]
     artifact_collection: CollectionInfoFragment | None = Field(
         alias="artifactCollection"

--- a/wandb/sdk/artifacts/_generated/operations.py
+++ b/wandb/sdk/artifacts/_generated/operations.py
@@ -882,6 +882,7 @@ query FetchLinkedArtifacts($artifactID: ID!) {
       edges {
         node {
           versionIndex
+          createdAt
           aliases {
             ...ArtifactAliasFragment
           }
@@ -1065,6 +1066,7 @@ fragment ArtifactMembershipFragment on ArtifactCollectionMembership {
   __typename
   id
   versionIndex
+  createdAt
   aliases {
     ...ArtifactAliasFragment
   }
@@ -1342,6 +1344,7 @@ fragment ArtifactMembershipFragment on ArtifactCollectionMembership {
   __typename
   id
   versionIndex
+  createdAt
   aliases {
     ...ArtifactAliasFragment
   }
@@ -1509,6 +1512,7 @@ fragment ArtifactMembershipFragment on ArtifactCollectionMembership {
   __typename
   id
   versionIndex
+  createdAt
   aliases {
     ...ArtifactAliasFragment
   }

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -52,6 +52,7 @@ class LinkArtifactFields:
     name: str
     version: str
     aliases: list[str]
+    linked_at: str
 
     # These fields shouldn't be user-editable, linked artifacts always have these values
     _is_link: Literal[True] = field(init=False, default=True)

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -1120,7 +1120,7 @@ class Artifact:
     def linked_at(self) -> str | None:
         """The time when this artifact was linked to its current collection.
 
-        Only valid for linked artifacts.
+        Only valid for linked artifacts, returns `None` otherwise.
         """
         return self._linked_at
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -238,6 +238,7 @@ class Artifact:
         self._file_count: int | None = None
         self._created_at: str | None = None
         self._updated_at: str | None = None
+        self._linked_at: str | None = None
         self._final: bool = False
         self._history_step: int | None = None
         self._linked_artifacts: list[Artifact] = []
@@ -484,6 +485,8 @@ class Artifact:
         self._file_count = src_art.file_count
         self._created_at = src_art.created_at
         self._updated_at = src_art.updated_at
+        if membership is not None and self.is_link:
+            self._linked_at = membership.created_at
         self._history_step = src_art.history_step
 
     @ensure_logged
@@ -1111,6 +1114,15 @@ class Artifact:
         """The time when the artifact was last updated."""
         assert self._created_at is not None
         return self._updated_at or self._created_at
+
+    @property
+    @ensure_logged
+    def linked_at(self) -> str | None:
+        """The time when this artifact was linked to its current collection.
+
+        Only valid for linked artifacts.
+        """
+        return self._linked_at
 
     @property
     @ensure_logged
@@ -2721,6 +2733,7 @@ class Artifact:
                 name=f"{col.name}:{version}",
                 version=version,
                 aliases=aliases,
+                linked_at=node.created_at,
             )
             link = self._create_linked_artifact_using_source_artifact(link_fields)
             linked_artifacts.append(link)
@@ -2740,6 +2753,7 @@ class Artifact:
         linked_artifact._project = link_fields.project_name
         linked_artifact._is_link = link_fields.is_link
         linked_artifact._linked_artifacts = link_fields.linked_artifacts
+        linked_artifact._linked_at = link_fields.linked_at
         return linked_artifact
 
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

This PR adds a `linked_at` field to the Artifact class. This field is only valid for linked versions, and will be None for source artifacts. This PR also allows ordering queried registry versions by `linked_at`.

Note: this is only populated if we fetch the membership for an artifact. I believe that `collection.artifacts()` where the collection is a portfolio does not fetch a membership. this is a gap and here we would not be able to populate `linked_at`. 

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
