### PR TITLE
feat(leet): breathe live run marks in the runs list

### DIFF
--- a/core/internal/leet/liveindicator.go
+++ b/core/internal/leet/liveindicator.go
@@ -1,6 +1,8 @@
 // liveindicator.go
 //
-// Run state indicators. The status bar's leftmost cell shows the state of
+// Run state indicators. A live run's mark in the workspace runs list
+// breathes — its color fades to the terminal background ("not filled") and
+// back to the run color. The status bar's leftmost cell shows the state of
 // the current run: an empty circle until the state is known, then a filled
 // dot in the state color, blinking while the run is live.
 package leet
@@ -36,6 +38,15 @@ func livePulseAlpha(now time.Time) float64 {
 	period := livePulsePeriod.Milliseconds()
 	phase := float64(now.UnixMilli()%period) / float64(period)
 	return 0.5 - 0.5*math.Cos(2*math.Pi*phase)
+}
+
+// runMarkPulseColor returns the color of a live run's list mark at now:
+// the run color breathing all the way down to the terminal background and
+// back, so the mark empties out and refills once per cycle.
+func runMarkPulseColor(runColor AdaptiveColor, now time.Time) color.Color {
+	r, g, b := rgb8(runColor)
+	tr, tg, tb := terminalBackgroundRGB()
+	return blendRGB(r, g, b, tr, tg, tb, livePulseAlpha(now))
 }
 
 // The status bar's background (colorLayoutHighlight) is light in both color

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -83,6 +83,19 @@ func blendRGB(r, g, b, tr, tg, tb uint8, alpha float64) color.Color {
 	))
 }
 
+// terminalBackgroundRGB returns the terminal's background color, falling
+// back to a typical dark/light background when detection failed.
+func terminalBackgroundRGB() (r, g, b uint8) {
+	initTerminalBg()
+	if termBgDetected {
+		return termBgR, termBgG, termBgB
+	}
+	if IsDarkBackground() {
+		return 0x1c, 0x1c, 0x1c
+	}
+	return 0xff, 0xff, 0xff
+}
+
 // getOddRunStyleColor returns a color 5% darker than the terminal background.
 func getOddRunStyleColor() color.Color {
 	initTerminalBg()

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -1506,8 +1506,15 @@ func (w *Workspace) renderRunLines(contentWidth int) []string {
 			mark = PinnedRunMark
 		}
 
+		// A live run's mark breathes: its color fades all the way to the
+		// terminal background ("not filled") and back to the run color.
+		prefixStyle := lipgloss.NewStyle().Foreground(runColor)
+		if run := w.runsByKey[runKey]; run != nil && run.state == RunStateRunning {
+			prefixStyle = prefixStyle.Foreground(runMarkPulseColor(runColor, time.Now()))
+		}
+
 		// Render prefix without background.
-		prefix := lipgloss.NewStyle().Foreground(runColor).Render(mark + " ")
+		prefix := prefixStyle.Render(mark + " ")
 		prefixWidth := lipgloss.Width(prefix)
 
 		// Apply subtle muting to unselected/unpinned runs


### PR DESCRIPTION
Description
-----------
A running run's mark in the workspace runs list now animates: its color fades from the run color to the terminal background and back once per pulse cycle, so live runs stand out at a glance without extra glyphs.

<img width="800" height="150" alt="leetliverun" src="https://github.com/user-attachments/assets/f4259616-34b1-4be7-8c24-4be2f79892e2" />
