### PR TITLE
feat(leet): mark silent live runs as crashed

### DIFF
--- a/core/internal/leet/heartbeat.go
+++ b/core/internal/leet/heartbeat.go
@@ -12,6 +12,16 @@ import (
 	"github.com/wandb/wandb/core/internal/observability"
 )
 
+// RunCrashTimeout is how long a live run may go without writing to its
+// transaction log before LEET presumes it crashed.
+//
+// Modeled on the server's stale-runs sweep (staleRunHeartbeatThreshold in
+// gorilla), which moves running runs with no filestream heartbeat for
+// 5 minutes to the crashed state. Locally, writes to the .wandb file play
+// the role of the heartbeat, and their cadence varies more than the SDK's
+// heartbeats, so be twice as lenient.
+const RunCrashTimeout = 10 * time.Minute
+
 // HeartbeatManager manages periodic heartbeat messages for live runs.
 type HeartbeatManager struct {
 	mu         sync.Mutex // guards timer lifecycle (start/stop/replace)

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -69,6 +69,10 @@ type Run struct {
 	// Written on the main goroutine; read from the HeartbeatManager timer goroutine.
 	liveRunning atomic.Bool
 
+	// lastUpdateAt tracks when the transaction log last produced a record.
+	// A live run that stays silent past RunCrashTimeout is presumed crashed.
+	lastUpdateAt time.Time
+
 	// Data reader.
 	historySource HistorySource
 	initCancel    context.CancelFunc

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -18,6 +19,11 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 		r.logger.Debug(fmt.Sprintf("perf: processRecordMsg(%T) took %s", msg, time.Since(start)))
 	}()
 	defer r.resolveFocusAfterData()
+
+	// Anything the reader produced counts as proof of life for the crash
+	// check. Terminal messages (FileComplete, Error) also land here, but
+	// they leave RunStateRunning, after which lastUpdateAt is irrelevant.
+	r.lastUpdateAt = time.Now()
 
 	switch msg := msg.(type) {
 	case RunMsg:
@@ -952,6 +958,12 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 			)
 		} else {
 			r.logger.Info("model: watcher started successfully")
+			// Seed the staleness clock from the file so a run that died
+			// before LEET started is caught on the first heartbeat rather
+			// than a full RunCrashTimeout later.
+			if info, err := os.Stat(r.runParams.RunFile); err == nil {
+				r.lastUpdateAt = info.ModTime()
+			}
 			r.heartbeatMgr.Start(r.isRunning)
 			cmds = append(cmds, r.watcherMgr.WaitForMsg)
 		}
@@ -980,6 +992,12 @@ func (r *Run) handleHeartbeat() []tea.Cmd {
 		r.heartbeatMgr.Stop()
 		return nil
 	}
+	if r.presumedCrashed() {
+		r.markPresumedCrashed()
+		// Keep listening: if the writer comes back, handleFileChange
+		// revives the run.
+		return []tea.Cmd{r.watcherMgr.WaitForMsg}
+	}
 	r.heartbeatMgr.Reset(r.isRunning)
 	return []tea.Cmd{
 		r.ReadLiveBatchCmd(r.historySource),
@@ -987,8 +1005,30 @@ func (r *Run) handleHeartbeat() []tea.Cmd {
 	}
 }
 
+// presumedCrashed reports whether a live run's transaction log has been
+// silent long enough to presume the writer is gone.
+func (r *Run) presumedCrashed() bool {
+	return !r.lastUpdateAt.IsZero() && time.Since(r.lastUpdateAt) > RunCrashTimeout
+}
+
+// markPresumedCrashed mirrors the server's stale-runs sweep: a running run
+// that stopped writing without an exit record is moved to the crashed state.
+func (r *Run) markPresumedCrashed() {
+	r.logger.Info(fmt.Sprintf(
+		"model: no transaction log updates in %v, presuming the run crashed",
+		time.Since(r.lastUpdateAt).Round(time.Second)))
+	r.setRunState(RunStateCrashed)
+	r.heartbeatMgr.Stop()
+}
+
 // handleFileChange coalesces change notifications into a read.
 func (r *Run) handleFileChange() []tea.Cmd {
+	if r.runState == RunStateCrashed {
+		// The writer came back: revive the presumed-crashed run.
+		r.logger.Info("model: transaction log updated, reviving crashed run")
+		r.lastUpdateAt = time.Now()
+		r.setRunState(RunStateRunning)
+	}
 	if r.runState != RunStateRunning {
 		return nil
 	}

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -75,6 +75,11 @@ func (r *Run) TestStopHeartbeat() {
 	}
 }
 
+// TestSetLastUpdateAt overrides the run's staleness clock.
+func (r *Run) TestSetLastUpdateAt(t time.Time) {
+	r.lastUpdateAt = t
+}
+
 // TestLayoutWidths returns the run view's current sidebar widths.
 func (r *Run) TestLayoutWidths() (left, right int) {
 	l := r.computeViewports()
@@ -363,6 +368,16 @@ func (r *WorkspaceRun) TestSetWatcherStarted(started bool) {
 
 func (r *WorkspaceRun) TestWatcherActive() bool {
 	return r.watcher != nil && r.watcher.started
+}
+
+// TestSetLastUpdateAt overrides the workspace run's staleness clock.
+func (r *WorkspaceRun) TestSetLastUpdateAt(t time.Time) {
+	r.lastUpdateAt = t
+}
+
+// TestState returns the workspace run's state.
+func (r *WorkspaceRun) TestState() RunState {
+	return r.state
 }
 
 func (w *Workspace) TestAttachRun(run *WorkspaceRun, selected bool) {

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -107,6 +107,10 @@ type WorkspaceRun struct {
 	wandbPath string
 	watcher   *WatcherManager
 	state     RunState
+
+	// lastUpdateAt tracks when the transaction log last produced a record.
+	// A live run that stays silent past RunCrashTimeout is presumed crashed.
+	lastUpdateAt time.Time
 }
 
 func NewWorkspace(

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -572,6 +572,12 @@ func (w *Workspace) ensureLiveStreaming(run *WorkspaceRun) tea.Cmd {
 			)
 			run.watcher = nil
 		} else {
+			// Seed the staleness clock from the file so a run that died
+			// before LEET started is caught on the first heartbeat rather
+			// than a full RunCrashTimeout later.
+			if info, err := os.Stat(run.wandbPath); err == nil {
+				run.lastUpdateAt = info.ModTime()
+			}
 			watcherCmd = w.waitForWatcher(run.Key)
 		}
 	}
@@ -708,6 +714,11 @@ func (w *Workspace) handleWorkspaceBatchedRecords(msg WorkspaceBatchedRecordsMsg
 
 // handleWorkspaceRecord updates per‑run and metrics state for an individual record.
 func (w *Workspace) handleWorkspaceRecord(run *WorkspaceRun, msg tea.Msg) {
+	// Every message here is derived from a transaction-log record —
+	// proof of life for the crash check. (FileComplete leaves
+	// RunStateRunning, after which lastUpdateAt is irrelevant.)
+	run.lastUpdateAt = time.Now()
+
 	switch m := msg.(type) {
 	case RunMsg:
 		w.getOrCreateRunOverview(run.Key).ProcessRunMsg(m)
@@ -756,6 +767,16 @@ func (w *Workspace) handleWorkspaceRecord(run *WorkspaceRun, msg tea.Msg) {
 
 // handleHeartbeat is invoked when the workspace heartbeat timer fires.
 func (w *Workspace) handleHeartbeat() tea.Cmd {
+	// Presume-crashed sweep: live runs whose transaction logs went silent.
+	for key, run := range w.runsByKey {
+		if run == nil || run.state != RunStateRunning || !w.selectedRuns[key] {
+			continue
+		}
+		if !run.lastUpdateAt.IsZero() && time.Since(run.lastUpdateAt) > RunCrashTimeout {
+			w.markRunPresumedCrashed(run)
+		}
+	}
+
 	if !w.anyRunRunning() {
 		w.heartbeatMgr.Stop()
 		return w.waitForLiveMsg
@@ -800,11 +821,34 @@ func (w *Workspace) handleRunReadErr(msg WorkspaceRunReadErrMsg) tea.Cmd {
 	return nil
 }
 
+// markRunPresumedCrashed mirrors the server's stale-runs sweep for a local
+// run: no transaction-log writes for RunCrashTimeout and no exit record
+// means the writer is presumed gone. The watcher stays armed so the run is
+// revived if writes resume.
+func (w *Workspace) markRunPresumedCrashed(run *WorkspaceRun) {
+	w.logger.Info(fmt.Sprintf(
+		"workspace: no transaction log updates for %s in %v, presuming the run crashed",
+		run.Key, time.Since(run.lastUpdateAt).Round(time.Second)))
+	run.state = RunStateCrashed
+	w.getOrCreateRunOverview(run.Key).SetRunState(run.state)
+	w.syncLiveRunState()
+}
+
 // handleWorkspaceFileChanged reacts to a filesystem change for a given run.
 func (w *Workspace) handleWorkspaceFileChanged(msg WorkspaceFileChangedMsg) tea.Cmd {
 	run := w.runsByKey[msg.RunKey]
 	if run == nil {
 		return nil
+	}
+
+	if run.state == RunStateCrashed {
+		// The writer came back: revive the presumed-crashed run.
+		w.logger.Info(fmt.Sprintf(
+			"workspace: transaction log updated, reviving crashed run %s", run.Key))
+		run.lastUpdateAt = time.Now()
+		run.state = RunStateRunning
+		w.getOrCreateRunOverview(run.Key).SetRunState(run.state)
+		w.syncLiveRunState()
 	}
 
 	// Re‑arm watcher for the next change if we're still watching this run.


### PR DESCRIPTION
Description
-----------
A run that died without writing an exit record stayed "Running" in LEET forever. Each streaming run now tracks when its transaction log last produced a record, and a running run that has been silent for 10 minutes flips to crashed. The check rides the existing heartbeat timer; no new timers.

The clock is seeded from the file's mtime (an OK approximation) when live streaming starts, so a run that died before LEET opened is caught on the first heartbeat rather than a full timeout later. The file watcher stays armed for crashed runs: if the writer comes back, the run revives to running and streaming resumes.

Modeled on the server's stale-runs sweep, which crashes runs after 5 minutes without a filestream heartbeat. Local write cadence varies more than the SDK's heartbeats, hence the more lenient timeout.

- [x] I updated CHANGELOG.unreleased.md, or it is not applicable
