### PR TITLE
fix(artifacts): validate path when using run file api to download

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,3 +36,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `Artifact.new_file` now works for artifacts uploaded with `wandb sync` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12437)
 - At certain pane widths, such as while dragging a sidebar edge, LEET drew metric charts wider than the space available, pushing the right sidebar off screen (@dmitryduev in https://github.com/wandb/wandb/pull/12513)
+
+### Security
+
+- Reject file or artifact name that contain relative path when downloading artifacts via `artifact.files()`, `artifact.checkout()` (@pingleiwandb in https://github.com/wandb/wandb/pull/12516)

--- a/tests/unit_tests/test_artifacts/test_validators.py
+++ b/tests/unit_tests/test_artifacts/test_validators.py
@@ -6,6 +6,7 @@ from wandb.sdk.artifacts._validators import (
     RESERVED_ARTIFACT_TYPE_PREFIX,
     ArtifactPath,
     validate_artifact_path,
+    validate_artifact_root_name,
     validate_artifact_type,
     validate_project_name,
 )
@@ -111,6 +112,48 @@ def test_validate_artifact_path_valid(path: StrPath, expected: str):
 def test_validate_artifact_path_invalid(path):
     with raises(ValueError, match="Invalid artifact path"):
         validate_artifact_path(path)
+
+
+@mark.parametrize(
+    "name",
+    [
+        "mnist",
+        "mnist:v0",
+        "model:latest",
+        "name:v0:extra",
+        # A single-character collection name followed by ":" looks like a
+        # Windows drive path but is a legal artifact name.
+        "a",
+        "a:v0",
+        "1:v0",
+        "..notevil",
+    ],
+)
+def test_validate_artifact_root_name_valid(name: str):
+    assert validate_artifact_root_name(name) == name
+
+
+@mark.parametrize(
+    "name",
+    [
+        "",
+        "..",
+        "../../evil:v0",
+        "nested/../evil:v0",
+        "/abs:v0",
+        "//server/share:v0",
+        r"\evil:v0",
+        r"C:\evil",
+        # Traversal hidden after the single-character collection prefix.
+        "a:../evil",
+        "a:v0/../../evil",
+        r"a:C:\evil",
+        r"a:\evil",
+    ],
+)
+def test_validate_artifact_root_name_invalid(name: str):
+    with raises(ValueError, match="Invalid artifact name"):
+        validate_artifact_root_name(name)
 
 
 @mark.parametrize(

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -46,7 +46,7 @@ from wandb.apis.paginator import SizedPaginator
 from wandb.apis.public import utils
 from wandb.apis.public.runs import Run
 from wandb.proto.wandb_api_pb2 import ApiRequest, DownloadFileRequest
-from wandb.sdk.lib.paths import validate_path
+from wandb.sdk.lib.paths import validate_fspath
 from wandb.util import POW_2_BYTES, to_human_size
 
 if TYPE_CHECKING:
@@ -338,8 +338,7 @@ class File(Attrs):
             `ValueError` if file already exists, `replace=False` and
             `exist_ok=False`.
         """
-        name = validate_path(self.name)
-        path = os.path.join(root, name)
+        path = validate_fspath(root, self.name)
         if os.path.exists(path) and not replace:
             if exist_ok:
                 return open(path)

--- a/wandb/apis/public/files.py
+++ b/wandb/apis/public/files.py
@@ -46,6 +46,7 @@ from wandb.apis.paginator import SizedPaginator
 from wandb.apis.public import utils
 from wandb.apis.public.runs import Run
 from wandb.proto.wandb_api_pb2 import ApiRequest, DownloadFileRequest
+from wandb.sdk.lib.paths import validate_path
 from wandb.util import POW_2_BYTES, to_human_size
 
 if TYPE_CHECKING:
@@ -337,7 +338,8 @@ class File(Attrs):
             `ValueError` if file already exists, `replace=False` and
             `exist_ok=False`.
         """
-        path = os.path.join(root, self.name)
+        name = validate_path(self.name)
+        path = os.path.join(root, name)
         if os.path.exists(path) and not replace:
             if exist_ok:
                 return open(path)

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -8,7 +8,6 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from functools import singledispatch, wraps
-from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING, Any, Concatenate, Literal, Optional, TypeVar
 
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -17,7 +16,7 @@ from typing_extensions import ParamSpec, Self
 from wandb._iterutils import always_list, unique_list
 from wandb._pydantic import from_json
 from wandb._strutils import nameof, repr_join
-from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath
+from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, validate_path
 from wandb.util import json_friendly_val
 
 from .exceptions import ArtifactFinalizedError, ArtifactNotLoggedError
@@ -71,20 +70,7 @@ def validate_artifact_path(path: StrPath) -> LogicalPath:
 
     Among other things, this forbids absolute paths or relative paths with traversal.
     """
-    logical_path = LogicalPath(path)
-    posix_path = logical_path.to_path()
-    windows_path = PureWindowsPath(path)
-
-    if (
-        logical_path == "."
-        or posix_path.anchor
-        or (".." in posix_path.parts)
-        or windows_path.anchor
-        or (".." in windows_path.parts)
-    ):
-        raise ValueError(f"Invalid artifact path: {path!r}")
-
-    return logical_path
+    return validate_path(path=path, error_prefix="Invalid artifact path")
 
 
 def validate_fspath(root: StrPath, relpath: StrPath) -> FilePathStr:

--- a/wandb/sdk/artifacts/_validators.py
+++ b/wandb/sdk/artifacts/_validators.py
@@ -16,7 +16,7 @@ from typing_extensions import ParamSpec, Self
 from wandb._iterutils import always_list, unique_list
 from wandb._pydantic import from_json
 from wandb._strutils import nameof, repr_join
-from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, validate_path
+from wandb.sdk.lib.paths import FilePathStr, LogicalPath, StrPath, validate_relpath
 from wandb.util import json_friendly_val
 
 from .exceptions import ArtifactFinalizedError, ArtifactNotLoggedError
@@ -70,12 +70,30 @@ def validate_artifact_path(path: StrPath) -> LogicalPath:
 
     Among other things, this forbids absolute paths or relative paths with traversal.
     """
-    return validate_path(path=path, error_prefix="Invalid artifact path")
+    try:
+        return validate_relpath(path)
+    except ValueError:
+        raise ValueError(f"Invalid artifact path: {path!r}") from None
 
 
 def validate_fspath(root: StrPath, relpath: StrPath) -> FilePathStr:
     """Validate a native filesystem path under `root`."""
     return os.path.join(os.fspath(root), validate_artifact_path(relpath))
+
+
+def validate_artifact_root_name(name: str) -> str:
+    """Validate an artifact `name` or `name:version` used to build a local download root.
+
+    Existing collection names can still include relative path, so we validate
+    it when it used in checkout and download as the default root. One exception is single
+    character collection name, e.g. `a:v0` is valid but can be rejected as Windows drive.
+    """
+    relpath = name[2:] if len(name) > 1 and name[1] == ":" else name
+    try:
+        validate_relpath(relpath)
+    except ValueError:
+        raise ValueError(f"Invalid artifact name: {name!r}") from None
+    return name
 
 
 def validate_artifact_name(name: str) -> str:

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -69,6 +69,7 @@ from ._validators import (
     ensure_logged,
     ensure_not_finalized,
     validate_artifact_path,
+    validate_artifact_root_name,
     validate_fspath,
 )
 from .artifact_download_logger import ArtifactDownloadLogger
@@ -2294,7 +2295,9 @@ class Artifact:
             ValueError: If the artifact contains more than one file.
         """
         if root is None:
-            root = os.path.join(".", "artifacts", self.name)
+            root = os.path.join(
+                ".", "artifacts", validate_artifact_root_name(self.name)
+            )
 
         if len(self.manifest.entries) > 1:
             raise ValueError(
@@ -2332,7 +2335,7 @@ class Artifact:
 
     def _default_root(self, include_version: bool = True) -> FilePathStr:
         name = self.source_name if include_version else self.source_name.split(":")[0]
-        root = os.path.join(env.get_artifact_dir(), name)
+        root = os.path.join(env.get_artifact_dir(), validate_artifact_root_name(name))
         # In case we're on a system where the artifact dir has a name corresponding to
         # an unexpected filesystem, we'll check for alternate roots. If one exists we'll
         # use that, otherwise we'll fall back to the system-preferred path.

--- a/wandb/sdk/lib/paths.py
+++ b/wandb/sdk/lib/paths.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import platform
 from functools import wraps
-from pathlib import PurePath, PurePosixPath
+from pathlib import PurePath, PurePosixPath, PureWindowsPath
 from typing import Any, TypeAlias, Union
 
 # Path _inputs_ should generally accept any kind of path. This is named the same and
@@ -13,6 +13,30 @@ StrPath: TypeAlias = Union[str, "os.PathLike[str]"]
 
 FilePathStr: TypeAlias = str  #: A native path to a file on a local filesystem.
 URIStr: TypeAlias = str
+
+
+def validate_path(path: StrPath, error_prefix: str | None = None) -> LogicalPath:
+    """Validate and canonicalize an relative path for artifact and run files before download.
+
+    Among other things, this forbids absolute paths or relative paths with traversal.
+    """
+    logical_path = LogicalPath(path)
+    posix_path = logical_path.to_path()
+    windows_path = PureWindowsPath(path)
+
+    if (
+        logical_path == "."
+        or posix_path.anchor
+        or (".." in posix_path.parts)
+        or windows_path.anchor
+        or (".." in windows_path.parts)
+    ):
+        if error_prefix is not None:
+            raise ValueError(f"{error_prefix}: {path!r}")
+        else:
+            raise ValueError(f"Invalid artifact/run file path: {path!r}")
+
+    return logical_path
 
 
 class LogicalPath(str):

--- a/wandb/sdk/lib/paths.py
+++ b/wandb/sdk/lib/paths.py
@@ -15,8 +15,8 @@ FilePathStr: TypeAlias = str  #: A native path to a file on a local filesystem.
 URIStr: TypeAlias = str
 
 
-def validate_path(path: StrPath, error_prefix: str | None = None) -> LogicalPath:
-    """Validate and canonicalize an relative path for artifact and run files before download.
+def validate_relpath(path: StrPath) -> LogicalPath:
+    """Validate and canonicalize a relative path for artifact or run files.
 
     Among other things, this forbids absolute paths or relative paths with traversal.
     """
@@ -31,12 +31,14 @@ def validate_path(path: StrPath, error_prefix: str | None = None) -> LogicalPath
         or windows_path.anchor
         or (".." in windows_path.parts)
     ):
-        if error_prefix is not None:
-            raise ValueError(f"{error_prefix}: {path!r}")
-        else:
-            raise ValueError(f"Invalid artifact/run file path: {path!r}")
+        raise ValueError(f"Invalid path: {path!r}")
 
     return logical_path
+
+
+def validate_fspath(root: StrPath, relpath: StrPath) -> FilePathStr:
+    """Validate a native filesystem path under `root`."""
+    return os.path.join(os.fspath(root), validate_relpath(relpath))
 
 
 class LogicalPath(str):


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-38900

Previously in https://github.com/wandb/wandb/pull/11735 we added validation to reject relative and abs paths when downloading artifact files. But there are more ways to download:

- artifact can be downloaded using the file api via `artifact.files()` `file.download`, which does not check path. This PR applies same logic to `File.download` before sending the path to go core for download.
- `artifact.download` and `artifact.checkout` use artifact name (collection name) as the default download root. User were allowed to rename artifact to relative path via direct api call, so sdk side validation is still required.

Example script.

```python
def log_realtive():
    with wandb.init(entity="reg-team-2", project="pinglei-path-traversal") as run:
        Path("hello.txt").write_text("Hello, W&B Artifacts!\n")
        artifact = wandb.Artifact(
            name="a1",
            type="dataset",
        )

        # Works when commenting out `validate_artifact_path` in sdk/artifacts/_validators.py
        artifact.add_file("hello.txt", name="../../hello_outside.txt")

        logged = run.log_artifact(artifact)
        logged.wait()

        print(f"Uploaded artifact: {logged.name}")

def download():
    api = wandb.Api()
    artifact = api.artifact("reg-team-2/pinglei-path-traversal/a1:v0")
    # Fails by validation
    artifact_dir = artifact.download()

def download_via_files():
    api = wandb.Api()
    artifact = api.artifact("reg-team-2/pinglei-path-traversal/a1:v0")
    files = artifact.files()
    # works until we fix it ...
    for f in files:
        f.download()
```


- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

- Run the previous example script using updated SDK and it fails with validation error
