### PR TITLE
feat(leet): draw separator rules between run overview sections

### DIFF
--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -441,9 +441,10 @@ func (s *RunOverviewSidebar) buildSectionLines(contentWidth int) []string {
 		if sectionContent != "" {
 			lines = append(lines, sectionContent)
 
-			// Add spacing between sections if there's a next section.
+			// Separate adjacent sections with the same rule the central
+			// column draws between its stacked panes.
 			if s.hasNextVisibleSection(i) {
-				lines = append(lines, "")
+				lines = append(lines, renderHorizontalSeparator(contentWidth))
 			}
 		}
 	}

--- a/core/internal/leet/runoverviewsidebar_test.go
+++ b/core/internal/leet/runoverviewsidebar_test.go
@@ -153,6 +153,35 @@ func TestSidebar_CalculateSectionHeights_PaginationAndAllItems(t *testing.T) {
 	s.Toggle()
 }
 
+func TestSidebar_View_SeparatorBetweenSections(t *testing.T) {
+	ro, s := testRunOverviewSidebar(t, false)
+	expandSidebar(t, s, 120, false)
+
+	ro.ProcessRunMsg(leet.RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"trainer", "epochs"}, ValueJson: "10"},
+			},
+		},
+	})
+	ro.ProcessSummaryMsg([]*spb.SummaryRecord{
+		{Update: []*spb.SummaryItem{{NestedKey: []string{"acc"}, ValueJson: "0.9"}}},
+	})
+	ro.ProcessSystemInfoMsg(&spb.EnvironmentRecord{WriterId: "writer-1", Os: "linux"})
+
+	s.Sync()
+
+	// Three visible sections are set apart by two horizontal rules.
+	view := stripANSI(s.View(30).Content)
+	rules := 0
+	for line := range strings.SplitSeq(view, "\n") {
+		if strings.Contains(line, "————") {
+			rules++
+		}
+	}
+	require.Equal(t, 2, rules)
+}
+
 func TestSidebar_SectionsFillAvailableHeight(t *testing.T) {
 	ro, s := testRunOverviewSidebar(t, false)
 	expandSidebar(t, s, 120, false)


### PR DESCRIPTION
Description
-----------
Adjacent sections in the run overview sidebar were set apart by a blank line. Draw the same horizontal rule the central column uses between its stacked panes, so the sections read as panes of the sidebar. This also gives #12525 a visible mouse target for resizing.

<img width="3438" height="2028" alt="image" src="https://github.com/user-attachments/assets/002881a9-9c63-4aa1-8996-c1f781edbbe3" />

<img width="3442" height="2024" alt="image" src="https://github.com/user-attachments/assets/cd83da2c-76c1-4f81-ba5b-6ba8d75008e4" />

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Unit test counts the rendered rules between visible sections.
