### PR TITLE
fix(leet): stop the metrics grid from overflowing its pane

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,3 +35,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - `Artifact.new_file` now works for artifacts uploaded with `wandb sync` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12437)
+- At certain pane widths, such as while dragging a sidebar edge, LEET drew metric charts wider than the space available, pushing the right sidebar off screen (@dmitryduev in https://github.com/wandb/wandb/pull/12513)

--- a/core/internal/leet/metricsgrid.go
+++ b/core/internal/leet/metricsgrid.go
@@ -251,9 +251,14 @@ func (mg *MetricsGrid) ProcessHistory(msg HistoryMsg) bool {
 }
 
 // effectiveGridSize returns the grid size that can fit in the current viewport.
+//
+// It must derive the column count from the same padded width as
+// CalculateChartDimensions: View renders this many columns at cell widths
+// computed there, and any disagreement overflows the pane.
 func (mg *MetricsGrid) effectiveGridSize() GridSize {
 	gridRows, gridCols := mg.gridConfig()
-	return EffectiveGridSize(mg.width, mg.height, GridSpec{
+	innerW := max(mg.width-ContentPaddingCols, 0)
+	return EffectiveGridSize(innerW, mg.height, GridSpec{
 		Rows:        gridRows,
 		Cols:        gridCols,
 		MinCellW:    MinChartWidth,

--- a/core/internal/leet/metricsgrid_test.go
+++ b/core/internal/leet/metricsgrid_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/require"
 
 	leet "github.com/wandb/wandb/core/internal/leet"
@@ -38,6 +39,29 @@ func TestCalculateChartDimensions_RespectsMinimums(t *testing.T) {
 	d := grid.CalculateChartDimensions(10, 5) // small on purpose
 	require.GreaterOrEqual(t, d.CellW, leet.MinChartWidth)
 	require.GreaterOrEqual(t, d.CellH, leet.MinChartHeight)
+}
+
+// The rendered grid must never be wider than the pane. Regression test for
+// the column count (raw pane width) disagreeing with the cell widths (pane
+// width minus content padding) in a narrow window around each column-count
+// transition, which overflowed the pane during sidebar drags.
+func TestMetricsGrid_View_FitsPaneWidth(t *testing.T) {
+	h := 30
+	grid := newMetricsGrid(t, 3, 2, 200, h, nil)
+
+	metrics := make(map[string]leet.MetricData, 6)
+	for _, name := range []string{"a", "b", "c", "d", "e", "f"} {
+		metrics[name] = leet.MetricData{X: []float64{1}, Y: []float64{1}}
+	}
+	grid.ProcessHistory(leet.HistoryMsg{Metrics: metrics})
+
+	// 24 is the narrowest the main column can be dragged to.
+	for w := 24; w <= 120; w++ {
+		grid.UpdateDimensions(w, h)
+		dims := grid.CalculateChartDimensions(w, h)
+		require.LessOrEqual(t, lipgloss.Width(grid.View(dims)), w,
+			"grid overflows a %d-wide pane", w)
+	}
 }
 
 func TestMetricsGrid_Render_EmptyGridShowsSectionHeader(t *testing.T) {


### PR DESCRIPTION
Description
-----------
The metrics grid computed its column count from the raw pane width but its cell widths from the pane width minus content padding. At pane widths where the two disagree on how many columns fit (a 2-column window at every column-count transition), the grid rendered N columns sized for N-1 columns. The row overflowed the main column and pushed the right sidebar off screen. Most visible as a jump while dragging a sidebar edge, self-correcting a couple of cells later.

Both now derive the column count from the same padded width.

- [x] I updated CHANGELOG.unreleased.md
