### PR TITLE
feat(leet): show run state in the status bar

### DIFF
--- a/core/internal/leet/liveindicator.go
+++ b/core/internal/leet/liveindicator.go
@@ -1,0 +1,86 @@
+// liveindicator.go
+//
+// Run state indicators. The status bar's leftmost cell shows the state of
+// the current run: an empty circle until the state is known, then a filled
+// dot in the state color, blinking while the run is live.
+package leet
+
+import (
+	"image/color"
+	"math"
+	"time"
+
+	"charm.land/lipgloss/v2"
+)
+
+const (
+	// liveDotMark is the filled-circle glyph for known run states.
+	liveDotMark = "●"
+
+	// idleDotMark is the empty-circle glyph shown before a run's state
+	// is known.
+	idleDotMark = "○"
+
+	// livePulsePeriod is the duration of one full breathing cycle.
+	livePulsePeriod = 1500 * time.Millisecond
+
+	// LivePulseFrame is the redraw interval while a breathing indicator is
+	// on screen. The phase is derived from the wall clock, so all live
+	// indicators breathe in sync regardless of which view drives redraws.
+	LivePulseFrame = 125 * time.Millisecond
+)
+
+// livePulseAlpha returns the breathing phase in [0, 1] at now:
+// 0 at full color, 1 at the fully faded-out point of the cycle.
+func livePulseAlpha(now time.Time) float64 {
+	period := livePulsePeriod.Milliseconds()
+	phase := float64(now.UnixMilli()%period) / float64(period)
+	return 0.5 - 0.5*math.Cos(2*math.Pi*phase)
+}
+
+// The status bar's background (colorLayoutHighlight) is light in both color
+// schemes, so its state dot always uses the dark color variants.
+var (
+	statusBarFinishedColor = colorRunning.Light
+	statusBarCrashedColor  = colorCrashed.Light
+)
+
+// statusBarPulseColor returns the status bar's blinking live dot color at
+// now: the running green fading into the bar's own background and back.
+func statusBarPulseColor(now time.Time) color.Color {
+	r, g, b := rgb8(statusBarFinishedColor)
+	tr, tg, tb := rgb8(colorLayoutHighlight)
+	return blendRGB(r, g, b, tr, tg, tb, livePulseAlpha(now))
+}
+
+// renderStateIndicator renders a status bar's leftmost cell for a run in
+// the given state. Shared by the single-run view (its run) and the
+// workspace (the run under the cursor).
+func renderStateIndicator(state RunState) string {
+	glyph := idleDotMark
+	fg := moon900
+
+	switch state {
+	case RunStateRunning:
+		glyph = liveDotMark
+		fg = statusBarPulseColor(time.Now())
+	case RunStateFinished:
+		glyph = liveDotMark
+		fg = statusBarFinishedColor
+	case RunStateCrashed, RunStateFailed:
+		glyph = liveDotMark
+		fg = statusBarCrashedColor
+	}
+
+	return lipgloss.NewStyle().
+		Foreground(fg).
+		Background(colorLayoutHighlight).
+		Padding(0, 0, 0, StatusBarPadding).
+		Render(glyph)
+}
+
+// rgb8 extracts 8-bit RGB components from a color.
+func rgb8(c color.Color) (r, g, b uint8) {
+	r16, g16, b16, _ := c.RGBA()
+	return uint8(r16 >> 8), uint8(g16 >> 8), uint8(b16 >> 8)
+}

--- a/core/internal/leet/messages.go
+++ b/core/internal/leet/messages.go
@@ -94,6 +94,12 @@ type ChunkedBatchMsg struct {
 // HeartbeatMsg is sent periodically for live runs to ensure we don't miss data.
 type HeartbeatMsg struct{}
 
+// RunLivePulseMsg drives the single-run view's breathing live indicator.
+type RunLivePulseMsg struct{}
+
+// WorkspaceLivePulseMsg drives the workspace's breathing live indicators.
+type WorkspaceLivePulseMsg struct{}
+
 // LeftSidebarAnimationMsg is sent during left sidebar animations.
 type LeftSidebarAnimationMsg struct{}
 

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -73,6 +73,9 @@ type Run struct {
 	// A live run that stays silent past RunCrashTimeout is presumed crashed.
 	lastUpdateAt time.Time
 
+	// pulseTicking reports whether the live-indicator redraw loop is armed.
+	pulseTicking bool
+
 	// Data reader.
 	historySource HistorySource
 	initCancel    context.CancelFunc
@@ -332,6 +335,8 @@ func (r *Run) dispatch(msg tea.Msg) []tea.Cmd {
 		return r.handleHeartbeat()
 	case FileChangedMsg:
 		return r.handleFileChange()
+	case RunLivePulseMsg:
+		return r.handleLivePulse()
 	case tea.WindowSizeMsg:
 		r.handleWindowResize(t)
 	case LeftSidebarAnimationMsg, RightSidebarAnimationMsg:
@@ -510,18 +515,23 @@ func (r *Run) renderLoadingScreen() string {
 
 // renderStatusBar creates the status bar.
 func (r *Run) renderStatusBar() string {
+	// The indicator is styled separately from the bar so its color codes
+	// don't reset the bar's own styling mid-line.
+	indicator := renderStateIndicator(r.runState)
+	barWidth := max(r.width-lipgloss.Width(indicator), 0)
+
 	statusText := r.buildStatusText()
 	helpText := r.buildHelpText()
 
-	innerWidth := max(r.width-2*StatusBarPadding, 0)
+	innerWidth := max(barWidth-2*StatusBarPadding, 0)
 	spaceForHelp := max(innerWidth-lipgloss.Width(statusText), 0)
 	rightAligned := lipgloss.PlaceHorizontal(spaceForHelp, lipgloss.Right, helpText)
 
 	fullStatus := statusText + rightAligned
 
-	return statusBarStyle.
-		Width(r.width).
-		MaxWidth(r.width).
+	return indicator + statusBarStyle.
+		Width(barWidth).
+		MaxWidth(barWidth).
 		Render(fullStatus)
 }
 

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -34,6 +34,7 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 		r.runState = RunStateRunning
 		r.syncLiveRunning()
 		r.isLoading = false
+		return r.ensureLivePulseCmd()
 
 	case HistoryMsg:
 		r.logger.Debug("model: processing HistoryMsg")
@@ -1036,7 +1037,34 @@ func (r *Run) handleFileChange() []tea.Cmd {
 	return []tea.Cmd{
 		r.ReadLiveBatchCmd(r.historySource),
 		r.watcherMgr.WaitForMsg,
+		r.ensureLivePulseCmd(),
 	}
+}
+
+// livePulseCmd schedules the next live-indicator frame.
+func (r *Run) livePulseCmd() tea.Cmd {
+	return tea.Tick(LivePulseFrame, func(time.Time) tea.Msg {
+		return RunLivePulseMsg{}
+	})
+}
+
+// ensureLivePulseCmd starts the live-indicator redraw loop for a live run.
+// Returns nil if the loop is already ticking or the run is not live.
+func (r *Run) ensureLivePulseCmd() tea.Cmd {
+	if r.pulseTicking || r.runState != RunStateRunning {
+		return nil
+	}
+	r.pulseTicking = true
+	return r.livePulseCmd()
+}
+
+// handleLivePulse keeps the live indicator animating while the run is live.
+func (r *Run) handleLivePulse() []tea.Cmd {
+	if r.runState != RunStateRunning {
+		r.pulseTicking = false
+		return nil
+	}
+	return []tea.Cmd{r.livePulseCmd()}
 }
 
 // handleSidebarTabNav cycles focus between overview sections and the

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -316,10 +316,7 @@ func (s *RunOverviewSidebar) buildHeaderLines(contentWidth int) []string {
 	lines := make([]string, 0, 8)
 
 	if s.runOverview.State() != RunStateUnknown {
-		lines = slices.Concat(
-			lines,
-			s.renderWrappedHeaderValue("State: ", s.runOverview.StateString(), contentWidth),
-		)
+		lines = append(lines, s.renderStateHeaderLine())
 	}
 
 	lines = slices.Concat(
@@ -336,6 +333,22 @@ func (s *RunOverviewSidebar) buildHeaderLines(contentWidth int) []string {
 	}
 
 	return lines
+}
+
+// renderStateHeaderLine renders the "State:" field with state-aware coloring:
+// green while the run is live, red when it crashed or failed.
+func (s *RunOverviewSidebar) renderStateHeaderLine() string {
+	prefixText := runOverviewSidebarKeyStyle.Render("State: ")
+	valueStyle := runOverviewSidebarValueStyle
+
+	switch s.runOverview.State() {
+	case RunStateRunning:
+		valueStyle = valueStyle.Foreground(colorRunning)
+	case RunStateCrashed, RunStateFailed:
+		valueStyle = valueStyle.Foreground(colorCrashed)
+	}
+
+	return prefixText + valueStyle.Render(s.runOverview.StateString())
 }
 
 // renderWrappedHeaderValue renders a single metadata field, wrapping the value

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -269,18 +269,23 @@ var (
 		Light: lipgloss.Color("#FCBC32"),
 	}
 
-	// Color for live (running) runs: the breathing liveness dot and the
+	// Color for live (running) runs: the state indicator dot and the
 	// "Running" state text.
+	//
+	// These state colors sit on exact xterm-256 cube entries: on
+	// non-truecolor terminals (e.g. tmux without RGB overrides) the
+	// downsampler maps off-cube dark reds to gray, turning the indicator
+	// black.
 	colorRunning = AdaptiveColor{
-		Light: lipgloss.Color("#00875D"),
+		Light: lipgloss.Color("#00875F"), // xterm 29
 		Dark:  lipgloss.Color("#3DD68C"),
 	}
 
 	// Color for runs that ended badly: crashed/failed state text and the
-	// crashed liveness dot.
+	// crashed state indicator dot.
 	colorCrashed = AdaptiveColor{
-		Light: lipgloss.Color("#B02D37"),
-		Dark:  lipgloss.Color("#FF5F66"),
+		Light: lipgloss.Color("#AF0000"), // xterm 124
+		Dark:  lipgloss.Color("#FF5F5F"), // xterm 203
 	}
 )
 

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -268,6 +268,20 @@ var (
 		Dark:  lipgloss.Color("#FCBC32"),
 		Light: lipgloss.Color("#FCBC32"),
 	}
+
+	// Color for live (running) runs: the breathing liveness dot and the
+	// "Running" state text.
+	colorRunning = AdaptiveColor{
+		Light: lipgloss.Color("#00875D"),
+		Dark:  lipgloss.Color("#3DD68C"),
+	}
+
+	// Color for runs that ended badly: crashed/failed state text and the
+	// crashed liveness dot.
+	colorCrashed = AdaptiveColor{
+		Light: lipgloss.Color("#B02D37"),
+		Dark:  lipgloss.Color("#FF5F66"),
+	}
 )
 
 // ASCII art for the loading screen and the help page.

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -47,6 +47,9 @@ type Workspace struct {
 	// hasLiveRuns caches whether any selected run is in RunStateRunning.
 	hasLiveRuns atomic.Bool
 
+	// pulseTicking reports whether the live-indicator redraw loop is armed.
+	pulseTicking bool
+
 	// Run overview for each run keyed by run path.
 	runOverview        map[string]*RunOverview
 	runOverviewSidebar *RunOverviewSidebar
@@ -289,6 +292,9 @@ func (w *Workspace) Update(msg tea.Msg) tea.Cmd {
 
 	case HeartbeatMsg:
 		return w.handleHeartbeat()
+
+	case WorkspaceLivePulseMsg:
+		return w.handleLivePulse()
 
 	case ErrorMsg:
 		// Errors without a run key; per-run read errors arrive as
@@ -1151,19 +1157,44 @@ func renderLogoArt(width, height int) string {
 }
 
 func (w *Workspace) renderStatusBar() string {
+	// The indicator shows the state of the run under the cursor. It is
+	// styled separately from the bar so its color codes don't reset the
+	// bar's own styling mid-line.
+	indicator := renderStateIndicator(w.cursorRunState())
+	barWidth := max(w.width-lipgloss.Width(indicator), 0)
+
 	statusText := w.buildStatusText()
 	helpText := w.buildHelpText()
 
-	innerWidth := max(w.width-2*StatusBarPadding, 0)
+	innerWidth := max(barWidth-2*StatusBarPadding, 0)
 	spaceForHelp := max(innerWidth-lipgloss.Width(statusText), 0)
 	rightAligned := lipgloss.PlaceHorizontal(spaceForHelp, lipgloss.Right, helpText)
 
 	fullStatus := statusText + rightAligned
 
-	return statusBarStyle.
-		Width(w.width).
-		MaxWidth(w.width).
+	return indicator + statusBarStyle.
+		Width(barWidth).
+		MaxWidth(barWidth).
 		Render(fullStatus)
+}
+
+// cursorRunState returns the known state of the run under the cursor.
+//
+// Only streaming (selected) runs have live state. For others, fall back to
+// the preloaded overview, never trusting a stale Running claim from a run
+// that is no longer streaming.
+func (w *Workspace) cursorRunState() RunState {
+	cur, ok := w.runs.CurrentItem()
+	if !ok {
+		return RunStateUnknown
+	}
+	if run := w.runsByKey[cur.Key]; run != nil {
+		return run.state
+	}
+	if ro := w.runOverview[cur.Key]; ro != nil && ro.State() != RunStateRunning {
+		return ro.State()
+	}
+	return RunStateUnknown
 }
 
 func (w *Workspace) buildStatusText() string {

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -589,7 +589,7 @@ func (w *Workspace) ensureLiveStreaming(run *WorkspaceRun) tea.Cmd {
 		w.heartbeatMgr.Start(w.hasLiveRuns.Load)
 	}
 
-	return watcherCmd
+	return batchCmds(watcherCmd, w.ensureLivePulseCmd())
 }
 
 // waitForWatcher blocks until the watcher for the given run emits a change
@@ -704,7 +704,7 @@ func (w *Workspace) handleWorkspaceBatchedRecords(msg WorkspaceBatchedRecordsMsg
 
 	// Continue draining while the run is still live.
 	if run.state == RunStateRunning {
-		return w.ReadAvailableCmd(run)
+		return batchCmds(w.ReadAvailableCmd(run), w.ensureLivePulseCmd())
 	}
 
 	if !w.anyRunRunning() {
@@ -865,7 +865,34 @@ func (w *Workspace) handleWorkspaceFileChanged(msg WorkspaceFileChangedMsg) tea.
 		w.heartbeatMgr.Reset(w.hasLiveRuns.Load)
 	}
 
-	return batchCmds(w.ReadAvailableCmd(run), watcherCmd)
+	return batchCmds(w.ReadAvailableCmd(run), watcherCmd, w.ensureLivePulseCmd())
+}
+
+// livePulseCmd schedules the next live-indicator frame.
+func (w *Workspace) livePulseCmd() tea.Cmd {
+	return tea.Tick(LivePulseFrame, func(time.Time) tea.Msg {
+		return WorkspaceLivePulseMsg{}
+	})
+}
+
+// ensureLivePulseCmd starts the live-indicator redraw loop when a selected
+// run is live. Returns nil if the loop is already ticking or nothing is live.
+func (w *Workspace) ensureLivePulseCmd() tea.Cmd {
+	if w.pulseTicking || !w.anyRunRunning() {
+		return nil
+	}
+	w.pulseTicking = true
+	return w.livePulseCmd()
+}
+
+// handleLivePulse keeps the live indicators animating while any selected
+// run is live.
+func (w *Workspace) handleLivePulse() tea.Cmd {
+	if !w.anyRunRunning() {
+		w.pulseTicking = false
+		return nil
+	}
+	return w.livePulseCmd()
 }
 
 func (w *Workspace) handleQuit(msg tea.KeyPressMsg) tea.Cmd {


### PR DESCRIPTION
Description
-----------
The status bar's leftmost cell now shows a state indicator: an empty circle until the run's state is known, then a filled dot in the state color. Green for finished, red for crashed and failed, and a blinking green dot while the run is live. The single-run view shows its own run; the workspace shows the run under the cursor.

<img width="698" height="220" alt="image" src="https://github.com/user-attachments/assets/24316283-80c2-415f-a36d-a6332500bdc2" />

The blink fades the dot into the bar background and back, driven by a redraw ticker that arms itself while a live run is on screen and stops when nothing is running. The phase derives from the wall clock, so indicators blink in sync regardless of which view schedules redraws.

The overview sidebar's State line is colored to match: green while running, red for crashed and failed runs.
