### PR TITLE
chore: add back opentelemetry publishing in python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "pydantic>=2.6,<3",
     "packaging",
     "opentelemetry-api>=1.43.0",
+    "opentelemetry-sdk>=1.43.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.43.0",
     "xxhash>=3.0.0",
 ]
 classifiers = [

--- a/tests/unit_tests/test_lib/test_telemetry.py
+++ b/tests/unit_tests/test_lib/test_telemetry.py
@@ -28,13 +28,14 @@ def test_telemetry_parse():
 
 def test_disabled_telemetry_does_not_publish(monkeypatch):
     monkeypatch.setattr(env, "error_reporting_enabled", lambda: False)
-    service_api = MagicMock(initialized=True)
-    recorder = TelemetryRecorder(service_api=service_api)
+    open_telemetry_proxy = MagicMock()
+    recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
 
     recorder.increment_counter_and_log_event("test")
     recorder.exception(Exception("test"))
 
-    service_api.api_publish.assert_not_called()
+    open_telemetry_proxy.increment_counter.assert_not_called()
+    open_telemetry_proxy.log.assert_not_called()
 
 
 def test_telemetry_without_service_api_does_not_publish(monkeypatch):
@@ -63,9 +64,9 @@ def test_telemetry_without_service_api_does_not_publish(monkeypatch):
 def test_errors_do_not_propagate_from_telemetry(monkeypatch):
     monkeypatch.setattr(env, "error_reporting_enabled", lambda: True)
     # _pretend_service_connected(monkeypatch)
-    service_api = MagicMock()
-    service_api.api_publish.side_effect = OSError("service connection closed")
-    recorder = TelemetryRecorder(service_api=service_api)
+    open_telemetry_proxy = MagicMock()
+    open_telemetry_proxy.increment_counter.side_effect = RuntimeError()
+    recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
 
     recorder.increment_counter(
         "test_counter",
@@ -73,46 +74,20 @@ def test_errors_do_not_propagate_from_telemetry(monkeypatch):
     )
     recorder.log("test log")
 
-    assert service_api.api_publish.call_count == 2
+    assert open_telemetry_proxy.increment_counter.call_count == 1
+    assert open_telemetry_proxy.log.call_count == 1
 
 
 def test_reraise_raises_original_on_telemetry_fail(monkeypatch):
     """`reraise` must always re-raise the original exception, even if recording
     telemetry itself fails."""
     monkeypatch.setattr(env, "error_reporting_enabled", lambda: True)
-    monkeypatch.setattr(
-        opentelemetry_proxy,
-        "OpenTelemetryLogRequest",
-        MagicMock(side_effect=ValueError()),
-    )
-    recorder = TelemetryRecorder(service_api=MagicMock())
+    open_telemetry_proxy = MagicMock()
+    open_telemetry_proxy.log.side_effect = ValueError()
+    recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
 
     original = RuntimeError("original error")
     with pytest.raises(RuntimeError, match="original error") as exc_info:
         recorder.reraise(original)
 
     assert exc_info.value is original
-
-
-def test_telemetry_does_not_publish_without_service_connection(monkeypatch):
-    monkeypatch.setattr(env, "error_reporting_enabled", lambda: True)
-    service_api = MagicMock(initialized=False)
-    recorder = TelemetryRecorder(service_api=service_api)
-
-    recorder.increment_counter("test_counter", LowCardinalityAttributes())
-    recorder.log("test log")
-    recorder.increment_counter_and_log_event("test event")
-    recorder.exception(Exception("test exception"))
-
-    service_api.api_publish.assert_not_called()
-
-
-def test_telemetry_publishes_with_service_connection(monkeypatch):
-    monkeypatch.setattr(env, "error_reporting_enabled", lambda: True)
-    service_api = MagicMock()
-    recorder = TelemetryRecorder(service_api=service_api)
-
-    recorder.increment_counter("test_counter", LowCardinalityAttributes())
-    recorder.log("test log")
-
-    assert service_api.api_publish.call_count == 2

--- a/tests/unit_tests/test_lib/test_telemetry.py
+++ b/tests/unit_tests/test_lib/test_telemetry.py
@@ -1,5 +1,6 @@
 """telemetry lib tests."""
 
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,9 +8,12 @@ from wandb import env
 from wandb.analytics.opentelemetry import opentelemetry_proxy
 from wandb.analytics.opentelemetry.opentelemetry_proxy import (
     LowCardinalityAttributes,
+    OpenTelemetryProxy,
     TelemetryRecorder,
+    disable,
 )
 from wandb.sdk.lib import telemetry
+from wandb.sdk.wandb_settings import Settings
 
 
 def test_telemetry_parse():
@@ -26,7 +30,7 @@ def test_telemetry_parse():
     assert pf(["@wandbcode{j=i-p,"]) == dict(j="i_p")
 
 
-def test_disabled_telemetry_does_not_publish(monkeypatch):
+def test_no_error_reporting_telemetry_does_not_publish(monkeypatch):
     monkeypatch.setattr(env, "error_reporting_enabled", lambda: False)
     open_telemetry_proxy = MagicMock()
     recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
@@ -38,27 +42,32 @@ def test_disabled_telemetry_does_not_publish(monkeypatch):
     open_telemetry_proxy.log.assert_not_called()
 
 
-def test_telemetry_without_service_api_does_not_publish(monkeypatch):
-    counter_request = MagicMock()
-    log_request = MagicMock()
-    api_request = MagicMock()
-    monkeypatch.setattr(
-        opentelemetry_proxy, "OpenTelemetryCounterRequest", counter_request
-    )
-    monkeypatch.setattr(opentelemetry_proxy, "OpenTelemetryLogRequest", log_request)
-    monkeypatch.setattr(opentelemetry_proxy, "ApiRequest", api_request)
+def test_disabled_telemetry_does_not_publish(monkeypatch):
+    monkeypatch.setattr(env, "error_reporting_enabled", lambda: True)
+    monkeypatch.setattr(opentelemetry_proxy, "_disabled", threading.Event())
 
-    recorder = TelemetryRecorder()
+    disable()
 
-    # even if we cannot publish, calling the methods should still be safe
+    open_telemetry_proxy = OpenTelemetryProxy.from_settings(settings=Settings())
+    assert open_telemetry_proxy is None
+
+    recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
+
+    recorder.increment_counter_and_log_event("test")
+    recorder.exception(Exception("test"))
+
+
+def test_telemetry_without_proxy_does_not_publish():
+    open_telemetry_proxy = MagicMock()
+    recorder = TelemetryRecorder(open_telemetry_proxy=None)
+
     recorder.increment_counter("test_counter", LowCardinalityAttributes())
     recorder.log("test log")
     recorder.increment_counter_and_log_event("test event")
     recorder.exception(Exception("test exception"))
 
-    counter_request.assert_not_called()
-    log_request.assert_not_called()
-    api_request.assert_not_called()
+    open_telemetry_proxy.increment_counter.assert_not_called()
+    open_telemetry_proxy.log.assert_not_called()
 
 
 def test_errors_do_not_propagate_from_telemetry(monkeypatch):

--- a/wandb/analytics/__init__.py
+++ b/wandb/analytics/__init__.py
@@ -2,7 +2,8 @@ __all__ = (
     "get_sentry",
     "TelemetryContext",
     "TelemetryRecorder",
+    "OpenTelemetryProxy",
 )
 
-from .opentelemetry import TelemetryContext, TelemetryRecorder
+from .opentelemetry import OpenTelemetryProxy, TelemetryContext, TelemetryRecorder
 from .sentry import get_sentry

--- a/wandb/analytics/opentelemetry/__init__.py
+++ b/wandb/analytics/opentelemetry/__init__.py
@@ -8,6 +8,7 @@ into Datadog.
 __all__ = (
     "TelemetryContext",
     "TelemetryRecorder",
+    "OpenTelemetryProxy",
 )
 
-from .opentelemetry_proxy import TelemetryContext, TelemetryRecorder
+from .opentelemetry_proxy import OpenTelemetryProxy, TelemetryContext, TelemetryRecorder

--- a/wandb/analytics/opentelemetry/opentelemetry_proxy.py
+++ b/wandb/analytics/opentelemetry/opentelemetry_proxy.py
@@ -3,27 +3,54 @@ from __future__ import annotations
 import contextlib
 import functools
 import platform
+import threading
 import traceback
 from collections.abc import Callable
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Concatenate
 
+import requests
 from opentelemetry._logs import SeverityNumber
+from opentelemetry.metrics import Counter
+from opentelemetry.sdk.metrics.export import AggregationTemporality
 from typing_extensions import Never, ParamSpec
 
-from wandb import env
-from wandb.proto.wandb_api_pb2 import ApiRequest
-from wandb.proto.wandb_otel_pb2 import (
-    LowCardinalityAttributes as LowCardinalityAttributesProto,
-)
-from wandb.proto.wandb_otel_pb2 import (
-    OpenTelemetryCounterRequest,
-    OpenTelemetryLogRequest,
-    OpenTelemetryRequest,
-)
+from wandb.sdk.wandb_settings import Settings
 
 if TYPE_CHECKING:
-    from wandb.apis.public.service_api import ServiceApi
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.resources import Resource
+
+# defaultExportInterval mirror: how often batched metrics/logs are flushed to
+# the backend proxy.
+_DEFAULT_EXPORT_INTERVAL_MILLIS = 60_000
+
+# defaultExportTimeout mirror: total time allowed for a single export to
+# collect and send its records.
+_DEFAULT_EXPORT_TIMEOUT_MILLIS = 5_000
+
+# httpClientTimeout mirror: per-request timeout for HTTP calls to the backend.
+_HTTP_CLIENT_TIMEOUT_SECONDS = 10
+
+# Backend OpenTelemetry proxy ingestion paths, appended to the base URL.
+_METRICS_PATH = "/sdk/otel/v1/metrics"
+_LOGS_PATH = "/sdk/otel/v1/logs"
+
+_DEFAULT_SERVICE_NAME = "sdk-wandb"
+
+# _disabled gates OpenTelemetryProxy for the whole process. Once set, no new
+# proxy is created and telemetry becomes a no-op.
+_disabled = threading.Event()
+
+
+def disable() -> None:
+    """Turn analytics off for the whole process.
+
+    Once called, `OpenTelemetryProxy.from_settings` returns `None`, so no
+    further telemetry is recorded.
+    """
+    _disabled.set()
 
 
 @dataclass(frozen=True)
@@ -169,7 +196,7 @@ def guard(
         **kwargs: _P.kwargs,
     ) -> None:
         with contextlib.suppress(Exception):
-            if self._service_api is None or not self._service_api.initialized:
+            if self._open_telemetry_proxy is None:
                 return
 
             method(self, *args, **kwargs)
@@ -192,7 +219,7 @@ class TelemetryRecorder:
 
     def __init__(
         self,
-        service_api: ServiceApi | None = None,
+        open_telemetry_proxy: OpenTelemetryProxy | None = None,
         context: TelemetryContext | None = None,
     ) -> None:
         """Initialize a TelemetryRecorder.
@@ -202,7 +229,7 @@ class TelemetryRecorder:
                 When omitted, telemetry calls are no-ops.
             context: The attributes to add to each emitted record.
         """
-        self._service_api = service_api if env.error_reporting_enabled() else None
+        self._open_telemetry_proxy = open_telemetry_proxy
         self._context = context or TelemetryContext()
 
     def with_context(
@@ -219,7 +246,7 @@ class TelemetryRecorder:
         recorder or its siblings.
         """
         return TelemetryRecorder(
-            self._service_api,
+            self._open_telemetry_proxy,
             self._context.with_attributes(
                 low_cardinality_attributes or LowCardinalityAttributes(),
                 high_cardinality_attributes or {},
@@ -238,27 +265,14 @@ class TelemetryRecorder:
         from the current context plus the low-cardinality attributes
         passed when this method is called.
         """
-        assert self._service_api is not None
+        assert self._open_telemetry_proxy is not None
 
         merged_attributes = low_cardinality_attributes.merge(
             self._context.low_cardinality_attributes
         )
-        otel_metric_request = OpenTelemetryCounterRequest(
-            name=name,
-            low_cardinality_attributes=LowCardinalityAttributesProto(
-                python_runtime=merged_attributes.python_runtime,
-                wandb_version=merged_attributes.wandb_version,
-                python_version=merged_attributes.python_version,
-                exception_type=merged_attributes.exception_type,
-            ),
-        )
-
-        self._service_api.api_publish(
-            ApiRequest(
-                open_telemetry_request=OpenTelemetryRequest(
-                    open_telemetry_counter_request=otel_metric_request,
-                ),
-            ),
+        self._open_telemetry_proxy.increment_counter(
+            name,
+            merged_attributes.as_dict(),
         )
 
     @guard
@@ -273,25 +287,17 @@ class TelemetryRecorder:
         The log record contains the attributes from the current context,
         in addition to the attributes passed when this method is called.
         """
-        assert self._service_api is not None
+        assert self._open_telemetry_proxy is not None
 
         merged_attributes = {
             **self._context.low_cardinality_attributes.as_dict(),
             **self._context.high_cardinality_attributes,
             **(attributes or {}),
         }
-        otel_log_request = OpenTelemetryLogRequest(
-            message=message,
-            attributes=merged_attributes,
-            severity=severity.value,
-        )
-
-        self._service_api.api_publish(
-            ApiRequest(
-                open_telemetry_request=OpenTelemetryRequest(
-                    open_telemetry_log_request=otel_log_request,
-                ),
-            ),
+        self._open_telemetry_proxy.log(
+            message,
+            merged_attributes,
+            severity,
         )
 
     @guard
@@ -352,6 +358,165 @@ class TelemetryRecorder:
         # or replace the exception we re-raise.
         self.exception(exc)
         raise exc
+
+
+class OpenTelemetryProxy:
+    """Exports OpenTelemetry metrics and logs to the W&B backend proxy API.
+
+    The proxy owns the OpenTelemetry SDK meter and log providers along with
+    their OTLP/HTTP exporters, and should be shut down when telemetry is no longer needed.
+
+    This class should not be used directly.
+    Instead, use the `TelemetryRecorder` class to record all telemetry.
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+    ) -> None:
+        """Initialize the proxy and its OpenTelemetry providers.
+
+        Args:
+            settings: The settings to use to configure the proxy.
+        """
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+        if _disabled.is_set() or settings._offline:
+            return None
+
+        session = requests.Session()
+
+        resource = Resource.create({SERVICE_NAME: _DEFAULT_SERVICE_NAME})
+        self._meter_provider = self._build_meter_provider(
+            resource=resource,
+            endpoint=settings.base_url,
+            session=session,
+        )
+        self._logger_provider = self._build_logger_provider(
+            resource=resource,
+            endpoint=settings.base_url,
+            session=session,
+        )
+
+        # Counters are cached by name so the same instrument is reused across
+        # calls, avoiding duplicate-instrument warnings from the SDK.
+        self._counters: dict[str, Counter] = {}
+        self._counters_lock = threading.Lock()
+
+        # shutdown guards Shutdown so the providers are only shut down once.
+        self._shutdown = False
+        self._shutdown_lock = threading.Lock()
+
+    def _build_meter_provider(
+        self,
+        *,
+        resource: Resource,
+        endpoint: str,
+        session: requests.Session,
+    ) -> MeterProvider:
+        """Build a meter provider that exports metrics via OTLP/HTTP."""
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+        from opentelemetry.sdk.metrics import Counter as SdkCounter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+        exporter = OTLPMetricExporter(
+            endpoint=endpoint.rstrip("/") + _METRICS_PATH,
+            session=session,
+            timeout=_HTTP_CLIENT_TIMEOUT_SECONDS,
+            preferred_temporality={SdkCounter: AggregationTemporality.DELTA},
+        )
+        reader = PeriodicExportingMetricReader(
+            exporter,
+            export_interval_millis=_DEFAULT_EXPORT_INTERVAL_MILLIS,
+            export_timeout_millis=_DEFAULT_EXPORT_TIMEOUT_MILLIS,
+        )
+        return MeterProvider(resource=resource, metric_readers=[reader])
+
+    def _build_logger_provider(
+        self,
+        *,
+        resource: Resource,
+        endpoint: str,
+        session: requests.Session,
+    ) -> LoggerProvider:
+        """Build a logger provider that exports logs via OTLP/HTTP."""
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+
+        exporter = OTLPLogExporter(
+            endpoint=endpoint.rstrip("/") + _LOGS_PATH,
+            session=session,
+            timeout=_HTTP_CLIENT_TIMEOUT_SECONDS,
+        )
+        provider = LoggerProvider(resource=resource)
+        provider.add_log_record_processor(
+            BatchLogRecordProcessor(
+                exporter,
+                schedule_delay_millis=_DEFAULT_EXPORT_INTERVAL_MILLIS,
+                export_timeout_millis=_DEFAULT_EXPORT_TIMEOUT_MILLIS,
+            )
+        )
+        return provider
+
+    def increment_counter(
+        self,
+        name: str,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        """Increment the counter metric `name` by 1 with the given attributes."""
+        if self._shutdown:
+            return
+
+        counter = self._counter(name)
+        counter.add(1, attributes or {})
+
+    def _counter(self, name: str) -> Counter:
+        with self._counters_lock:
+            counter = self._counters.get(name)
+            if counter is None:
+                meter = self._meter_provider.get_meter(_DEFAULT_SERVICE_NAME)
+                counter = meter.create_counter(name)
+                self._counters[name] = counter
+            return counter
+
+    def log(
+        self,
+        body: str,
+        attributes: dict[str, str] | None = None,
+        severity: SeverityNumber = SeverityNumber.INFO,
+    ) -> None:
+        """Emit a log record with the given body, attributes, and severity."""
+        if self._shutdown:
+            return
+
+        logger = self._logger_provider.get_logger(_DEFAULT_SERVICE_NAME)
+        logger.emit(
+            body=body,
+            severity_number=severity,
+            severity_text=severity.name,
+            attributes=attributes or {},
+        )
+
+    def shutdown(self, timeout_millis: float = 30_000) -> None:
+        """Flush pending records and shut down the providers.
+
+        After this returns, the proxy becomes a no-op. Additional calls are
+        ignored. Should be called once when telemetry is no longer needed.
+        """
+        with self._shutdown_lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+
+        with contextlib.suppress(Exception):
+            self._meter_provider.shutdown(timeout_millis=timeout_millis)
+        with contextlib.suppress(Exception):
+            self._logger_provider.shutdown()
 
 
 def _exception_stacktrace(exc: Exception) -> str:

--- a/wandb/analytics/opentelemetry/opentelemetry_proxy.py
+++ b/wandb/analytics/opentelemetry/opentelemetry_proxy.py
@@ -15,6 +15,7 @@ from opentelemetry.metrics import Counter
 from opentelemetry.sdk.metrics.export import AggregationTemporality
 from typing_extensions import Never, ParamSpec
 
+from wandb import env
 from wandb.sdk.wandb_settings import Settings
 
 if TYPE_CHECKING:
@@ -196,7 +197,7 @@ def guard(
         **kwargs: _P.kwargs,
     ) -> None:
         with contextlib.suppress(Exception):
-            if self._open_telemetry_proxy is None:
+            if not self._enabled or self._open_telemetry_proxy is None:
                 return
 
             method(self, *args, **kwargs)
@@ -229,6 +230,7 @@ class TelemetryRecorder:
                 When omitted, telemetry calls are no-ops.
             context: The attributes to add to each emitted record.
         """
+        self._enabled = bool(env.error_reporting_enabled())
         self._open_telemetry_proxy = open_telemetry_proxy
         self._context = context or TelemetryContext()
 
@@ -370,6 +372,13 @@ class OpenTelemetryProxy:
     Instead, use the `TelemetryRecorder` class to record all telemetry.
     """
 
+    @classmethod
+    def from_settings(cls, settings: Settings) -> OpenTelemetryProxy | None:
+        """Create a proxy from settings, or None if telemetry is disabled."""
+        if _disabled.is_set() or settings._offline:
+            return None
+        return cls(settings=settings)
+
     def __init__(
         self,
         *,
@@ -381,9 +390,6 @@ class OpenTelemetryProxy:
             settings: The settings to use to configure the proxy.
         """
         from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-
-        if _disabled.is_set() or settings._offline:
-            return None
 
         session = requests.Session()
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -22,6 +22,7 @@ import yaml
 from click.exceptions import ClickException
 
 import wandb
+from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 import wandb.errors
 import wandb.sdk.verify.verify as wandb_verify
 from wandb import Config, Error, env, util, wandb_agent
@@ -1798,8 +1799,9 @@ def launch(
 
     api = _get_cling_api()
     get_sentry().configure_scope(process_context="launch_cli")
-    service_api = ServiceApi(wandb_setup.singleton().settings)
-    telemetry_recorder = TelemetryRecorder(service_api=service_api)
+    settings = wandb_setup.singleton().settings.model_copy()
+    open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+    telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
 
     if run_async and queue is not None:
         raise LaunchError(
@@ -2043,8 +2045,9 @@ def launch_agent(
         _launch.set_launch_logfile(log_file)
 
     api = _get_cling_api()
-    service_api = ServiceApi(wandb_setup.singleton().settings)
-    telemetry_recorder = TelemetryRecorder(service_api=service_api)
+    settings = wandb_setup.singleton().settings.model_copy()
+    open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+    telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
     get_sentry().configure_scope(process_context="launch_agent")
     agent_config, api = _launch.resolve_agent_config(
         entity, max_jobs, queues, config, verbose
@@ -2189,8 +2192,9 @@ def scheduler(
         ctx.invoke(login, no_offline=True)
         api = InternalApi(reset=True)
 
-    service_api = ServiceApi(wandb_setup.singleton().settings)
-    telemetry_recorder = TelemetryRecorder(service_api=service_api)
+    settings = wandb_setup.singleton().settings.model_copy()
+    open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+    telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
     get_sentry().configure_scope(process_context="sweep_scheduler")
     wandb.termlog("Starting a Launch Scheduler 🚀")
     from wandb.sdk.launch.sweeps import load_scheduler

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -22,13 +22,12 @@ import yaml
 from click.exceptions import ClickException
 
 import wandb
-from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 import wandb.errors
 import wandb.sdk.verify.verify as wandb_verify
 from wandb import Config, Error, env, util, wandb_agent
 from wandb.analytics import TelemetryRecorder, get_sentry
+from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 from wandb.apis import InternalApi, PublicApi
-from wandb.apis.public.service_api import ServiceApi
 from wandb.cli import beta_sync
 from wandb.errors.links import url_registry
 from wandb.sdk import wandb_setup, wandb_sweep

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1799,7 +1799,7 @@ def launch(
     api = _get_cling_api()
     get_sentry().configure_scope(process_context="launch_cli")
     settings = wandb_setup.singleton().settings.model_copy()
-    open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+    open_telemetry_proxy = OpenTelemetryProxy.from_settings(settings=settings)
     telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
 
     if run_async and queue is not None:
@@ -2045,7 +2045,7 @@ def launch_agent(
 
     api = _get_cling_api()
     settings = wandb_setup.singleton().settings.model_copy()
-    open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+    open_telemetry_proxy = OpenTelemetryProxy.from_settings(settings=settings)
     telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
     get_sentry().configure_scope(process_context="launch_agent")
     agent_config, api = _launch.resolve_agent_config(
@@ -2192,7 +2192,7 @@ def scheduler(
         api = InternalApi(reset=True)
 
     settings = wandb_setup.singleton().settings.model_copy()
-    open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+    open_telemetry_proxy = OpenTelemetryProxy.from_settings(settings=settings)
     telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
     get_sentry().configure_scope(process_context="sweep_scheduler")
     wandb.termlog("Starting a Launch Scheduler 🚀")

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2331,13 +2331,17 @@ class Artifact:
             ArtifactNotLoggedError: If the artifact is not logged.
             ValueError: If the verification fails.
         """
-        from wandb.analytics import TelemetryRecorder
+        from wandb.analytics import OpenTelemetryProxy, TelemetryRecorder
         from wandb.analytics.opentelemetry.opentelemetry_proxy import (
             LowCardinalityAttributes,
         )
 
-        TelemetryRecorder(service_api=self._get_service_api()).increment_counter(
-            "artifact_verify", LowCardinalityAttributes()
+        proxy = OpenTelemetryProxy.from_settings(
+            settings=wandb_setup.singleton().settings.model_copy(),
+        )
+        TelemetryRecorder(open_telemetry_proxy=proxy).increment_counter(
+            "artifact_verify",
+            LowCardinalityAttributes(),
         )
 
         root = root or self._default_root()

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -21,6 +21,7 @@ import click
 import wandb
 from wandb import env, util
 from wandb.analytics import TelemetryRecorder, get_sentry
+from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 from wandb.apis.normalize import normalize_exceptions
 from wandb.errors import AuthenticationError, CommError, UsageError
 from wandb.integration.sagemaker import parse_sm_secrets
@@ -307,7 +308,9 @@ class Api:
         self._request_proxies = dict(proxies or {})
         self._service_api = self._new_service_api()
         self._telemetry_recorder = telemetry_recorder or TelemetryRecorder(
-            service_api=self._service_api,
+            open_telemetry_proxy=OpenTelemetryProxy(
+                settings=wandb_setup.singleton().settings.model_copy(),
+            ),
         )
 
         self.retry_callback = retry_callback

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -308,7 +308,7 @@ class Api:
         self._request_proxies = dict(proxies or {})
         self._service_api = self._new_service_api()
         self._telemetry_recorder = telemetry_recorder or TelemetryRecorder(
-            open_telemetry_proxy=OpenTelemetryProxy(
+            open_telemetry_proxy=OpenTelemetryProxy.from_settings(
                 settings=wandb_setup.singleton().settings.model_copy(),
             ),
         )

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import wandb
 from wandb import util
 from wandb.analytics import TelemetryRecorder, get_sentry
+from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 from wandb.apis.public.service_api import ServiceApi
 from wandb.errors import CommError, UsageError
 from wandb.errors.util import ProtobufErrorHandler
@@ -271,8 +272,10 @@ class SendManager:
         self._record_exit = None
         self._exit_result = None
 
-        service_api = ServiceApi(settings)
-        self._telemetry_recorder = TelemetryRecorder(service_api=service_api)
+        open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+        self._telemetry_recorder = TelemetryRecorder(
+            open_telemetry_proxy=open_telemetry_proxy
+        )
         self._api = internal_api.Api(
             default_settings=settings,
             retry_callback=self.retry_callback,

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -22,7 +22,6 @@ import wandb
 from wandb import util
 from wandb.analytics import TelemetryRecorder, get_sentry
 from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
-from wandb.apis.public.service_api import ServiceApi
 from wandb.errors import CommError, UsageError
 from wandb.errors.util import ProtobufErrorHandler
 from wandb.filesync.dir_watcher import DirWatcher

--- a/wandb/sdk/internal/sender.py
+++ b/wandb/sdk/internal/sender.py
@@ -271,7 +271,7 @@ class SendManager:
         self._record_exit = None
         self._exit_result = None
 
-        open_telemetry_proxy = OpenTelemetryProxy(settings=settings)
+        open_telemetry_proxy = OpenTelemetryProxy.from_settings(settings=settings)
         self._telemetry_recorder = TelemetryRecorder(
             open_telemetry_proxy=open_telemetry_proxy
         )

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Literal
 from typing_extensions import Any, Protocol
 
 import wandb
+from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 import wandb.env
 from wandb import env, trigger
 from wandb.analytics import TelemetryRecorder, get_sentry
@@ -1458,7 +1459,8 @@ def init(  # noqa: C901
 
     # Create a noop telemetry recorder while we do not know the user's credentials
     # once that is resolve we can create a proper telemetry recorder.
-    telemetry_recorder = TelemetryRecorder()
+    open_telemetry_proxy = OpenTelemetryProxy(settings=init_settings)
+    telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
 
     try:
         wl = wandb_setup.singleton()
@@ -1470,8 +1472,9 @@ def init(  # noqa: C901
 
         # Create a telemetry recorder once we know the user's credentials
         # Anything after this point will actually record telemetry.
-        service_api = ServiceApi(run_settings)
-        telemetry_recorder = TelemetryRecorder(service_api=service_api)
+        telemetry_recorder = TelemetryRecorder(
+            open_telemetry_proxy=OpenTelemetryProxy(settings=run_settings)
+        )
 
         if isinstance(run_settings.reinit, bool):
             wi.deprecated_features_used.append(

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -1458,7 +1458,7 @@ def init(  # noqa: C901
 
     # Create a noop telemetry recorder while we do not know the user's credentials
     # once that is resolve we can create a proper telemetry recorder.
-    open_telemetry_proxy = OpenTelemetryProxy(settings=init_settings)
+    open_telemetry_proxy = OpenTelemetryProxy.from_settings(settings=init_settings)
     telemetry_recorder = TelemetryRecorder(open_telemetry_proxy=open_telemetry_proxy)
 
     try:
@@ -1472,7 +1472,7 @@ def init(  # noqa: C901
         # Create a telemetry recorder once we know the user's credentials
         # Anything after this point will actually record telemetry.
         telemetry_recorder = TelemetryRecorder(
-            open_telemetry_proxy=OpenTelemetryProxy(settings=run_settings)
+            open_telemetry_proxy=OpenTelemetryProxy.from_settings(settings=run_settings)
         )
 
         if isinstance(run_settings.reinit, bool):

--- a/wandb/sdk/wandb_init.py
+++ b/wandb/sdk/wandb_init.py
@@ -27,11 +27,10 @@ from typing import TYPE_CHECKING, Literal
 from typing_extensions import Any, Protocol
 
 import wandb
-from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 import wandb.env
 from wandb import env, trigger
 from wandb.analytics import TelemetryRecorder, get_sentry
-from wandb.apis.public.service_api import ServiceApi
+from wandb.analytics.opentelemetry.opentelemetry_proxy import OpenTelemetryProxy
 from wandb.errors import Error, UsageError
 from wandb.errors.links import url_registry
 from wandb.errors.util import ProtobufErrorHandler


### PR DESCRIPTION
## Description

What does the PR do? Include a concise description of the PR contents.

This PR removes the `ServiceApi` from the `TelemetryRecorder`needed for publishing otel events via `wandb-core`

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

## Testing

How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->