### PR TITLE
fix(leet): run-dir scan fixes

### DIFF
--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -189,10 +189,7 @@ func (w *Workspace) handleWorkspaceRunDirs(msg WorkspaceRunDirsMsg) tea.Cmd {
 	w.enqueueMissingRunOverviews(msg.RunKeys)
 
 	startCmd := w.startRunOverviewPreloadsCmd()
-	if startCmd == nil {
-		return pollCmd
-	}
-	return tea.Batch(pollCmd, startCmd, selectLatestCmd)
+	return batchCmds(pollCmd, startCmd, selectLatestCmd)
 }
 
 // enqueueMissingRunOverviews queues runs that don't yet have overview state and
@@ -282,18 +279,24 @@ func (w *Workspace) handleWorkspaceRunOverviewPreloaded(
 ) tea.Cmd {
 	w.overviewPreloader.MarkDone(msg.RunKey)
 
-	if msg.Err == nil && msg.Run != nil && msg.Run.ID != "" {
+	_, streaming := w.runsByKey[msg.RunKey]
+
+	switch {
+	case msg.Err == nil && msg.Run != nil && msg.Run.ID != "" && streaming:
+		// A selected run streams its own records; don't let a stale preload
+		// snapshot overwrite the live overview (e.g., reset its state).
+
+	case msg.Err == nil && msg.Run != nil && msg.Run.ID != "":
 		ro := w.getOrCreateRunOverview(msg.RunKey)
-		if msg.Run != nil {
-			ro.ProcessRunMsg(*msg.Run)
-			w.indexRunFilterData(msg.RunKey, *msg.Run)
-		}
+		ro.ProcessRunMsg(*msg.Run)
+		w.indexRunFilterData(msg.RunKey, *msg.Run)
 		if w.filter.Query() != "" {
 			w.applyRunFilter()
 		}
 		// We don't know the final state of this run after a pre-load.
 		ro.SetRunState(RunStateUnknown)
-	} else if msg.Err != nil && !errors.Is(msg.Err, errRunRecordNotFound) && !os.IsNotExist(msg.Err) {
+
+	case msg.Err != nil && !errors.Is(msg.Err, errRunRecordNotFound) && !os.IsNotExist(msg.Err):
 		// Best-effort logging for unexpected failures; avoid spamming for
 		// "file not ready yet" or missing run records.
 		err := fmt.Errorf("workspace: preload run overview for %s: %v", msg.RunKey, msg.Err)


### PR DESCRIPTION
Description
-----------
Two fixes in the workspace's run-dir handling:

- An overview preload could finish after its run was already selected and streaming, overwriting the streamed overview and resetting its state to Unknown. Preload results are now dropped for streaming runs.
- handleWorkspaceRunDirs returned early when no overview preloads were startable, dropping the auto-select command in that branch. The poll, preload, and auto-select commands are now batched together.

- [x] I updated CHANGELOG.unreleased.md, or it is not applicable
