### PR TITLE
fix(sdk): keep single-element tensors/arrays consistent with json_friendly's type conversion

### DIFF
--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -41,6 +41,12 @@ def nested_list(*shape):
 
 
 def assert_deep_lists_equal(a, b, indices=None):
+    # A tensor/array containing a single element is converted by
+    # `json_friendly` into a bare scalar rather than a (possibly deeply
+    # nested) singleton list, so unwrap `a` accordingly before comparing.
+    if not isinstance(b, (list, tuple)):
+        while isinstance(a, (list, tuple)) and len(a) == 1:
+            a = a[0]
     try:
         assert a == b
     except ValueError:
@@ -102,6 +108,30 @@ def test_pytorch_json_nd(array_shape):
     a = nested_list(*array_shape)
     json_friendly_test(a, torch.Tensor(a))
     json_friendly_test(a, pt_variable(a))
+
+
+def test_pytorch_single_element_tensor_converts_to_native_python_type():
+    """Regression test for https://github.com/wandb/wandb/issues/8951.
+
+    A single-element tensor used to be converted to a numpy scalar (e.g.
+    ``numpy.float32``) instead of a native Python type, unlike every other
+    tensor size which is converted to a native ``list``. That inconsistency
+    meant downstream YAML serialization (e.g. writing ``wandb.config``)
+    would fail or silently stringify the value.
+    """
+    pytest.importorskip("torch")
+    import torch
+
+    single, converted = util.json_friendly(torch.Tensor([1]))
+    assert converted
+    assert single == 1.0
+    assert isinstance(single, float)
+    assert not isinstance(single, np.generic)
+
+    multi, converted = util.json_friendly(torch.Tensor([1, 2]))
+    assert converted
+    assert multi == [1.0, 2.0]
+    assert isinstance(multi, list)
 
 
 @pytest.mark.parametrize(

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -626,7 +626,9 @@ def json_friendly(  # noqa: C901
 
     if is_numpy_array(obj):
         if obj.size == 1:
-            obj = obj.flatten()[0]
+            obj = _numpy_generic_convert(
+                obj.flatten()[0], preserve_nan=preserve_numpy_nan
+            )
         elif obj.size <= 32:
             obj = obj.tolist()
     elif np and isinstance(obj, np.generic):


### PR DESCRIPTION
## Summary

Fixes #8951.

`wandb.util.json_friendly()` converts tensors/arrays into JSON/YAML-friendly Python types before they're stored, e.g. in `wandb.config`. For arrays with more than one element it calls `.tolist()`, producing a native Python `list`. But for an array with exactly **one** element, it instead did:

```python
obj = obj.flatten()[0]
```

which returns a numpy scalar (e.g. `numpy.float32`), not a native Python type.

```python
x = torch.Tensor([1])
wandb.config.x = x
type(wandb.config.x)  # str  (numpy.float32 isn't YAML-serializable, so it gets stringified downstream)

y = torch.Tensor([1, 2])
wandb.config.y = y
type(wandb.config.y)  # list, as expected
```

## Root cause

In `wandb/util.py::json_friendly`, the size-1 branch of the numpy-array handling assigns a raw numpy scalar without routing it through `_numpy_generic_convert`, the helper that normally turns numpy scalars into native Python types elsewhere in the same function (see the `elif np and isinstance(obj, np.generic):` branch a few lines below, which is skipped once the `if is_numpy_array(obj):` branch above has already been taken).

## Fix

Route the size-1 case through `_numpy_generic_convert` (respecting `preserve_numpy_nan`), matching the multi-element path's behavior of yielding native Python types.

## Test plan

- Added `test_pytorch_single_element_tensor_converts_to_native_python_type` in `tests/unit_tests/test_util.py`, which fails on `main` (`numpy.float32` is not a `float`) and passes with the fix.
- Fixed a latent bug in the existing `assert_deep_lists_equal` test helper: it happened to "pass" for single-element tensors only because comparing a numpy scalar against a nested list triggers numpy broadcasting; comparing a native Python scalar (the correct post-fix output) against the same nested list does not. Updated the helper to unwrap singleton nesting before comparing against a scalar.
- Ran `pytest tests/unit_tests/test_util.py` (64 passed, 22 skipped — skips are unrelated tf/jax deps) and `tests/unit_tests/test_wandb_config.py` (12 passed) locally.
- `ruff check` and `ruff format --diff` clean on the changed files.