### PR TITLE
fix(leet): mark workspace runs failed when reads error

### DIFF
--- a/core/internal/leet/messages.go
+++ b/core/internal/leet/messages.go
@@ -125,6 +125,13 @@ type WorkspaceBatchedRecordsMsg struct {
 	Batch  BatchedRecordsMsg
 }
 
+// WorkspaceRunReadErrMsg reports a failed read of a workspace run's
+// transaction log.
+type WorkspaceRunReadErrMsg struct {
+	RunKey string
+	Err    error
+}
+
 // WorkspaceFileChangedMsg is emitted when a watched workspace run's .wandb
 // file changes on disk.
 //

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -280,15 +280,18 @@ func (w *Workspace) Update(msg tea.Msg) tea.Cmd {
 	case WorkspaceFileChangedMsg:
 		return w.handleWorkspaceFileChanged(t)
 
+	case WorkspaceRunReadErrMsg:
+		return w.handleRunReadErr(t)
+
 	case HeartbeatMsg:
 		return w.handleHeartbeat()
 
 	case ErrorMsg:
-		// Read errors from per-run commands; the affected run simply stops
-		// streaming, so surface the error in the logs.
+		// Errors without a run key; per-run read errors arrive as
+		// WorkspaceRunReadErrMsg and are handled above.
 		w.logger.CaptureError(
 			"leet",
-			fmt.Errorf("workspace: run read failed: %v", t.Err),
+			fmt.Errorf("workspace: %v", t.Err),
 		)
 	}
 

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -487,7 +487,7 @@ func (w *Workspace) readAllChunkCmd(run *WorkspaceRun) tea.Cmd {
 	return func() tea.Msg {
 		msg, err := reader.Read(BootLoadChunkSize, BootLoadMaxTime)
 		if err != nil && !errors.Is(err, io.EOF) {
-			return ErrorMsg{Err: err}
+			return WorkspaceRunReadErrMsg{RunKey: runKey, Err: err}
 		}
 		if msg == nil {
 			return nil
@@ -514,7 +514,7 @@ func (w *Workspace) ReadAvailableCmd(run *WorkspaceRun) tea.Cmd {
 	return func() tea.Msg {
 		msg, err := reader.Read(LiveMonitorChunkSize, LiveMonitorMaxTime)
 		if err != nil && !errors.Is(err, io.EOF) {
-			return ErrorMsg{Err: err}
+			return WorkspaceRunReadErrMsg{RunKey: runKey, Err: err}
 		}
 		if msg == nil {
 			return nil
@@ -777,6 +777,32 @@ func (w *Workspace) handleHeartbeat() tea.Cmd {
 		cmds = append(cmds, w.ReadAvailableCmd(run))
 	}
 	return tea.Batch(cmds...)
+}
+
+// handleRunReadErr handles a failed transaction-log read for a run.
+//
+// Mirrors the single-run view's ErrorMsg path: the run can no longer
+// stream, so mark it failed instead of leaving it silently frozen in
+// whatever state it was in.
+func (w *Workspace) handleRunReadErr(msg WorkspaceRunReadErrMsg) tea.Cmd {
+	w.logger.CaptureError(
+		"leet",
+		fmt.Errorf("workspace: run %s read failed: %v", msg.RunKey, msg.Err),
+	)
+
+	run := w.runsByKey[msg.RunKey]
+	if run == nil {
+		return nil
+	}
+
+	run.state = RunStateFailed
+	w.getOrCreateRunOverview(run.Key).SetRunState(run.state)
+	w.stopWatcher(run)
+	w.syncLiveRunState()
+	if !w.anyRunRunning() {
+		w.heartbeatMgr.Stop()
+	}
+	return nil
 }
 
 // handleWorkspaceFileChanged reacts to a filesystem change for a given run.


### PR DESCRIPTION
Description
-----------
A failed transaction-log read produced a bare ErrorMsg that was only logged. The run stayed selected, looked alive, and never streamed again. Read errors now carry the run key and are handled like the single-run view's error path: the run is marked failed, its overview synced, and its watcher stopped.

- [x] I updated CHANGELOG.unreleased.md, or it is not applicable
