### PR TITLE
chore: deprecate step argument to log()

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -135,3 +135,8 @@ When preparing a release that can include breaking changes, consider applying ch
   - Owner: @timoffex
   - Deprecated after 0.28.0 (https://github.com/wandb/wandb/pull/12098)
   - Can do a few releases after 0.28.1 or 0.29.0 (whichever comes first)
+
+- Remove `step=` argument from `run.log()`:
+  - Owner: @timoffex
+  - Deprecated after 0.28.2 (https://github.com/wandb/wandb/pull/12491)
+  - Usage is high, so watch telemetry to decide when to remove

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,3 +27,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - The message format used to communicate between internal processes has slightly changed. If you use `wandb beta core`, restart the service after upgrading `wandb`, as some operations may fail if the SDK and service versions differ. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12374)
 - `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)
 - Registry search methods (`Api.registries()`, `.collections()`, `.versions()`) now validate filter field names, rejecting unsupported field names. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12182)
+
+### Deprecated
+
+- Passing `step=` to `run.log()` / `wandb.log()` is deprecated (@timoffex in https://github.com/wandb/wandb/pull/12491)

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -577,8 +577,8 @@ def log(
     ```
 
     It is possible to use multiple `wandb.Run.log()` invocations to log to
-    the same step with the `step` and `commit` parameters.
-    The following are all equivalent:
+    the same step with the `step` and `commit` parameters, but this is
+    deprecated. The following are all equivalent:
 
     ```python
     with wandb.init() as run:
@@ -592,7 +592,7 @@ def log(
         run.log({"train-loss": 0.4}, commit=False)
         run.log({"accuracy": 0.9})
 
-        # Explicit step:
+        # Explicit step (deprecated):
         run.log({"train-loss": 0.5}, step=current_step)
         run.log({"accuracy": 0.8}, step=current_step)
         current_step += 1
@@ -606,8 +606,8 @@ def log(
             any of the `wandb.data_types`; lists, tuples and NumPy arrays
             of serializable Python objects; other `dict`s of this
             structure.
-        step: The step number to log. If `None`, then an implicit
-            auto-incrementing step is used. See the notes in
+        step: Deprecated. The step number to log. If `None`, then an
+            implicit auto-incrementing step is used. See the notes in
             the description.
         commit: If true, finalize and upload the step. If false, then
             accumulate data for the step. See the notes in the description.

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1825,8 +1825,8 @@ class Run:
         ```
 
         It is possible to use multiple `wandb.Run.log()` invocations to log to
-        the same step with the `step` and `commit` parameters.
-        The following are all equivalent:
+        the same step with the `step` and `commit` parameters, but this is
+        deprecated. The following are all equivalent:
 
         ```python
         with wandb.init() as run:
@@ -1840,7 +1840,7 @@ class Run:
             run.log({"train-loss": 0.4}, commit=False)
             run.log({"accuracy": 0.9})
 
-            # Explicit step:
+            # Explicit step (deprecated):
             run.log({"train-loss": 0.5}, step=current_step)
             run.log({"accuracy": 0.8}, step=current_step)
             current_step += 1
@@ -1854,8 +1854,8 @@ class Run:
                 any of the `wandb.data_types`; lists, tuples and NumPy arrays
                 of serializable Python objects; other `dict`s of this
                 structure.
-            step: The step number to log. If `None`, then an implicit
-                auto-incrementing step is used. See the notes in
+            step: Deprecated. The step number to log. If `None`, then an
+                implicit auto-incrementing step is used. See the notes in
                 the description.
             commit: If true, finalize and upload the step. If false, then
                 accumulate data for the step. See the notes in the description.
@@ -1999,6 +1999,15 @@ class Run:
 
         """
         if step is not None:
+            wandb.termwarn(
+                "Passing step= to run.log() is deprecated. Consider logging"
+                + " a separate metric and making it a chart X axis, if needed."
+                + " If you are using this to accumulate a W&B step from"
+                + " multiple log() calls, build up the accumulated dict instead"
+                + " and pass it in a single log() call.",
+                repeat=False,
+            )
+
             with telemetry.context(run=self) as tel:
                 tel.feature.set_step_log = True
 


### PR DESCRIPTION
Deprecates passing `step=` to `run.log()`. It causes a lot of confusion because it does not work like people expect. It can be replaced by using custom X axes and/or the `commit=` parameter.

I don't recommend the `commit=` parameter in the message because we'd like to deprecate it too, but we can't do that yet because some niche use-cases aren't possible without it (it has an interesting interaction with "attached" runs when using multiprocessing). It's not clear if anyone actually finds this useful though.

I didn't use the "deprecation" telemetry mechanism because we have "feature" telemetry for it already.