### PR TITLE
fix(leet): keep watching runs with no flushed data yet

### DIFF
--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -950,12 +950,7 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 	// Boot load complete -> begin live mode once. The WaitForMsg pump is
 	// started alongside the watcher so it only runs while the watcher and
 	// heartbeat can produce messages; WatcherManager.Finish unblocks it.
-	//
-	// A run that is still Unknown hasn't flushed its Run record to disk
-	// yet (the writer buffers the transaction log in blocks), so watch it
-	// like a live run and let the records stream in as they land.
-	stateAllowsLive := r.runState == RunStateRunning || r.runState == RunStateUnknown
-	if !r.IsRemote() && stateAllowsLive && !r.watcherMgr.IsStarted() {
+	if !r.IsRemote() && r.runState.mayBeLive() && !r.watcherMgr.IsStarted() {
 		if err := r.watcherMgr.Start(r.runParams.RunFile); err != nil {
 			r.logger.CaptureError(
 				"leet",
@@ -1034,9 +1029,7 @@ func (r *Run) handleFileChange() []tea.Cmd {
 		r.lastUpdateAt = time.Now()
 		r.setRunState(RunStateRunning)
 	}
-	// Unknown-state runs are watched too: their Run record hasn't been
-	// flushed yet and this change may be it.
-	if r.runState != RunStateRunning && r.runState != RunStateUnknown {
+	if !r.runState.mayBeLive() {
 		return nil
 	}
 	r.heartbeatMgr.Reset(r.isRunning)

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -950,7 +950,12 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 	// Boot load complete -> begin live mode once. The WaitForMsg pump is
 	// started alongside the watcher so it only runs while the watcher and
 	// heartbeat can produce messages; WatcherManager.Finish unblocks it.
-	if !r.IsRemote() && r.runState == RunStateRunning && !r.watcherMgr.IsStarted() {
+	//
+	// A run that is still Unknown hasn't flushed its Run record to disk
+	// yet (the writer buffers the transaction log in blocks), so watch it
+	// like a live run and let the records stream in as they land.
+	stateAllowsLive := r.runState == RunStateRunning || r.runState == RunStateUnknown
+	if !r.IsRemote() && stateAllowsLive && !r.watcherMgr.IsStarted() {
 		if err := r.watcherMgr.Start(r.runParams.RunFile); err != nil {
 			r.logger.CaptureError(
 				"leet",
@@ -1029,7 +1034,9 @@ func (r *Run) handleFileChange() []tea.Cmd {
 		r.lastUpdateAt = time.Now()
 		r.setRunState(RunStateRunning)
 	}
-	if r.runState != RunStateRunning {
+	// Unknown-state runs are watched too: their Run record hasn't been
+	// flushed yet and this change may be it.
+	if r.runState != RunStateRunning && r.runState != RunStateUnknown {
 		return nil
 	}
 	r.heartbeatMgr.Reset(r.isRunning)

--- a/core/internal/leet/runoverview.go
+++ b/core/internal/leet/runoverview.go
@@ -24,6 +24,16 @@ const (
 	RunStateCrashed
 )
 
+// mayBeLive reports whether the run could still be producing data.
+//
+// True while the run is known to be running, and also while its state is
+// unknown: a freshly started run's Run record may not have been flushed to
+// the transaction log yet, so an Unknown run must be watched like a live
+// one or it would never stream.
+func (s RunState) mayBeLive() bool {
+	return s == RunStateRunning || s == RunStateUnknown
+}
+
 // KeyValuePair represents a single key-value item to display.
 type KeyValuePair struct {
 	Key, Value string

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -737,3 +737,8 @@ func (w *Workspace) TestFilteredRunKeys() []string {
 	}
 	return keys
 }
+
+// TestRunByKey returns the workspace's streaming state for a run key.
+func (w *Workspace) TestRunByKey(key string) *WorkspaceRun {
+	return w.runsByKey[key]
+}

--- a/core/internal/leet/workspace_test.go
+++ b/core/internal/leet/workspace_test.go
@@ -252,3 +252,35 @@ func TestWorkspace_Cleanup_ReleasesRunResources(t *testing.T) {
 	// Cleanup is idempotent.
 	w.Cleanup()
 }
+
+// A selected run whose state is still Unknown after the initial drain (its
+// Run record hasn't been flushed to disk yet) must keep being watched, or
+// it would never stream.
+func TestWorkspaceBoot_WatchesUnknownStateRun(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	workspace := leet.NewWorkspace(t.TempDir(), cfg, logger)
+	defer workspace.Cleanup()
+
+	wandbFile := filepath.Join(t.TempDir(), "run-abc.wandb")
+	require.NoError(t, os.WriteFile(wandbFile, nil, 0o644))
+
+	workspace.TestAttachRun(leet.TestNewWorkspaceRun("run-1"), true)
+	workspace.Update(leet.WorkspaceRunInitMsg{
+		RunKey:  "run-1",
+		RunPath: wandbFile,
+		Reader:  &stubHistorySource{msg: leet.ChunkedBatchMsg{}},
+	})
+
+	// Initial drain ends with no records: the run's state is Unknown.
+	workspace.Update(leet.WorkspaceChunkedBatchMsg{
+		RunKey: "run-1",
+		Batch:  leet.ChunkedBatchMsg{HasMore: false},
+	})
+
+	run := workspace.TestRunByKey("run-1")
+	require.NotNil(t, run)
+	require.Equal(t, leet.RunStateUnknown, run.TestState())
+	require.True(t, run.TestWatcherActive(),
+		"unknown-state run must stay watched so it streams once data lands")
+}

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -545,13 +545,7 @@ func (w *Workspace) waitForLiveMsg() tea.Msg {
 }
 
 // ensureLiveStreaming wires up watcher + heartbeat for a selected run that
-// is running or whose state is still unknown.
-//
-// A run that is still Unknown after the initial drain hasn't flushed its Run
-// record to disk yet: the writer buffers the transaction log in blocks, so a
-// freshly started run's file can lag its data by minutes. Watch it like a
-// live run so records stream in as soon as they land; without this the run
-// would never be read again.
+// may still be live (see RunState.mayBeLive).
 //
 // It is a no-op if the run is nil, already in a terminal state, or its
 // reader is not initialized. When a watcher is started it also returns a
@@ -559,8 +553,7 @@ func (w *Workspace) waitForLiveMsg() tea.Msg {
 // updates are driven primarily by filesystem events, with the heartbeat as
 // a safety net.
 func (w *Workspace) ensureLiveStreaming(run *WorkspaceRun) tea.Cmd {
-	if run == nil || run.Reader == nil ||
-		(run.state != RunStateRunning && run.state != RunStateUnknown) {
+	if run == nil || run.Reader == nil || !run.state.mayBeLive() {
 		return nil
 	}
 

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -544,14 +544,23 @@ func (w *Workspace) waitForLiveMsg() tea.Msg {
 	return <-w.liveChan
 }
 
-// ensureLiveStreaming wires up watcher + heartbeat for a selected, running run.
+// ensureLiveStreaming wires up watcher + heartbeat for a selected run that
+// is running or whose state is still unknown.
 //
-// It is a no-op if the run is nil, not live, or its reader is not initialized.
-// When a watcher is started it also returns a command that waits for the first
-// change notification so that subsequent updates are driven primarily by
-// filesystem events, with the heartbeat as a safety net.
+// A run that is still Unknown after the initial drain hasn't flushed its Run
+// record to disk yet: the writer buffers the transaction log in blocks, so a
+// freshly started run's file can lag its data by minutes. Watch it like a
+// live run so records stream in as soon as they land; without this the run
+// would never be read again.
+//
+// It is a no-op if the run is nil, already in a terminal state, or its
+// reader is not initialized. When a watcher is started it also returns a
+// command that waits for the first change notification so that subsequent
+// updates are driven primarily by filesystem events, with the heartbeat as
+// a safety net.
 func (w *Workspace) ensureLiveStreaming(run *WorkspaceRun) tea.Cmd {
-	if run == nil || run.Reader == nil || run.state != RunStateRunning {
+	if run == nil || run.Reader == nil ||
+		(run.state != RunStateRunning && run.state != RunStateUnknown) {
 		return nil
 	}
 


### PR DESCRIPTION
Description
-----------
The writer buffers the transaction log in 32KB blocks, so a freshly started run's .wandb file holds only the 7-byte header for a while; for light loggers even the Run record could reach disk minutes later.
When LEET opened such a run, the initial drain found zero records, the run's state stayed Unknown, and both views refused to start the file watcher, which was gated on the run being live. The run was never read again: no charts, no state, no live streaming, until deselecting and reselecting it.

Treat Unknown like Running when starting the watcher and when reacting to file changes, in both the workspace and the single-run view. Once the first flush lands, the Run record streams in and the run proceeds through its normal live lifecycle. Terminal states still stop the watcher as before.

- [x] I updated CHANGELOG.unreleased.md, or it is not applicable
