### PR TITLE
refactor: don't read mailbox_slot in runupdatework

### DIFF
--- a/core/internal/runupserter/runupdatework.go
+++ b/core/internal/runupserter/runupdatework.go
@@ -105,11 +105,7 @@ func (w *RunUpdateWork) initRun(request *runwork.Request) {
 
 	if err != nil {
 		w.Logger.Error("runupserter: failed to init run", "error", err)
-
-		if w.Record.Control.GetMailboxSlot() != "" {
-			respondRunUpdate(request, runInitErrorResult(err))
-		}
-
+		respondRunUpdate(request, runInitErrorResult(err))
 		return
 	}
 
@@ -123,14 +119,11 @@ func (w *RunUpdateWork) initRun(request *runwork.Request) {
 			),
 		)
 
-		if w.Record.Control.GetMailboxSlot() != "" {
-			respondRunUpdate(request, runInitErrorResult(err))
-		}
-
+		respondRunUpdate(request, runInitErrorResult(err))
 		return
 	}
 
-	if w.Record.Control.GetMailboxSlot() != "" {
+	if request != nil {
 		updatedRun := proto.CloneOf(w.Record.GetRun())
 		upserter.FillRunRecord(updatedRun)
 		respondRunUpdate(request, &spb.RunUpdateResult{Run: updatedRun})


### PR DESCRIPTION
Removes one last piece of code that was reading `mailbox_slot` instead of using the `runwork.Request` abstraction. I forgot to update this when migrating to `runwork.Request`.

Checking if `request == nil` isn't necessary because `Respond()` on a `nil` request is a no-op, but I kept it in the last case as an example of how to avoid doing unnecessary work.