### PR TITLE
fix(leet): show the status bar on the help screen

### DIFF
--- a/core/internal/leet/help.go
+++ b/core/internal/leet/help.go
@@ -155,7 +155,10 @@ func (h *HelpModel) SetSize(width, height int) {
 	h.width = width
 	h.height = height - StatusBarHeight
 	h.viewport.SetWidth(width)
-	h.viewport.SetHeight(h.height)
+	// Leave room for helpContentStyle's margins: without this the rendered
+	// help view exceeds h.height and the status bar below it is pushed off
+	// screen (bubbletea v2's altscreen renderer clips the bottom).
+	h.viewport.SetHeight(max(h.height-helpContentStyle.GetVerticalFrameSize(), 0))
 
 	if h.active {
 		h.viewport.SetContent(h.generateHelpContent())


### PR DESCRIPTION
Description
-----------
The help view rendered one line taller than its budget: SetSize ignored helpContentStyle's top margin. Bubble Tea v1's renderer cropped overflow from the top, which hid only the blank margin line. The v2 altscreen renderer clips the bottom instead, so since the v2 migration the status bar ended up off screen whenever help was open, which I never noticed.

- [x] I updated CHANGELOG.unreleased.md, or it is not applicable
