### PR TITLE
fix(leet): preserve unknown config keys across saves

### DIFF
--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -186,9 +188,15 @@ type LayoutOverrides struct {
 // All setter methods automatically save changes to disk.
 // Getters use read locks for concurrent access.
 type ConfigManager struct {
-	mu                sync.RWMutex
-	path              string
-	config            Config
+	mu     sync.RWMutex
+	path   string
+	config Config
+
+	// unknown holds config-file keys this build doesn't recognize,
+	// captured at load and written back on save, so settings from newer
+	// builds survive round-trips through older ones.
+	unknown map[string]json.RawMessage
+
 	pendingGridConfig gridConfigTarget
 	logger            *observability.CoreLogger
 }
@@ -272,12 +280,32 @@ func (cm *ConfigManager) loadOrCreateConfig() error {
 	}
 
 	err = json.Unmarshal(data, &cm.config)
+	cm.unknown = unknownConfigKeys(data)
 
 	// Unmarshal decodes what it can before failing, and the caller keeps
 	// the partial config, so normalize even on error.
 	cm.normalizeConfig()
 
 	return err
+}
+
+// unknownConfigKeys returns the top-level keys in data that do not map to
+// any Config field, or nil if there are none.
+func unknownConfigKeys(data []byte) map[string]json.RawMessage {
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(data, &raw) != nil {
+		return nil
+	}
+
+	for field := range reflect.TypeFor[Config]().Fields() {
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		delete(raw, name)
+	}
+
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
 }
 
 // normalizeConfig ensures all config values are within valid ranges.
@@ -404,7 +432,7 @@ func clamp(val, minimum, maximum int) int {
 //
 // Must be called while holding the lock.
 func (cm *ConfigManager) save() error {
-	data, err := json.MarshalIndent(cm.config, "", "  ")
+	data, err := cm.marshalConfig()
 	if err != nil {
 		return err
 	}
@@ -421,6 +449,25 @@ func (cm *ConfigManager) save() error {
 	}
 
 	return nil
+}
+
+// marshalConfig encodes the config for disk, re-attaching any keys this
+// build doesn't recognize (see ConfigManager.unknown).
+func (cm *ConfigManager) marshalConfig() ([]byte, error) {
+	if len(cm.unknown) == 0 {
+		return json.MarshalIndent(cm.config, "", "  ")
+	}
+
+	data, err := json.Marshal(cm.config)
+	if err != nil {
+		return nil, err
+	}
+	merged := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &merged); err != nil {
+		return nil, err
+	}
+	maps.Copy(merged, cm.unknown)
+	return json.MarshalIndent(merged, "", "  ")
 }
 
 // MetricsGrid returns the metrics grid configuration.

--- a/core/internal/leet/config_test.go
+++ b/core/internal/leet/config_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -204,4 +205,27 @@ func TestConfig_SetRunLayoutRejectsNaN(t *testing.T) {
 
 	// Later unrelated saves keep working.
 	require.NoError(t, cfg.SetLeftSidebarVisible(false))
+}
+
+func TestConfig_PreservesUnknownKeysAcrossSaves(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	// A config written by a newer build, with a key this build's Config
+	// struct does not have.
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"color_scheme": "sunset", "future_setting": {"answer": 42}}`,
+	), 0o644))
+
+	cfg := leet.NewConfigManager(path, logger)
+	require.NoError(t, cfg.SetLeftSidebarVisible(false))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"future_setting"`)
+	require.Contains(t, string(data), `"answer": 42`)
+
+	// Known keys are written from the struct, not duplicated from the
+	// original file.
+	require.Equal(t, 1, strings.Count(string(data), `"color_scheme"`))
 }


### PR DESCRIPTION
Description
-----------
Every leet build that saves the config rewrites the file from its own
Config struct, silently erasing keys it doesn't know about. Running an
older binary after upgrading (for example the wandb-core bundled with
an installed wandb package) wipes settings introduced since. This is
how chart_guides disappeared from a config once an older build saved
it: the setting reverted to off and guides stopped rendering.

Capture unrecognized top-level keys at load and write them back on
save, so settings round-trip through builds that don't understand
them. This protects configs from the next mismatch onward; binaries
without this fix will still drop newer keys.

- [x] I updated CHANGELOG.unreleased.md, or it is not applicable

Testing
-------
Unit test round-trips an unknown key through load and save.
