### PR TITLE
feat(leet): size run overview sections to fill the sidebar

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Changed
 
+- The run overview sections in LEET (Environment, Config, Summary) now share the sidebar height proportionally and use all of the available space; previously they stopped growing at fixed sizes, leaving the bottom of tall terminals empty (@dmitryduev in https://github.com/wandb/wandb/pull/12523)
 - `Api.{create,update}_automation()` now raise `UnsupportedError` instead of `CommError` when the server doesn't support the given automation (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12194)
 - The message format used to communicate between internal processes has slightly changed. If you use `wandb beta core`, restart the service after upgrading `wandb`, as some operations may fail if the SDK and service versions differ. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12374)
 - `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -18,11 +18,6 @@ const (
 	SidebarSideRight
 )
 
-// minSidebarHeaderLines preserves the existing baseline layout when only the
-// original metadata fields are present, while still allowing the header to grow
-// for wrapped tags and notes.
-const minSidebarHeaderLines = 6
-
 // RunOverviewSidebar stores and displays run metadata.
 //
 // It handles presentation concerns: sections, filtering, navigation, layout, and rendering.
@@ -456,7 +451,8 @@ func (s *RunOverviewSidebar) buildSectionLines(contentWidth int) []string {
 	return lines
 }
 
-// renderSection renders a single section.
+// renderSection renders a single section, always exactly Height rows so
+// the layout matches the allocation and stays put while paging.
 func (s *RunOverviewSidebar) renderSection(idx, width int) string {
 	section := &s.sections[idx]
 
@@ -467,17 +463,23 @@ func (s *RunOverviewSidebar) renderSection(idx, width int) string {
 	var lines []string
 
 	// Render section header.
-	lines = append(lines, s.renderSectionHeader(section))
+	lines = append(lines, s.renderSectionHeader(section, width))
 
 	// Render section items.
 	itemLines := s.renderSectionItems(section, width)
 	lines = append(lines, itemLines...)
 
+	// A partial last page still occupies the section's allocated rows.
+	for len(lines) < section.Height {
+		lines = append(lines, "")
+	}
+
 	return lipgloss.JoinVertical(lipgloss.Top, lines...)
 }
 
-// renderSectionHeader renders the section title with pagination info.
-func (s *RunOverviewSidebar) renderSectionHeader(section *PagedList) string {
+// renderSectionHeader renders the section title with pagination info,
+// truncated to a single row (the section heights budget one row for it).
+func (s *RunOverviewSidebar) renderSectionHeader(section *PagedList, width int) string {
 	titleStyle := runOverviewSidebarSectionStyle
 	if section.Active {
 		titleStyle = runOverviewSidebarSectionHeaderStyle
@@ -492,7 +494,8 @@ func (s *RunOverviewSidebar) renderSectionHeader(section *PagedList) string {
 	titleText := section.Title
 	infoText := s.buildSectionInfo(section, totalItems, filteredItems, startIdx, endIdx)
 
-	return titleStyle.Render(titleText) + navInfoStyle.Render(infoText)
+	header := titleStyle.Render(titleText) + navInfoStyle.Render(infoText)
+	return lipgloss.NewStyle().MaxWidth(width).Render(header)
 }
 
 // buildSectionInfo builds the pagination/count info string for a section.

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -52,18 +52,22 @@ func NewRunOverviewSidebar(
 	runOverview *RunOverview,
 	side SidebarSide,
 ) *RunOverviewSidebar {
-	es := PagedList{Title: "Environment", Active: true}
-	es.SetItemsPerPage(10)
-	cs := PagedList{Title: "Config"}
-	cs.SetItemsPerPage(15)
-	ss := PagedList{Title: "Summary"}
-	ss.SetItemsPerPage(20)
+	sections := []PagedList{
+		{Title: "Environment", Active: true},
+		{Title: "Config"},
+		{Title: "Summary"},
+	}
+	for i := range sections {
+		// Provisional page size for navigation that happens before the
+		// first render computes the real section heights.
+		sections[i].SetItemsPerPage(10)
+	}
 
 	return &RunOverviewSidebar{
 		config:        config,
 		animState:     animState,
 		runOverview:   runOverview,
-		sections:      []PagedList{es, cs, ss},
+		sections:      sections,
 		activeSection: 0,
 		filter:        NewFilter(),
 		side:          side,
@@ -296,15 +300,11 @@ func truncateValue(value string, maxWidth int) string {
 	return value + "..."
 }
 
-// headerLineCount returns the number of lines occupied by the fixed header area,
-// including the top-level section title.
+// headerLineCount returns the number of lines the header area (the
+// top-level title plus the metadata block) renders at the current width.
 func (s *RunOverviewSidebar) headerLineCount() int {
-	if s.runOverview == nil {
-		return 1
-	}
-
 	contentWidth := s.sidebarContentWidth(s.animState.Value())
-	return max(minSidebarHeaderLines, 1+len(s.buildHeaderLines(contentWidth)))
+	return 1 + len(s.buildHeaderLines(contentWidth))
 }
 
 // buildHeaderLines builds the width-aware header metadata section.

--- a/core/internal/leet/runoverviewsidebar_test.go
+++ b/core/internal/leet/runoverviewsidebar_test.go
@@ -139,9 +139,9 @@ func TestSidebar_CalculateSectionHeights_PaginationAndAllItems(t *testing.T) {
 
 	s.Sync()
 
-	// Small height -> single-item pages for the squeezed sections.
+	// Small height -> the squeezed Config section paginates.
 	view := stripANSI(s.View(15).Content)
-	require.Contains(t, view, "Config [1-1 of 5]")
+	require.Contains(t, view, "Config [1-3 of 5]")
 	require.Contains(t, view, "Summary [2 items]")
 	require.Contains(t, view, "Environment")
 
@@ -235,7 +235,7 @@ func TestSidebar_SectionsReflowAsDataChanges(t *testing.T) {
 	s.Sync()
 	view = stripANSI(s.View(30).Content)
 	require.Contains(t, view, "Config [5 items]")
-	require.Contains(t, view, "Summary [1-12 of 43]")
+	require.Contains(t, view, "Summary [1-15 of 43]")
 
 	// Three config values are deleted: the freed rows flow to Summary.
 	ro.ProcessRunMsg(leet.RunMsg{
@@ -250,7 +250,7 @@ func TestSidebar_SectionsReflowAsDataChanges(t *testing.T) {
 	s.Sync()
 	view = stripANSI(s.View(30).Content)
 	require.Contains(t, view, "Config [2 items]")
-	require.Contains(t, view, "Summary [1-15 of 43]")
+	require.Contains(t, view, "Summary [1-18 of 43]")
 }
 
 func TestSidebar_Navigation_SectionPageUpDown(t *testing.T) {

--- a/core/internal/leet/runoverviewsidebar_test.go
+++ b/core/internal/leet/runoverviewsidebar_test.go
@@ -139,10 +139,10 @@ func TestSidebar_CalculateSectionHeights_PaginationAndAllItems(t *testing.T) {
 
 	s.Sync()
 
-	// Small height -> ItemsPerPage=1 -> expect "[1-1 of N]" pagination per section.
+	// Small height -> single-item pages for the squeezed sections.
 	view := stripANSI(s.View(15).Content)
-	require.Contains(t, view, "Config [1-2 of 5]")
-	require.Contains(t, view, "Summary [1-1 of 2]")
+	require.Contains(t, view, "Config [1-1 of 5]")
+	require.Contains(t, view, "Summary [2 items]")
 	require.Contains(t, view, "Environment")
 
 	// Larger height -> enough space -> expect "[N items]" (non-paginated).
@@ -151,6 +151,106 @@ func TestSidebar_CalculateSectionHeights_PaginationAndAllItems(t *testing.T) {
 	require.Contains(t, view, "Summary [2 items]")
 
 	s.Toggle()
+}
+
+func TestSidebar_SectionsFillAvailableHeight(t *testing.T) {
+	ro, s := testRunOverviewSidebar(t, false)
+	expandSidebar(t, s, 120, false)
+
+	ro.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"alpha", "a"}, ValueJson: "1"},
+				{NestedKey: []string{"alpha", "b"}, ValueJson: "2"},
+				{NestedKey: []string{"alpha", "c"}, ValueJson: "3"},
+				{NestedKey: []string{"beta", "d"}, ValueJson: "4"},
+				{NestedKey: []string{"beta", "e"}, ValueJson: "5"},
+			},
+		},
+	})
+
+	for i := range 40 {
+		ro.ProcessSummaryMsg([]*spb.SummaryRecord{{
+			Update: []*spb.SummaryItem{{
+				NestedKey: []string{"custom", fmt.Sprintf("metric_%d", i)},
+				ValueJson: fmt.Sprintf("%d", i),
+			}},
+		}})
+	}
+
+	ro.ProcessSystemInfoMsg(&spb.EnvironmentRecord{
+		WriterId: "writer-1",
+		Os:       "linux",
+	})
+
+	s.Sync()
+
+	// A tall sidebar shows all 40 summary items on one page instead of
+	// stopping at a fixed section size.
+	view := stripANSI(s.View(60).Content)
+	require.Contains(t, view, "Summary [40 items]")
+}
+
+func TestSidebar_SectionsReflowAsDataChanges(t *testing.T) {
+	ro, s := testRunOverviewSidebar(t, false)
+	expandSidebar(t, s, 120, false)
+
+	ro.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"alpha", "a"}, ValueJson: "1"},
+				{NestedKey: []string{"alpha", "b"}, ValueJson: "2"},
+				{NestedKey: []string{"alpha", "c"}, ValueJson: "3"},
+				{NestedKey: []string{"beta", "d"}, ValueJson: "4"},
+				{NestedKey: []string{"beta", "e"}, ValueJson: "5"},
+			},
+		},
+	})
+	ro.ProcessSummaryMsg([]*spb.SummaryRecord{{
+		Update: []*spb.SummaryItem{
+			{NestedKey: []string{"acc"}, ValueJson: "0.9"},
+			{NestedKey: []string{"loss"}, ValueJson: "0.1"},
+			{NestedKey: []string{"lr"}, ValueJson: "0.001"},
+		},
+	}})
+	ro.ProcessSystemInfoMsg(&spb.EnvironmentRecord{WriterId: "writer-1", Os: "linux"})
+
+	// Everything fits: each section sized to its items.
+	s.Sync()
+	view := stripANSI(s.View(30).Content)
+	require.Contains(t, view, "Environment [2 items]")
+	require.Contains(t, view, "Config [5 items]")
+	require.Contains(t, view, "Summary [3 items]")
+
+	// The run logs 40 more summary metrics: Summary overflows and takes
+	// every row the sized-to-content sections do not use.
+	for i := range 40 {
+		ro.ProcessSummaryMsg([]*spb.SummaryRecord{{
+			Update: []*spb.SummaryItem{{
+				NestedKey: []string{"custom", fmt.Sprintf("metric_%d", i)},
+				ValueJson: fmt.Sprintf("%d", i),
+			}},
+		}})
+	}
+	s.Sync()
+	view = stripANSI(s.View(30).Content)
+	require.Contains(t, view, "Config [5 items]")
+	require.Contains(t, view, "Summary [1-12 of 43]")
+
+	// Three config values are deleted: the freed rows flow to Summary.
+	ro.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Remove: []*spb.ConfigItem{
+				{NestedKey: []string{"alpha", "a"}},
+				{NestedKey: []string{"alpha", "b"}},
+				{NestedKey: []string{"alpha", "c"}},
+			},
+		},
+	})
+	s.Sync()
+	view = stripANSI(s.View(30).Content)
+	require.Contains(t, view, "Config [2 items]")
+	require.Contains(t, view, "Summary [1-15 of 43]")
 }
 
 func TestSidebar_Navigation_SectionPageUpDown(t *testing.T) {

--- a/core/internal/leet/runoverviewsidebarnav.go
+++ b/core/internal/leet/runoverviewsidebarnav.go
@@ -1,11 +1,12 @@
 package leet
 
 const (
-	// Relative weights that set each section's share of the sidebar's
-	// vertical space when the sections want more rows than fit.
-	sectionWeightEnvironment = 1.0
-	sectionWeightConfig      = 1.5
-	sectionWeightSummary     = 2.0
+	// Each section's default share of the sidebar's vertical space when
+	// the sections want more rows than fit. The shares sum to 1, so a
+	// value reads directly as that section's slice of the area.
+	sectionWeightEnvironment = 0.20
+	sectionWeightConfig      = 0.35
+	sectionWeightSummary     = 0.45
 
 	// Minimum section height when visible (title + 1 item).
 	sectionMinHeight = 2

--- a/core/internal/leet/runoverviewsidebarnav.go
+++ b/core/internal/leet/runoverviewsidebarnav.go
@@ -44,7 +44,6 @@ func (s *RunOverviewSidebar) updateSectionHeights() {
 
 // sectionsArea returns the rows available to sections: the sidebar height
 // minus the header block and one spacing row between adjacent sections.
-// The header reservation never drops below minSidebarHeaderLines.
 func (s *RunOverviewSidebar) sectionsArea(needs []int) int {
 	visible := 0
 	for _, need := range needs {
@@ -52,8 +51,7 @@ func (s *RunOverviewSidebar) sectionsArea(needs []int) int {
 			visible++
 		}
 	}
-	header := max(minSidebarHeaderLines, s.headerLineCount())
-	return s.height - header - max(visible-1, 0)
+	return s.height - s.headerLineCount() - max(visible-1, 0)
 }
 
 // flexSectionHeights divides area rows among sections proportionally to
@@ -120,8 +118,8 @@ func proportionalShares(active []int, weights []float64, remaining int) []float6
 	return shares
 }
 
-// settleSections assigns their final height to the active sections decide
-// selects and returns the still-active rest.
+// settleSections assigns a final height to each active section that decide
+// settles and returns the still-active rest.
 func settleSections(
 	active []int,
 	heights []int,

--- a/core/internal/leet/runoverviewsidebarnav.go
+++ b/core/internal/leet/runoverviewsidebarnav.go
@@ -1,179 +1,165 @@
 package leet
 
 const (
-	// Maximum heights for each section type.
-	// TODO: dynamically upscale if more space is available.
-	sectionMaxHeightEnvironment = 12
-	sectionMaxHeightConfig      = 20
-	sectionMaxHeightSummary     = 25
+	// Relative weights that set each section's share of the sidebar's
+	// vertical space when the sections want more rows than fit.
+	sectionWeightEnvironment = 1.0
+	sectionWeightConfig      = 1.5
+	sectionWeightSummary     = 2.0
 
 	// Minimum section height when visible (title + 1 item).
 	sectionMinHeight = 2
 )
 
-// updateSectionHeights dynamically allocates heights to sections.
+// sectionWeights returns each section's desired share of the section area.
+func (s *RunOverviewSidebar) sectionWeights() []float64 {
+	return []float64{
+		sectionWeightEnvironment,
+		sectionWeightConfig,
+		sectionWeightSummary,
+	}
+}
+
+// updateSectionHeights divides the sidebar rows below the header among the
+// sections and re-derives every section's page size from its height.
 func (s *RunOverviewSidebar) updateSectionHeights() {
 	if s.height == 0 {
 		return
 	}
 
-	totalAvailable := s.availableHeight()
-	if totalAvailable <= 0 {
-		return
+	needs := make([]int, len(s.sections))
+	for i := range s.sections {
+		if itemCount := len(s.sections[i].FilteredItems); itemCount > 0 {
+			needs[i] = itemCount + 1 // Title line.
+		}
 	}
 
-	desired := s.calculateDesiredHeights()
-	totalDesired := s.sumDesiredHeights(desired)
-
-	if totalDesired > totalAvailable {
-		s.scaleHeightsProportionally(desired, totalAvailable)
-	} else {
-		s.allocateDesiredHeights(desired)
-		s.distributeExtraSpace(totalAvailable, totalDesired)
+	heights := flexSectionHeights(s.sectionsArea(needs), s.sectionWeights(), needs)
+	for i := range s.sections {
+		s.sections[i].Height = heights[i]
 	}
 
 	s.updateItemsPerPage()
 }
 
-// availableHeight returns the height available for sections.
-func (s *RunOverviewSidebar) availableHeight() int {
-	availableHeight := s.height - s.headerLineCount()
-
-	activeSections := s.countActiveSections()
-	if activeSections == 0 {
-		return 0
-	}
-
-	// Account for spacing between sections.
-	spacingBetweenSections := 0
-	if activeSections > 1 {
-		spacingBetweenSections = activeSections - 1
-	}
-
-	// Ensure minimum space for all active sections.
-	minRequired := activeSections * sectionMinHeight
-	return max(availableHeight-spacingBetweenSections, minRequired)
-}
-
-// countActiveSections returns the number of sections with items.
-func (s *RunOverviewSidebar) countActiveSections() int {
-	count := 0
-	for i := range s.sections {
-		if len(s.sections[i].FilteredItems) > 0 {
-			count++
+// sectionsArea returns the rows available to sections: the sidebar height
+// minus the header block and one spacing row between adjacent sections.
+// The header reservation never drops below minSidebarHeaderLines.
+func (s *RunOverviewSidebar) sectionsArea(needs []int) int {
+	visible := 0
+	for _, need := range needs {
+		if need > 0 {
+			visible++
 		}
 	}
-	return count
+	header := max(minSidebarHeaderLines, s.headerLineCount())
+	return s.height - header - max(visible-1, 0)
 }
 
-// calculateDesiredHeights calculates the desired height for each section.
-func (s *RunOverviewSidebar) calculateDesiredHeights() []int {
-	maxHeights := []int{
-		sectionMaxHeightEnvironment,
-		sectionMaxHeightConfig,
-		sectionMaxHeightSummary,
+// flexSectionHeights divides area rows among sections proportionally to
+// weights. Sections with need 0 are hidden and get no rows. A visible
+// section is capped at its need (title + items) so surplus rows go to
+// sections that can still grow, and floored at sectionMinHeight so it stays
+// usable when squeezed. When even the minimums do not fit, the total
+// overflows area and the renderer crops it (tiny-terminal degradation).
+func flexSectionHeights(area int, weights []float64, needs []int) []int {
+	heights := make([]int, len(needs))
+	active := make([]int, 0, len(needs))
+	for i, need := range needs {
+		if need > 0 {
+			active = append(active, i)
+		}
 	}
 
-	desired := make([]int, len(s.sections))
+	remaining := area
+	for len(active) > 0 {
+		shares := proportionalShares(active, weights, remaining)
 
-	for i := range s.sections {
-		itemCount := len(s.sections[i].FilteredItems)
-		if itemCount == 0 {
-			s.sections[i].Height = 0
-			desired[i] = 0
+		// Sections offered more rows than their items can fill keep only
+		// their need; the surplus re-divides among the rest next pass.
+		if next := settleSections(active, heights, &remaining, func(k, i int) (int, bool) {
+			return needs[i], shares[k] >= float64(needs[i])
+		}); len(next) < len(active) {
+			active = next
 			continue
 		}
 
-		// Desired height is item count + 1 (for title), capped at max.
-		maxHeight := maxHeights[i]
-		desired[i] = max(min(itemCount+1, maxHeight), sectionMinHeight)
+		// Sections offered fewer rows than the minimum take the minimum
+		// anyway; the deficit comes out of the rest next pass.
+		if next := settleSections(active, heights, &remaining, func(k, i int) (int, bool) {
+			return min(sectionMinHeight, needs[i]), shares[k] < sectionMinHeight
+		}); len(next) < len(active) {
+			active = next
+			continue
+		}
+
+		// Steady state: every share fits between its minimum and its need.
+		roundShares(active, shares, heights, remaining)
+		break
 	}
 
-	return desired
+	return heights
 }
 
-// sumDesiredHeights returns the sum of all desired heights.
-func (s *RunOverviewSidebar) sumDesiredHeights(desired []int) int {
-	total := 0
-	for _, h := range desired {
-		total += h
+// proportionalShares splits remaining rows across the active sections in
+// proportion to their weights (evenly, if the weights sum to zero).
+func proportionalShares(active []int, weights []float64, remaining int) []float64 {
+	var weightSum float64
+	for _, i := range active {
+		weightSum += weights[i]
 	}
-	return total
-}
 
-// scaleHeightsProportionally scales section heights when total exceeds available.
-func (s *RunOverviewSidebar) scaleHeightsProportionally(desired []int, totalAvailable int) {
-	totalDesired := s.sumDesiredHeights(desired)
-	scaleFactor := float64(totalAvailable) / float64(totalDesired)
-
-	allocated := 0
-	for i := range s.sections {
-		if desired[i] > 0 {
-			scaled := int(float64(desired[i]) * scaleFactor)
-			// Enforce minimum height for visible sections.
-			if scaled < sectionMinHeight && len(s.sections[i].FilteredItems) > 0 {
-				scaled = sectionMinHeight
-			}
-			s.sections[i].Height = scaled
-			allocated += scaled
+	shares := make([]float64, len(active))
+	for k, i := range active {
+		if weightSum > 0 {
+			shares[k] = float64(remaining) * weights[i] / weightSum
 		} else {
-			s.sections[i].Height = 0
+			shares[k] = float64(remaining) / float64(len(active))
 		}
 	}
-
-	// Distribute remainder to last section with items.
-	if allocated < totalAvailable {
-		remainder := totalAvailable - allocated
-		s.allocateRemainder(remainder)
-	}
+	return shares
 }
 
-// allocateDesiredHeights sets each section to its desired height.
-func (s *RunOverviewSidebar) allocateDesiredHeights(desired []int) {
-	for i := range s.sections {
-		s.sections[i].Height = desired[i]
+// settleSections assigns their final height to the active sections decide
+// selects and returns the still-active rest.
+func settleSections(
+	active []int,
+	heights []int,
+	remaining *int,
+	decide func(k, i int) (int, bool),
+) []int {
+	rest := make([]int, 0, len(active))
+	for k, i := range active {
+		if h, settled := decide(k, i); settled {
+			heights[i] = h
+			*remaining -= h
+		} else {
+			rest = append(rest, i)
+		}
 	}
+	return rest
 }
 
-// distributeExtraSpace distributes unused space to sections that can use it.
-func (s *RunOverviewSidebar) distributeExtraSpace(totalAvailable, totalDesired int) {
-	maxHeights := []int{
-		sectionMaxHeightEnvironment,
-		sectionMaxHeightConfig,
-		sectionMaxHeightSummary,
+// roundShares converts fractional shares to whole rows, handing the leftover
+// rows to the largest fractional remainders (ties to the earlier section).
+func roundShares(active []int, shares []float64, heights []int, remaining int) {
+	leftover := remaining
+	fracs := make([]float64, len(active))
+	for k, i := range active {
+		heights[i] = int(shares[k])
+		fracs[k] = shares[k] - float64(heights[i])
+		leftover -= heights[i]
 	}
 
-	extraSpace := totalAvailable - totalDesired
-
-	// Try to expand sections from bottom to top (summary, config, env).
-	for i := 2; i >= 0 && extraSpace > 0; i-- {
-		section := &s.sections[i]
-		if section.Height == 0 {
-			continue
+	for ; leftover > 0; leftover-- {
+		best := 0
+		for k := range fracs {
+			if fracs[k] > fracs[best] {
+				best = k
+			}
 		}
-
-		itemCount := len(section.FilteredItems)
-		currentItems := section.Height - 1 // Subtract title line
-
-		// Only expand if we have more items to show.
-		if currentItems < itemCount {
-			maxIncrease := min(maxHeights[i]-section.Height, itemCount+1-section.Height)
-			increase := min(maxIncrease, extraSpace)
-
-			section.Height += increase
-			extraSpace -= increase
-		}
-	}
-}
-
-// allocateRemainder distributes remaining space to the last section with items.
-func (s *RunOverviewSidebar) allocateRemainder(remainder int) {
-	// Try sections from bottom to top.
-	for i := 2; i >= 0; i-- {
-		if len(s.sections[i].FilteredItems) > 0 && s.sections[i].Height > 0 {
-			s.sections[i].Height += remainder
-			return
-		}
+		heights[active[best]]++
+		fracs[best] = -1
 	}
 }
 

--- a/core/internal/leet/runoverviewsidebarnav_test.go
+++ b/core/internal/leet/runoverviewsidebarnav_test.go
@@ -1,0 +1,90 @@
+package leet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlexSectionHeights(t *testing.T) {
+	equal := []float64{1, 1, 1}
+
+	tests := []struct {
+		name    string
+		area    int
+		weights []float64
+		needs   []int
+		want    []int
+	}{
+		{
+			name:    "hidden sections get no rows",
+			area:    10,
+			weights: equal,
+			needs:   []int{0, 0, 0},
+			want:    []int{0, 0, 0},
+		},
+		{
+			name:    "everything fits at need",
+			area:    100,
+			weights: []float64{1, 1.5, 2},
+			needs:   []int{3, 6, 4},
+			want:    []int{3, 6, 4},
+		},
+		{
+			name:    "single section takes the whole area",
+			area:    10,
+			weights: equal,
+			needs:   []int{100, 0, 0},
+			want:    []int{10, 0, 0},
+		},
+		{
+			name:    "contention splits by weight",
+			area:    9,
+			weights: []float64{1, 2},
+			needs:   []int{100, 100},
+			want:    []int{3, 6},
+		},
+		{
+			name:    "capped section frees rows for the rest",
+			area:    20,
+			weights: []float64{1, 1, 2},
+			needs:   []int{3, 100, 100},
+			want:    []int{3, 6, 11},
+		},
+		{
+			name:    "squeezed section floors at the minimum",
+			area:    7,
+			weights: []float64{1, 10},
+			needs:   []int{50, 50},
+			want:    []int{2, 5},
+		},
+		{
+			name:    "minimums overflow a tiny area",
+			area:    3,
+			weights: equal,
+			needs:   []int{5, 5, 5},
+			want:    []int{2, 2, 2},
+		},
+		{
+			name:    "leftover row goes to the earlier of tied remainders",
+			area:    7,
+			weights: []float64{1, 1},
+			needs:   []int{50, 50},
+			want:    []int{4, 3},
+		},
+		{
+			name:    "zero weights split evenly",
+			area:    6,
+			weights: []float64{0, 0},
+			needs:   []int{50, 50},
+			want:    []int{3, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := flexSectionHeights(tt.area, tt.weights, tt.needs)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Description
-----------
The run overview sections (Environment, Config, Summary) stopped growing at hardcoded heights, leaving the bottom of tall sidebars empty while Summary paginated large runs a couple dozen items at a time.

I replaced the fixed caps (and the three overlapping correction passes) with a single allocator. Each visible section gets a share of the space below the header proportional to its (hardcoded :)) weight (1 : 1.5 : 2). Surplus rows go to sections that can still grow, so the sidebar always fills. Page sizes follow the heights as before.

The render is also kept in lockstep with the allocation:

- Section headers truncate to one row. A wrapped header (narrow sidebar, long pagination info) used to push the bottom rows out of view while the pagination label claimed they were shown.
- A section occupies exactly its allocated rows, so the layout stays put while paging through a partial last page.
- The 6-row header reservation is gone. It budgeted rows the render never used, leaving blank rows at the sidebar bottom for metadata-sparse runs.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Unit tests for the allocator, the reflow as data changes, and pagination.
