### PR TITLE
chore: remove auth from wandb-core for publishing opentelemetry

### DIFF
--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
-	"github.com/wandb/wandb/core/internal/api"
 	"github.com/wandb/wandb/core/internal/httplayers"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/version"
@@ -495,14 +494,6 @@ func newOpenTelemetryProxy(
 func newOTLPHTTPClient(
 	wandbSettings *settings.Settings,
 ) (*http.Client, error) {
-	credentialProvider, err := api.NewCredentialProvider(
-		wandbSettings,
-		slog.Default(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.Proxy = wandbSettings.GetProxyFn()
 	transport.ProxyConnectHeader = wandbSettings.GetProxyConnectHeader()
@@ -521,7 +512,6 @@ func newOTLPHTTPClient(
 		transport,
 		httplayers.Concat(
 			httplayers.DefaultHeaders(extraHeaders),
-			credentialProvider,
 		),
 	)
 	return client, nil

--- a/core/internal/analytics/opentelemetryproxy_test.go
+++ b/core/internal/analytics/opentelemetryproxy_test.go
@@ -341,40 +341,6 @@ func TestTelemetryRecorder_RecordDuration(t *testing.T) {
 	assert.Equal(t, "local", metric.Attributes["execution_context"])
 }
 
-func TestTelemetryRecorder_SendsAPIKeyAuth(t *testing.T) {
-	proxy := analyticstest.NewOpenTelemetryProxyTest(t)
-	recorder := analytics.NewTelemetryRecorder(
-		proxy.OpenTelemetryProxy,
-		analytics.NewTelemetryContext(),
-	)
-
-	recorder.IncrementCounterAndLogEvent(
-		t.Context(),
-		"authenticated_event",
-		nil,
-		analytics.LowCardinalityAttributes{},
-	)
-	require.NoError(t, proxy.Shutdown(context.Background()))
-
-	requests := proxy.Requests()
-	assert.Greater(t, len(requests), 1, "expected at least two requests")
-	for _, req := range requests {
-		// The capability probe sent during proxy construction is intentionally
-		// unauthenticated and carries no body.
-		// Only OTLP export requests must include the API key.
-		if req.ContentLength == 0 {
-			continue
-		}
-		assert.Equal(
-			t,
-			"Basic YXBpOnRlc3QtYXBpLWtleQ==",
-			req.Authorization,
-			"path %s",
-			req.Path,
-		)
-	}
-}
-
 func TestTelemetryRecorder_ErrorLog(t *testing.T) {
 	proxy := analyticstest.NewOpenTelemetryProxyTest(t)
 	recorder := analytics.NewTelemetryRecorder(


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

This pr removes including authentication as part of the opentelemtry requests to the W&B backend.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->