### PR TITLE
feat(leet): drag run overview separators to resize sections

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
 - The automations API now supports creating and editing automations whose scope is a `Registry` object (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10867)
 - Press `g` in LEET to draw guides behind line charts: a dotted background or horizontal lines aligned with the axis ticks. The choice is saved and can also be set with `chart_guides` in `wandb leet config`. (@dmitryduev in https://github.com/wandb/wandb/pull/12463)
+- Drag the separator lines between LEET's run overview sections to resize them with the mouse. The proportions are saved per view; press `0` to reset them along with the other pane sizes (@dmitryduev in https://github.com/wandb/wandb/pull/12525)
 - Registry API version queries (`Api.registries().versions()`, `Api.registries().collections().versions()`, `Registry.versions()`, `Registry.collections().versions()`) now accept an optional `order` string as a keyword argument for organizations with advanced search. The API supports ordering versions by `created_at`, `artifact_size`, and `linked_at` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12489)
 - Added `Artifact.linked_at` which returns when the version was linked to the relevant portfolio. This is valid only for linked versions, and for source artifacts returns `None` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12490)
 

--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -407,12 +407,23 @@ func nextChartGuides(guides string) string {
 func normalizeLayoutOverrides(o *LayoutOverrides) {
 	for _, f := range []*float64{
 		&o.LeftSidebar, &o.RightSidebar, &o.System, &o.Media, &o.Logs,
-		&o.OverviewEnv, &o.OverviewConfig, &o.OverviewSummary,
 	} {
 		if math.IsNaN(*f) {
 			*f = 0
 		} else if *f != 0 {
 			*f = min(max(*f, MinLayoutFrac), MaxLayoutFrac)
+		}
+	}
+	// Overview shares are fractions of the sidebar's section area, not of
+	// the terminal, so only the unit range applies; the drag and the
+	// allocator enforce the real bounds (minimum heights, item counts).
+	for _, f := range []*float64{
+		&o.OverviewEnv, &o.OverviewConfig, &o.OverviewSummary,
+	} {
+		if math.IsNaN(*f) {
+			*f = 0
+		} else if *f != 0 {
+			*f = min(max(*f, 0), 1)
 		}
 	}
 }

--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -178,6 +178,32 @@ type LayoutOverrides struct {
 	System       float64 `json:"system,omitempty"`
 	Media        float64 `json:"media,omitempty"`
 	Logs         float64 `json:"logs,omitempty"`
+
+	// Run overview section shares, set by dragging the separator rules
+	// between sections. Each is a fraction of the sidebar rows available
+	// to sections (not of the terminal height).
+	OverviewEnv     float64 `json:"overview_env,omitempty"`
+	OverviewConfig  float64 `json:"overview_config,omitempty"`
+	OverviewSummary float64 `json:"overview_summary,omitempty"`
+}
+
+// overviewFractions returns the run overview section shares indexed like
+// the sidebar's sections (environment, config, summary).
+func (o LayoutOverrides) overviewFractions() []float64 {
+	return []float64{o.OverviewEnv, o.OverviewConfig, o.OverviewSummary}
+}
+
+// setOverviewFraction records one run overview section's share by its
+// index in the sidebar's sections.
+func (o *LayoutOverrides) setOverviewFraction(idx int, frac float64) {
+	switch idx {
+	case 0:
+		o.OverviewEnv = frac
+	case 1:
+		o.OverviewConfig = frac
+	case 2:
+		o.OverviewSummary = frac
+	}
 }
 
 // ConfigManager manages application configuration with thread-safe access
@@ -381,6 +407,7 @@ func nextChartGuides(guides string) string {
 func normalizeLayoutOverrides(o *LayoutOverrides) {
 	for _, f := range []*float64{
 		&o.LeftSidebar, &o.RightSidebar, &o.System, &o.Media, &o.Logs,
+		&o.OverviewEnv, &o.OverviewConfig, &o.OverviewSummary,
 	} {
 		if math.IsNaN(*f) {
 			*f = 0

--- a/core/internal/leet/config_test.go
+++ b/core/internal/leet/config_test.go
@@ -107,13 +107,16 @@ func TestConfig_SetWorkspaceLayout_ClampsFractions(t *testing.T) {
 	require.NoError(t, cfg.SetWorkspaceLayout(leet.LayoutOverrides{
 		LeftSidebar: 0.001, // below the minimum
 		Logs:        1.5,   // above the maximum
+		OverviewEnv: 2.0,   // overview section shares clamp the same way
 	}))
 
 	got := cfg.WorkspaceLayout()
 	require.Equal(t, leet.MinLayoutFrac, got.LeftSidebar)
 	require.Equal(t, leet.MaxLayoutFrac, got.Logs)
+	require.Equal(t, leet.MaxLayoutFrac, got.OverviewEnv)
 	// Unset fractions stay zero ("use default") rather than being clamped.
 	require.Zero(t, got.Media)
+	require.Zero(t, got.OverviewSummary)
 }
 
 func TestConfig_SetTagColorScheme_Persists(t *testing.T) {

--- a/core/internal/leet/config_test.go
+++ b/core/internal/leet/config_test.go
@@ -107,13 +107,13 @@ func TestConfig_SetWorkspaceLayout_ClampsFractions(t *testing.T) {
 	require.NoError(t, cfg.SetWorkspaceLayout(leet.LayoutOverrides{
 		LeftSidebar: 0.001, // below the minimum
 		Logs:        1.5,   // above the maximum
-		OverviewEnv: 2.0,   // overview section shares clamp the same way
+		OverviewEnv: 2.0,   // overview section shares clamp to the unit range
 	}))
 
 	got := cfg.WorkspaceLayout()
 	require.Equal(t, leet.MinLayoutFrac, got.LeftSidebar)
 	require.Equal(t, leet.MaxLayoutFrac, got.Logs)
-	require.Equal(t, leet.MaxLayoutFrac, got.OverviewEnv)
+	require.Equal(t, 1.0, got.OverviewEnv)
 	// Unset fractions stay zero ("use default") rather than being clamped.
 	require.Zero(t, got.Media)
 	require.Zero(t, got.OverviewSummary)

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -35,26 +35,17 @@ const (
 // overrides accumulates the view's pending layout fractions as the mouse
 // moves (a separator drag between two fixed panes updates two of them) and
 // is persisted once on mouse release. section is set for stack separator
-// drags; overview for run overview section drags.
+// drags; overview names the latched rule's neighbor sections for run
+// overview section drags.
 type layoutDrag struct {
 	boundary  dragBoundary
 	section   stackSectionID
-	overview  overviewSectionDrag
+	overview  overviewSeparator
 	overrides LayoutOverrides
 	dirty     bool
 }
 
-// overviewSectionDrag pins the geometry of a run overview section drag at
-// latch time; mouse motion is applied relative to it.
-type overviewSectionDrag struct {
-	above, below         int // Section indices either side of the rule.
-	baseY                int // Rule's screen row at latch.
-	aboveH, belowH       int // Allocated section heights at latch.
-	aboveNeed, belowNeed int // Content caps (title + items) at latch.
-	area                 int // Rows available to sections at latch.
-}
-
-func (d *layoutDrag) active() bool { return d.boundary != dragBoundaryNone }
+func (d layoutDrag) active() bool { return d.boundary != dragBoundaryNone }
 
 // setSection records a stacked pane's height fraction.
 func (o *LayoutOverrides) setSection(id stackSectionID, frac float64) {
@@ -174,7 +165,7 @@ func (d *paneDragger) apply(x, y int, layout Layout, t dragTargets) {
 			return
 		}
 	case dragBoundaryOverviewSection:
-		if !dragOverviewSection(o, d.drag.overview, y) {
+		if t.overview == nil || !dragOverviewSection(o, t.overview, d.drag.overview, y) {
 			return
 		}
 	}
@@ -182,6 +173,11 @@ func (d *paneDragger) apply(x, y int, layout Layout, t dragTargets) {
 	// layout cannot snap when the drag is released and re-derived.
 	normalizeLayoutOverrides(o)
 	d.drag.dirty = true
+	if d.drag.boundary == dragBoundaryOverviewSection {
+		// Only the sidebar consumes the overview shares, and it re-reads
+		// them on its next render; skip the full pane relayout.
+		return
+	}
 	d.relayout()
 }
 
@@ -292,9 +288,8 @@ func boundaryAt(x, y int, layout Layout, t dragTargets) (layoutDrag, bool) {
 }
 
 // overviewBoundaryAt hit-tests a mouse position against the separator rules
-// between the run overview sidebar's sections. The sidebar is drawn from
-// the top row of its side of the screen, so its cached rule rows are screen
-// rows.
+// between the run overview sidebar's sections, as recorded by the sidebar's
+// last render.
 func overviewBoundaryAt(x, y int, layout Layout, t dragTargets) (layoutDrag, bool) {
 	switch t.overview.side {
 	case SidebarSideLeft:
@@ -309,28 +304,62 @@ func overviewBoundaryAt(x, y int, layout Layout, t dragTargets) (layoutDrag, boo
 		return layoutDrag{}, false
 	}
 
-	ov, ok := t.overview.separatorDragAt(y)
-	if !ok {
-		return layoutDrag{}, false
+	for _, sep := range t.overview.separators {
+		if sep.row == y {
+			return layoutDrag{boundary: dragBoundaryOverviewSection, overview: sep}, true
+		}
 	}
-	return layoutDrag{boundary: dragBoundaryOverviewSection, overview: ov}, true
+	return layoutDrag{}, false
 }
 
-// dragOverviewSection records in o the section shares for dragging a run
-// overview separator rule to row y: the two neighbors trade rows within the
-// total they held at latch, each keeping at least the minimum height and at
-// most the rows its items can fill. It reports whether o was updated.
-func dragOverviewSection(o *LayoutOverrides, ov overviewSectionDrag, y int) bool {
-	total := ov.aboveH + ov.belowH
-	lo := max(sectionMinHeight, total-ov.belowNeed)
-	hi := min(ov.aboveNeed, total-sectionMinHeight)
-	if lo > hi {
+// dragOverviewSection records in o the section shares for dragging the run
+// overview rule between latched's neighbor sections to row y. Like
+// dragSeparator, it re-reads the live geometry on every motion event, so a
+// mid-drag data update cannot leave the drag working against stale rows.
+//
+// The two neighbors trade rows within the total they currently hold, each
+// keeping at least the minimum height and at most the rows its items can
+// fill. Every visible section's share is recorded so the allocator
+// reproduces exactly these heights. It reports whether o was updated.
+func dragOverviewSection(
+	o *LayoutOverrides,
+	s *RunOverviewSidebar,
+	latched overviewSeparator,
+	y int,
+) bool {
+	row := -1
+	for _, sep := range s.separators {
+		if sep.above == latched.above && sep.below == latched.below {
+			row = sep.row
+			break
+		}
+	}
+	if row < 0 {
+		return false // A neighbor emptied mid-drag; nothing to trade.
+	}
+
+	needs := s.sectionNeeds()
+	area := s.sectionsArea(needs)
+	if area <= 0 {
 		return false
 	}
 
-	aboveH := clamp(ov.aboveH+y-ov.baseY, lo, hi)
-	o.setOverviewFraction(ov.above, float64(aboveH)/float64(ov.area))
-	o.setOverviewFraction(ov.below, float64(total-aboveH)/float64(ov.area))
+	aboveH := s.sections[latched.above].Height
+	total := aboveH + s.sections[latched.below].Height
+	lo := max(sectionMinHeight, total-needs[latched.below])
+	hi := min(needs[latched.above], total-sectionMinHeight)
+	if lo > hi {
+		return false
+	}
+	aboveH = clamp(aboveH+y-row, lo, hi)
+
+	for i := range s.sections {
+		if h := s.sections[i].Height; h > 0 {
+			o.setOverviewFraction(i, float64(h)/float64(area))
+		}
+	}
+	o.setOverviewFraction(latched.above, float64(aboveH)/float64(area))
+	o.setOverviewFraction(latched.below, float64(total-aboveH)/float64(area))
 	return true
 }
 

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -27,21 +27,34 @@ const (
 	dragBoundaryLeftSidebar
 	dragBoundaryRightSidebar
 	dragBoundarySeparator
+	dragBoundaryOverviewSection
 )
 
 // layoutDrag tracks an in-progress boundary drag.
 //
 // overrides accumulates the view's pending layout fractions as the mouse
 // moves (a separator drag between two fixed panes updates two of them) and
-// is persisted once on mouse release. section is set for separator drags.
+// is persisted once on mouse release. section is set for stack separator
+// drags; overview for run overview section drags.
 type layoutDrag struct {
 	boundary  dragBoundary
 	section   stackSectionID
+	overview  overviewSectionDrag
 	overrides LayoutOverrides
 	dirty     bool
 }
 
-func (d layoutDrag) active() bool { return d.boundary != dragBoundaryNone }
+// overviewSectionDrag pins the geometry of a run overview section drag at
+// latch time; mouse motion is applied relative to it.
+type overviewSectionDrag struct {
+	above, below         int // Section indices either side of the rule.
+	baseY                int // Rule's screen row at latch.
+	aboveH, belowH       int // Allocated section heights at latch.
+	aboveNeed, belowNeed int // Content caps (title + items) at latch.
+	area                 int // Rows available to sections at latch.
+}
+
+func (d *layoutDrag) active() bool { return d.boundary != dragBoundaryNone }
 
 // setSection records a stacked pane's height fraction.
 func (o *LayoutOverrides) setSection(id stackSectionID, frac float64) {
@@ -63,6 +76,10 @@ type dragTargets struct {
 	width, height               int
 	leftExpanded, rightExpanded bool
 	mediaFullscreen             bool
+
+	// overview is the view's run overview sidebar when it is stably
+	// expanded; the rules between its sections are then draggable.
+	overview *RunOverviewSidebar
 }
 
 // paneDragger owns mouse-drag pane resizing for one view.
@@ -96,7 +113,7 @@ func (d *paneDragger) handleMouse(msg tea.MouseMsg, layout Layout, t dragTargets
 		if m.Button != tea.MouseLeft {
 			return false
 		}
-		drag, ok := boundaryAt(m.X, m.Y, t.width, layout, t.leftExpanded, t.rightExpanded)
+		drag, ok := boundaryAt(m.X, m.Y, layout, t)
 		if !ok || (drag.boundary == dragBoundarySeparator && t.mediaFullscreen) {
 			// A stale latch survives when the matching release never
 			// reached this view (help overlay, view switch); any new
@@ -154,6 +171,10 @@ func (d *paneDragger) apply(x, y int, layout Layout, t dragTargets) {
 			return // Fullscreen entered mid-drag hides the stack.
 		}
 		if !dragSeparator(o, layout, d.drag.section, y, t.height) {
+			return
+		}
+	case dragBoundaryOverviewSection:
+		if !dragOverviewSection(o, d.drag.overview, y) {
 			return
 		}
 	}
@@ -228,31 +249,34 @@ func nearColumn(x, col int) bool {
 }
 
 // boundaryAt hit-tests a mouse position against the draggable boundaries:
-// the sidebars' border columns (with one column of tolerance either side)
-// and the separator rows of the central stack.
+// the sidebars' border columns (with one column of tolerance either side),
+// the separator rules between run overview sections, and the separator rows
+// of the central stack.
 //
 // Sidebar borders are only draggable when the sidebar is stably expanded so
 // a drag never fights an animation.
-func boundaryAt(
-	x, y, width int,
-	layout Layout,
-	leftExpanded, rightExpanded bool,
-) (layoutDrag, bool) {
+func boundaryAt(x, y int, layout Layout, t dragTargets) (layoutDrag, bool) {
 	if y >= layout.totalContentAreaHeight {
 		return layoutDrag{}, false
 	}
 
-	if layout.leftSidebarWidth > 0 && leftExpanded &&
+	if layout.leftSidebarWidth > 0 && t.leftExpanded &&
 		nearColumn(x, layout.leftSidebarWidth-1) {
 		return layoutDrag{boundary: dragBoundaryLeftSidebar}, true
 	}
-	if layout.rightSidebarWidth > 0 && rightExpanded &&
-		nearColumn(x, width-layout.rightSidebarWidth) {
+	if layout.rightSidebarWidth > 0 && t.rightExpanded &&
+		nearColumn(x, t.width-layout.rightSidebarWidth) {
 		return layoutDrag{boundary: dragBoundaryRightSidebar}, true
 	}
 
+	if t.overview != nil {
+		if drag, ok := overviewBoundaryAt(x, y, layout, t); ok {
+			return drag, true
+		}
+	}
+
 	// Separator rows span the central column only.
-	if x < layout.leftSidebarWidth || x >= width-layout.rightSidebarWidth {
+	if x < layout.leftSidebarWidth || x >= t.width-layout.rightSidebarWidth {
 		return layoutDrag{}, false
 	}
 	sections := stackGeometry(layout)
@@ -265,6 +289,49 @@ func boundaryAt(
 		}
 	}
 	return layoutDrag{}, false
+}
+
+// overviewBoundaryAt hit-tests a mouse position against the separator rules
+// between the run overview sidebar's sections. The sidebar is drawn from
+// the top row of its side of the screen, so its cached rule rows are screen
+// rows.
+func overviewBoundaryAt(x, y int, layout Layout, t dragTargets) (layoutDrag, bool) {
+	switch t.overview.side {
+	case SidebarSideLeft:
+		if x >= layout.leftSidebarWidth {
+			return layoutDrag{}, false
+		}
+	case SidebarSideRight:
+		if x < t.width-layout.rightSidebarWidth {
+			return layoutDrag{}, false
+		}
+	default:
+		return layoutDrag{}, false
+	}
+
+	ov, ok := t.overview.separatorDragAt(y)
+	if !ok {
+		return layoutDrag{}, false
+	}
+	return layoutDrag{boundary: dragBoundaryOverviewSection, overview: ov}, true
+}
+
+// dragOverviewSection records in o the section shares for dragging a run
+// overview separator rule to row y: the two neighbors trade rows within the
+// total they held at latch, each keeping at least the minimum height and at
+// most the rows its items can fill. It reports whether o was updated.
+func dragOverviewSection(o *LayoutOverrides, ov overviewSectionDrag, y int) bool {
+	total := ov.aboveH + ov.belowH
+	lo := max(sectionMinHeight, total-ov.belowNeed)
+	hi := min(ov.aboveNeed, total-sectionMinHeight)
+	if lo > hi {
+		return false
+	}
+
+	aboveH := clamp(ov.aboveH+y-ov.baseY, lo, hi)
+	o.setOverviewFraction(ov.above, float64(aboveH)/float64(ov.area))
+	o.setOverviewFraction(ov.below, float64(total-aboveH)/float64(ov.area))
+	return true
 }
 
 // dragSeparator records in o the pane fractions for dragging the separator

--- a/core/internal/leet/dragresize_test.go
+++ b/core/internal/leet/dragresize_test.go
@@ -1,6 +1,7 @@
 package leet
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,66 +29,162 @@ func testRunLayout() Layout {
 	}
 }
 
+// testDragTargets returns drag targets for testRunLayout's terminal with
+// both sidebars stably expanded.
+func testDragTargets() dragTargets {
+	return dragTargets{width: 200, leftExpanded: true, rightExpanded: true}
+}
+
 func TestBoundaryAtSidebarBorders(t *testing.T) {
 	layout := testRunLayout()
-	const width = 200
+	targets := testDragTargets()
+	width := targets.width
 
 	// The left sidebar's border is its last column; the border column and
 	// one column either side latch (mouse coordinates are cell-quantized,
 	// so a one-column target is luck-based).
 	for _, x := range []int{38, 39, 40} {
-		drag, ok := boundaryAt(x, 5, width, layout, true, true)
+		drag, ok := boundaryAt(x, 5, layout, targets)
 		require.True(t, ok, "x=%d", x)
 		require.Equal(t, dragBoundaryLeftSidebar, drag.boundary)
 	}
 
 	// The right sidebar's border is its first column, same tolerance.
 	for _, x := range []int{width - 61, width - 60, width - 59} {
-		drag, ok := boundaryAt(x, 5, width, layout, true, true)
+		drag, ok := boundaryAt(x, 5, layout, targets)
 		require.True(t, ok, "x=%d", x)
 		require.Equal(t, dragBoundaryRightSidebar, drag.boundary)
 	}
 
 	// Two columns off is a miss.
-	_, ok := boundaryAt(37, 5, width, layout, true, true)
+	_, ok := boundaryAt(37, 5, layout, targets)
 	require.False(t, ok)
-	_, ok = boundaryAt(width-58, 5, width, layout, true, true)
+	_, ok = boundaryAt(width-58, 5, layout, targets)
 	require.False(t, ok)
 
 	// A collapsed/animating sidebar is not draggable.
-	_, ok = boundaryAt(39, 5, width, layout, false, true)
+	collapsed := targets
+	collapsed.leftExpanded = false
+	_, ok = boundaryAt(39, 5, layout, collapsed)
 	require.False(t, ok)
 
 	// The status bar area is off limits.
-	_, ok = boundaryAt(39, layout.totalContentAreaHeight, width, layout, true, true)
+	_, ok = boundaryAt(39, layout.totalContentAreaHeight, layout, targets)
 	require.False(t, ok)
 }
 
 func TestBoundaryAtStackSeparators(t *testing.T) {
 	layout := testRunLayout()
-	const width = 200
+	targets := testDragTargets()
+	width := targets.width
 
 	// Separator above media.
-	drag, ok := boundaryAt(100, layout.mediaY-1, width, layout, true, true)
+	drag, ok := boundaryAt(100, layout.mediaY-1, layout, targets)
 	require.True(t, ok)
 	require.Equal(t, dragBoundarySeparator, drag.boundary)
 	require.Equal(t, stackSectionMedia, drag.section)
 
 	// Separator above console logs.
-	drag, ok = boundaryAt(100, layout.consoleLogsY-1, width, layout, true, true)
+	drag, ok = boundaryAt(100, layout.consoleLogsY-1, layout, targets)
 	require.True(t, ok)
 	require.Equal(t, dragBoundarySeparator, drag.boundary)
 	require.Equal(t, stackSectionConsoleLogs, drag.section)
 
 	// Separator rows are only draggable within the central column.
-	_, ok = boundaryAt(10, layout.mediaY-1, width, layout, true, true)
+	_, ok = boundaryAt(10, layout.mediaY-1, layout, targets)
 	require.False(t, ok)
-	_, ok = boundaryAt(width-30, layout.mediaY-1, width, layout, true, true)
+	_, ok = boundaryAt(width-30, layout.mediaY-1, layout, targets)
 	require.False(t, ok)
 
 	// Non-separator rows in the central column are misses.
-	_, ok = boundaryAt(100, layout.mediaY, width, layout, true, true)
+	_, ok = boundaryAt(100, layout.mediaY, layout, targets)
 	require.False(t, ok)
+}
+
+func TestBoundaryAtOverviewSeparators(t *testing.T) {
+	layout := testRunLayout()
+	targets := testDragTargets()
+
+	sb := testOverviewSidebar(t, SidebarSideLeft, layout.leftSidebarWidth)
+	view := sb.View(layout.totalContentAreaHeight)
+	seps := sb.sectionSeparators()
+	require.Len(t, seps, 2)
+	targets.overview = sb
+
+	// The derived separator rows match the rendered rule rows.
+	var ruleRows []int
+	for row, line := range strings.Split(view.Content, "\n") {
+		if strings.Contains(line, "————") {
+			ruleRows = append(ruleRows, row)
+		}
+	}
+	require.Equal(t, []int{seps[0].row, seps[1].row}, ruleRows)
+
+	// A click on a separator rule inside the sidebar latches a section drag.
+	for _, sep := range seps {
+		drag, ok := boundaryAt(5, sep.row, layout, targets)
+		require.True(t, ok, "row=%d", sep.row)
+		require.Equal(t, dragBoundaryOverviewSection, drag.boundary)
+		require.Equal(t, sep.above, drag.overview.above)
+		require.Equal(t, sep.below, drag.overview.below)
+		require.Equal(t, sep.row, drag.overview.baseY)
+	}
+
+	// One row off is a miss.
+	_, ok := boundaryAt(5, seps[0].row+1, layout, targets)
+	require.False(t, ok)
+
+	// The same row outside the sidebar is not an overview drag.
+	drag, ok := boundaryAt(100, seps[0].row, layout, targets)
+	require.True(t, !ok || drag.boundary != dragBoundaryOverviewSection)
+
+	// No latch without the sidebar (collapsed or animating).
+	targets.overview = nil
+	_, ok = boundaryAt(5, seps[0].row, layout, targets)
+	require.False(t, ok)
+}
+
+func TestDragOverviewSectionTradesRows(t *testing.T) {
+	ov := overviewSectionDrag{
+		above: 0, below: 1,
+		baseY:  10,
+		aboveH: 5, belowH: 7,
+		aboveNeed: 20, belowNeed: 20,
+		area: 30,
+	}
+
+	// Dragging down by 3 rows grows the section above and shrinks the one
+	// below; both shares are fractions of the section area.
+	var o LayoutOverrides
+	require.True(t, dragOverviewSection(&o, ov, 13))
+	require.InDelta(t, 8.0/30, o.OverviewEnv, 1e-9)
+	require.InDelta(t, 4.0/30, o.OverviewConfig, 1e-9)
+
+	// Dragging far up stops at the minimum height for the section above.
+	o = LayoutOverrides{}
+	require.True(t, dragOverviewSection(&o, ov, 0))
+	require.InDelta(t, 2.0/30, o.OverviewEnv, 1e-9)
+	require.InDelta(t, 10.0/30, o.OverviewConfig, 1e-9)
+
+	// Dragging far down stops where the section above meets its need.
+	o = LayoutOverrides{}
+	ov.aboveNeed = 6
+	require.True(t, dragOverviewSection(&o, ov, 25))
+	require.InDelta(t, 6.0/30, o.OverviewEnv, 1e-9)
+	require.InDelta(t, 6.0/30, o.OverviewConfig, 1e-9)
+
+	// No legal position: nothing recorded.
+	o = LayoutOverrides{}
+	ov = overviewSectionDrag{
+		above: 0, below: 1,
+		baseY:  10,
+		aboveH: 2, belowH: 3,
+		aboveNeed: 2, belowNeed: 2,
+		area: 30,
+	}
+	require.False(t, dragOverviewSection(&o, ov, 11))
+	require.Zero(t, o.OverviewEnv)
+	require.Zero(t, o.OverviewConfig)
 }
 
 // frac converts a pane extent to its terminal-dimension fraction.

--- a/core/internal/leet/dragresize_test.go
+++ b/core/internal/leet/dragresize_test.go
@@ -1,10 +1,13 @@
 package leet
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
 // testRunLayout mirrors a single-run view: metrics (flex) on top, media and
@@ -105,13 +108,13 @@ func TestBoundaryAtOverviewSeparators(t *testing.T) {
 	layout := testRunLayout()
 	targets := testDragTargets()
 
-	sb := testOverviewSidebar(t, SidebarSideLeft, layout.leftSidebarWidth)
+	_, sb := testOverviewSidebar(t, SidebarSideLeft, layout.leftSidebarWidth)
 	view := sb.View(layout.totalContentAreaHeight)
-	seps := sb.sectionSeparators()
+	seps := sb.separators
 	require.Len(t, seps, 2)
 	targets.overview = sb
 
-	// The derived separator rows match the rendered rule rows.
+	// The recorded separator rows match the rendered rule rows.
 	var ruleRows []int
 	for row, line := range strings.Split(view.Content, "\n") {
 		if strings.Contains(line, "————") {
@@ -125,9 +128,7 @@ func TestBoundaryAtOverviewSeparators(t *testing.T) {
 		drag, ok := boundaryAt(5, sep.row, layout, targets)
 		require.True(t, ok, "row=%d", sep.row)
 		require.Equal(t, dragBoundaryOverviewSection, drag.boundary)
-		require.Equal(t, sep.above, drag.overview.above)
-		require.Equal(t, sep.below, drag.overview.below)
-		require.Equal(t, sep.row, drag.overview.baseY)
+		require.Equal(t, sep, drag.overview)
 	}
 
 	// One row off is a miss.
@@ -138,6 +139,13 @@ func TestBoundaryAtOverviewSeparators(t *testing.T) {
 	drag, ok := boundaryAt(100, seps[0].row, layout, targets)
 	require.True(t, !ok || drag.boundary != dragBoundaryOverviewSection)
 
+	// A sidebar rendered without data offers no rules to grab.
+	sb.SetRunOverview(nil)
+	sb.View(layout.totalContentAreaHeight)
+	require.Empty(t, sb.separators)
+	_, ok = boundaryAt(5, seps[0].row, layout, targets)
+	require.False(t, ok)
+
 	// No latch without the sidebar (collapsed or animating).
 	targets.overview = nil
 	_, ok = boundaryAt(5, seps[0].row, layout, targets)
@@ -145,46 +153,54 @@ func TestBoundaryAtOverviewSeparators(t *testing.T) {
 }
 
 func TestDragOverviewSectionTradesRows(t *testing.T) {
-	ov := overviewSectionDrag{
-		above: 0, below: 1,
-		baseY:  10,
-		aboveH: 5, belowH: 7,
-		aboveNeed: 20, belowNeed: 20,
-		area: 30,
+	ro, sb := testOverviewSidebar(t, SidebarSideLeft, 40)
+	for i := range 20 {
+		ro.ProcessSummaryMsg([]*spb.SummaryRecord{{
+			Update: []*spb.SummaryItem{{
+				NestedKey: []string{"m", fmt.Sprintf("k%d", i)},
+				ValueJson: "1",
+			}},
+		}})
 	}
+	ro.ProcessRunMsg(RunMsg{Config: &spb.ConfigRecord{
+		Update: configItems(20),
+	}})
+	sb.Sync()
+	sb.View(30)
+	require.Len(t, sb.separators, 2)
 
-	// Dragging down by 3 rows grows the section above and shrinks the one
-	// below; both shares are fractions of the section area.
+	// Dragging the Config/Summary rule down 3 rows lands it exactly on the
+	// mouse row once the pending shares flow back through the allocator.
+	sep := sb.separators[1]
+	before := sb.sections[sep.above].Height
 	var o LayoutOverrides
-	require.True(t, dragOverviewSection(&o, ov, 13))
-	require.InDelta(t, 8.0/30, o.OverviewEnv, 1e-9)
-	require.InDelta(t, 4.0/30, o.OverviewConfig, 1e-9)
+	require.True(t, dragOverviewSection(&o, sb, sep, sep.row+3))
+	sb.overridesSource = func() LayoutOverrides { return o }
+	sb.View(30)
+	require.Equal(t, sep.row+3, sb.separators[1].row)
+	require.Equal(t, before+3, sb.sections[sep.above].Height)
 
-	// Dragging far up stops at the minimum height for the section above.
-	o = LayoutOverrides{}
-	require.True(t, dragOverviewSection(&o, ov, 0))
-	require.InDelta(t, 2.0/30, o.OverviewEnv, 1e-9)
-	require.InDelta(t, 10.0/30, o.OverviewConfig, 1e-9)
+	// Dragging far up floors the section above at its minimum.
+	require.True(t, dragOverviewSection(&o, sb, sep, 0))
+	sb.View(30)
+	require.Equal(t, sectionMinHeight, sb.sections[sep.above].Height)
 
-	// Dragging far down stops where the section above meets its need.
-	o = LayoutOverrides{}
-	ov.aboveNeed = 6
-	require.True(t, dragOverviewSection(&o, ov, 25))
-	require.InDelta(t, 6.0/30, o.OverviewEnv, 1e-9)
-	require.InDelta(t, 6.0/30, o.OverviewConfig, 1e-9)
+	// Dragging far down floors the section below at its minimum.
+	require.True(t, dragOverviewSection(&o, sb, sep, 100))
+	sb.View(30)
+	require.Equal(t, sectionMinHeight, sb.sections[sep.below].Height)
+}
 
-	// No legal position: nothing recorded.
-	o = LayoutOverrides{}
-	ov = overviewSectionDrag{
-		above: 0, below: 1,
-		baseY:  10,
-		aboveH: 2, belowH: 3,
-		aboveNeed: 2, belowNeed: 2,
-		area: 30,
+// configItems returns n distinct config update items.
+func configItems(n int) []*spb.ConfigItem {
+	items := make([]*spb.ConfigItem, 0, n)
+	for i := range n {
+		items = append(items, &spb.ConfigItem{
+			NestedKey: []string{"c", fmt.Sprintf("k%d", i)},
+			ValueJson: "1",
+		})
 	}
-	require.False(t, dragOverviewSection(&o, ov, 11))
-	require.Zero(t, o.OverviewEnv)
-	require.Zero(t, o.OverviewConfig)
+	return items
 }
 
 // frac converts a pane extent to its terminal-dimension fraction.

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -180,6 +180,7 @@ func NewRun(
 		relayout: run.applyLayoutConfig,
 		logger:   logger,
 	}
+	run.leftSidebar.overridesSource = run.layoutOverrides
 	return run
 }
 

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -150,13 +150,17 @@ func (r *Run) handleMouseMsg(msg tea.MouseMsg) tea.Cmd {
 
 // dragTargets reports which layout boundaries a mouse event may grab.
 func (r *Run) dragTargets() dragTargets {
-	return dragTargets{
+	t := dragTargets{
 		width:           r.width,
 		height:          r.height,
 		leftExpanded:    r.leftSidebar.IsExpanded(),
 		rightExpanded:   r.rightSidebar.animState.IsExpanded(),
 		mediaFullscreen: r.mediaPane.IsFullscreen(),
 	}
+	if t.leftExpanded {
+		t.overview = r.leftSidebar
+	}
+	return t
 }
 
 // handleResetLayout resets the view's pane proportions to the defaults.

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -44,6 +44,10 @@ type RunOverviewSidebar struct {
 	// an in-progress drag's pending values, or the persisted config.
 	// Nil means no overrides (built-in section weights).
 	overridesSource func() LayoutOverrides
+
+	// separators are the rules between sections as drawn by the last
+	// render; mouse drags hit-test against them.
+	separators []overviewSeparator
 }
 
 // overviewSeparator locates one rendered separator rule between sections.
@@ -133,6 +137,10 @@ func (s *RunOverviewSidebar) headerStyle() lipgloss.Style {
 
 // View renders the sidebar.
 func (s *RunOverviewSidebar) View(height int) tea.View {
+	// This render's rules are the drag targets; a sidebar that renders
+	// nothing must offer nothing to grab.
+	s.separators = s.separators[:0]
+
 	width := s.animState.Value()
 	if height <= 0 || width <= SidebarOverhead {
 		return tea.NewView("")
@@ -146,7 +154,7 @@ func (s *RunOverviewSidebar) View(height int) tea.View {
 	if s.runOverview != nil {
 		headerLines := s.buildHeaderLines(contentWidth)
 		s.updateSectionHeights()
-		sectionLines := s.buildSectionLines(contentWidth)
+		sectionLines := s.buildSectionLines(contentWidth, 1+len(headerLines))
 
 		lines = slices.Concat(lines, headerLines, sectionLines)
 	} else {
@@ -439,95 +447,39 @@ func (s *RunOverviewSidebar) renderTagHeaderValue(
 	return lines
 }
 
-// buildSectionLines builds all section content lines.
-func (s *RunOverviewSidebar) buildSectionLines(contentWidth int) []string {
+// buildSectionLines builds all section content lines, recording the screen
+// row of each separator rule it draws between adjacent sections. firstRow
+// is the screen row of the first section line (the sidebar is drawn from
+// the top row of its side of the screen, below its title and header).
+func (s *RunOverviewSidebar) buildSectionLines(contentWidth, firstRow int) []string {
 	var lines []string
 
+	row := firstRow
+	prev := -1
 	for i := range s.sections {
 		if s.sections[i].Height == 0 {
 			continue
 		}
 
 		sectionContent := s.renderSection(i, contentWidth)
-		if sectionContent != "" {
-			lines = append(lines, sectionContent)
-
-			// Separate adjacent sections with the same rule the central
-			// column draws between its stacked panes.
-			if s.hasNextVisibleSection(i) {
-				lines = append(lines, renderHorizontalSeparator(contentWidth))
-			}
+		if sectionContent == "" {
+			continue
 		}
+
+		// Separate adjacent sections with the same rule the central
+		// column draws between its stacked panes.
+		if prev >= 0 {
+			lines = append(lines, renderHorizontalSeparator(contentWidth))
+			s.separators = append(s.separators,
+				overviewSeparator{row: row, above: prev, below: i})
+			row++
+		}
+		lines = append(lines, sectionContent)
+		row += lipgloss.Height(sectionContent)
+		prev = i
 	}
 
 	return lines
-}
-
-// hasNextVisibleSection returns true if there's another visible section after idx.
-func (s *RunOverviewSidebar) hasNextVisibleSection(idx int) bool {
-	for j := idx + 1; j < len(s.sections); j++ {
-		if s.sections[j].Height > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// sectionSeparators locates the separator rules between visible sections as
-// buildSectionLines lays them out. The sidebar is drawn from the top row of
-// its side of the screen, so these are screen rows.
-func (s *RunOverviewSidebar) sectionSeparators() []overviewSeparator {
-	var seps []overviewSeparator
-
-	row := s.headerLineCount()
-	prev := -1
-	for i := range s.sections {
-		if s.sections[i].Height == 0 || len(s.sections[i].FilteredItems) == 0 {
-			continue
-		}
-		if prev >= 0 {
-			seps = append(seps, overviewSeparator{row: row, above: prev, below: i})
-			row++
-		}
-		row += s.renderedSectionLines(i)
-		prev = i
-	}
-	return seps
-}
-
-// renderedSectionLines returns the rows section i occupies on screen: a
-// title line plus the items on its current page (mirrors renderSectionItems).
-func (s *RunOverviewSidebar) renderedSectionLines(i int) int {
-	sec := &s.sections[i]
-	return 1 + sec.itemsOnPage(sec.CurrentPage())
-}
-
-// separatorDragAt returns the latch-time geometry for a drag starting on
-// the separator rule at screen row y, if there is one.
-func (s *RunOverviewSidebar) separatorDragAt(y int) (overviewSectionDrag, bool) {
-	for _, sep := range s.sectionSeparators() {
-		if sep.row != y {
-			continue
-		}
-
-		needs := s.sectionNeeds()
-		area := s.sectionsArea(needs)
-		if area <= 0 {
-			break
-		}
-
-		return overviewSectionDrag{
-			above:     sep.above,
-			below:     sep.below,
-			baseY:     y,
-			aboveH:    s.sections[sep.above].Height,
-			belowH:    s.sections[sep.below].Height,
-			aboveNeed: needs[sep.above],
-			belowNeed: needs[sep.below],
-			area:      area,
-		}, true
-	}
-	return overviewSectionDrag{}, false
 }
 
 // renderSection renders a single section, always exactly Height rows so

--- a/core/internal/leet/runoverviewsidebar.go
+++ b/core/internal/leet/runoverviewsidebar.go
@@ -39,6 +39,17 @@ type RunOverviewSidebar struct {
 	// Placement and dimensions.
 	side   SidebarSide
 	height int
+
+	// overridesSource returns the owning view's live layout overrides:
+	// an in-progress drag's pending values, or the persisted config.
+	// Nil means no overrides (built-in section weights).
+	overridesSource func() LayoutOverrides
+}
+
+// overviewSeparator locates one rendered separator rule between sections.
+type overviewSeparator struct {
+	row          int // Screen row of the rule.
+	above, below int // Section indices either side of it.
 }
 
 func NewRunOverviewSidebar(
@@ -452,6 +463,73 @@ func (s *RunOverviewSidebar) buildSectionLines(contentWidth int) []string {
 	return lines
 }
 
+// hasNextVisibleSection returns true if there's another visible section after idx.
+func (s *RunOverviewSidebar) hasNextVisibleSection(idx int) bool {
+	for j := idx + 1; j < len(s.sections); j++ {
+		if s.sections[j].Height > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// sectionSeparators locates the separator rules between visible sections as
+// buildSectionLines lays them out. The sidebar is drawn from the top row of
+// its side of the screen, so these are screen rows.
+func (s *RunOverviewSidebar) sectionSeparators() []overviewSeparator {
+	var seps []overviewSeparator
+
+	row := s.headerLineCount()
+	prev := -1
+	for i := range s.sections {
+		if s.sections[i].Height == 0 || len(s.sections[i].FilteredItems) == 0 {
+			continue
+		}
+		if prev >= 0 {
+			seps = append(seps, overviewSeparator{row: row, above: prev, below: i})
+			row++
+		}
+		row += s.renderedSectionLines(i)
+		prev = i
+	}
+	return seps
+}
+
+// renderedSectionLines returns the rows section i occupies on screen: a
+// title line plus the items on its current page (mirrors renderSectionItems).
+func (s *RunOverviewSidebar) renderedSectionLines(i int) int {
+	sec := &s.sections[i]
+	return 1 + sec.itemsOnPage(sec.CurrentPage())
+}
+
+// separatorDragAt returns the latch-time geometry for a drag starting on
+// the separator rule at screen row y, if there is one.
+func (s *RunOverviewSidebar) separatorDragAt(y int) (overviewSectionDrag, bool) {
+	for _, sep := range s.sectionSeparators() {
+		if sep.row != y {
+			continue
+		}
+
+		needs := s.sectionNeeds()
+		area := s.sectionsArea(needs)
+		if area <= 0 {
+			break
+		}
+
+		return overviewSectionDrag{
+			above:     sep.above,
+			below:     sep.below,
+			baseY:     y,
+			aboveH:    s.sections[sep.above].Height,
+			belowH:    s.sections[sep.below].Height,
+			aboveNeed: needs[sep.above],
+			belowNeed: needs[sep.below],
+			area:      area,
+		}, true
+	}
+	return overviewSectionDrag{}, false
+}
+
 // renderSection renders a single section, always exactly Height rows so
 // the layout matches the allocation and stays put while paging.
 func (s *RunOverviewSidebar) renderSection(idx, width int) string {
@@ -578,16 +656,6 @@ func (s *RunOverviewSidebar) renderItem(
 		return renderedKey + gap + renderedValue
 	}
 	return renderedKey + gap + valueStyle.MaxWidth(maxValueWidth).Render(value)
-}
-
-// hasNextVisibleSection returns true if there's another visible section after idx.
-func (s *RunOverviewSidebar) hasNextVisibleSection(idx int) bool {
-	for j := idx + 1; j < len(s.sections); j++ {
-		if s.sections[j].Height > 0 {
-			return true
-		}
-	}
-	return false
 }
 
 // activateSelection ensures that exactly one section is marked active (if possible).

--- a/core/internal/leet/runoverviewsidebarnav.go
+++ b/core/internal/leet/runoverviewsidebarnav.go
@@ -12,13 +12,59 @@ const (
 	sectionMinHeight = 2
 )
 
-// sectionWeights returns each section's desired share of the section area.
-func (s *RunOverviewSidebar) sectionWeights() []float64 {
-	return []float64{
+// sectionWeights returns each section's desired share of the section area:
+// the user-dragged fractions where set, with the remaining share divided
+// among the unset visible sections by the built-in weights.
+func (s *RunOverviewSidebar) sectionWeights(needs []int) []float64 {
+	defaults := []float64{
 		sectionWeightEnvironment,
 		sectionWeightConfig,
 		sectionWeightSummary,
 	}
+
+	var o LayoutOverrides
+	if s.overridesSource != nil {
+		o = s.overridesSource()
+	}
+	fracs := o.overviewFractions()
+
+	var explicitSum, defaultSum float64
+	for i, need := range needs {
+		if need <= 0 {
+			continue
+		}
+		if fracs[i] > 0 {
+			explicitSum += fracs[i]
+		} else {
+			defaultSum += defaults[i]
+		}
+	}
+
+	weights := make([]float64, len(needs))
+	leftover := max(1-explicitSum, 0)
+	for i, need := range needs {
+		if need <= 0 {
+			continue
+		}
+		if fracs[i] > 0 {
+			weights[i] = fracs[i]
+		} else if defaultSum > 0 {
+			weights[i] = leftover * defaults[i] / defaultSum
+		}
+	}
+	return weights
+}
+
+// sectionNeeds returns the rows each section can usefully fill (title +
+// items), 0 for empty sections.
+func (s *RunOverviewSidebar) sectionNeeds() []int {
+	needs := make([]int, len(s.sections))
+	for i := range s.sections {
+		if itemCount := len(s.sections[i].FilteredItems); itemCount > 0 {
+			needs[i] = itemCount + 1 // Title line.
+		}
+	}
+	return needs
 }
 
 // updateSectionHeights divides the sidebar rows below the header among the
@@ -28,14 +74,8 @@ func (s *RunOverviewSidebar) updateSectionHeights() {
 		return
 	}
 
-	needs := make([]int, len(s.sections))
-	for i := range s.sections {
-		if itemCount := len(s.sections[i].FilteredItems); itemCount > 0 {
-			needs[i] = itemCount + 1 // Title line.
-		}
-	}
-
-	heights := flexSectionHeights(s.sectionsArea(needs), s.sectionWeights(), needs)
+	needs := s.sectionNeeds()
+	heights := flexSectionHeights(s.sectionsArea(needs), s.sectionWeights(needs), needs)
 	for i := range s.sections {
 		s.sections[i].Height = heights[i]
 	}

--- a/core/internal/leet/runoverviewsidebarnav.go
+++ b/core/internal/leet/runoverviewsidebarnav.go
@@ -3,7 +3,8 @@ package leet
 const (
 	// Each section's default share of the sidebar's vertical space when
 	// the sections want more rows than fit. The shares sum to 1, so a
-	// value reads directly as that section's slice of the area.
+	// value reads directly as that section's slice of the area, in the
+	// same unit as the dragged overview_* fractions.
 	sectionWeightEnvironment = 0.20
 	sectionWeightConfig      = 0.35
 	sectionWeightSummary     = 0.45
@@ -12,9 +13,11 @@ const (
 	sectionMinHeight = 2
 )
 
-// sectionWeights returns each section's desired share of the section area:
-// the user-dragged fractions where set, with the remaining share divided
-// among the unset visible sections by the built-in weights.
+// sectionWeights returns each visible section's share of the section area:
+// the user-dragged fraction where set, otherwise the built-in default.
+// proportionalShares normalizes the weights, so dragged sections keep their
+// exact shares while all of them are set and every section degrades
+// proportionally when the data changes underneath.
 func (s *RunOverviewSidebar) sectionWeights(needs []int) []float64 {
 	defaults := []float64{
 		sectionWeightEnvironment,
@@ -28,28 +31,15 @@ func (s *RunOverviewSidebar) sectionWeights(needs []int) []float64 {
 	}
 	fracs := o.overviewFractions()
 
-	var explicitSum, defaultSum float64
-	for i, need := range needs {
-		if need <= 0 {
-			continue
-		}
-		if fracs[i] > 0 {
-			explicitSum += fracs[i]
-		} else {
-			defaultSum += defaults[i]
-		}
-	}
-
 	weights := make([]float64, len(needs))
-	leftover := max(1-explicitSum, 0)
 	for i, need := range needs {
 		if need <= 0 {
 			continue
 		}
 		if fracs[i] > 0 {
 			weights[i] = fracs[i]
-		} else if defaultSum > 0 {
-			weights[i] = leftover * defaults[i] / defaultSum
+		} else {
+			weights[i] = defaults[i]
 		}
 	}
 	return weights

--- a/core/internal/leet/runoverviewsidebarnav_test.go
+++ b/core/internal/leet/runoverviewsidebarnav_test.go
@@ -10,8 +10,12 @@ import (
 )
 
 // testOverviewSidebar returns an expanded run overview sidebar with items
-// in every section (2 environment, 1 config, 1 summary).
-func testOverviewSidebar(t *testing.T, side SidebarSide, width int) *RunOverviewSidebar {
+// in every section (2 environment, 1 config, 1 summary), along with its
+// run overview for feeding in more data.
+func testOverviewSidebar(t *testing.T, side SidebarSide, width int) (
+	*RunOverview,
+	*RunOverviewSidebar,
+) {
 	t.Helper()
 
 	cfg := NewConfigManager(filepath.Join(t.TempDir(), "config.json"), nil)
@@ -31,42 +35,46 @@ func testOverviewSidebar(t *testing.T, side SidebarSide, width int) *RunOverview
 	ro.ProcessSystemInfoMsg(&spb.EnvironmentRecord{WriterId: "writer-1", Os: "linux"})
 	sb.Sync()
 
-	return sb
+	return ro, sb
 }
 
 func TestSectionWeights_DraggedFractions(t *testing.T) {
-	sb := testOverviewSidebar(t, SidebarSideLeft, 40)
+	_, sb := testOverviewSidebar(t, SidebarSideLeft, 40)
 
 	// Without overrides, the built-in weights apply (normalized to sum 1).
 	w := sb.sectionWeights([]int{3, 6, 4})
-	require.InDelta(t, 1.0/4.5, w[0], 1e-9)
-	require.InDelta(t, 1.5/4.5, w[1], 1e-9)
-	require.InDelta(t, 2.0/4.5, w[2], 1e-9)
+	require.InDelta(t, 0.20, w[0], 1e-9)
+	require.InDelta(t, 0.35, w[1], 1e-9)
+	require.InDelta(t, 0.45, w[2], 1e-9)
 
-	// A dragged share is used as-is; the rest of the area divides among the
-	// unset sections by the built-in weights (environment:summary = 1:2).
+	// A dragged share is used as-is; unset sections keep their default
+	// weights, so a section that appears later always gets a share.
 	sb.overridesSource = func() LayoutOverrides {
-		return LayoutOverrides{OverviewConfig: 0.5}
+		return LayoutOverrides{OverviewEnv: 0.3, OverviewConfig: 0.7}
 	}
 	w = sb.sectionWeights([]int{3, 6, 4})
-	require.InDelta(t, 0.5/3, w[0], 1e-9)
-	require.InDelta(t, 0.5, w[1], 1e-9)
-	require.InDelta(t, 1.0/3, w[2], 1e-9)
+	require.InDelta(t, 0.3, w[0], 1e-9)
+	require.InDelta(t, 0.7, w[1], 1e-9)
+	require.InDelta(t, 0.45, w[2], 1e-9)
 
-	// Hidden sections get no weight and no share of the leftover.
+	// Hidden sections get no weight.
 	w = sb.sectionWeights([]int{0, 6, 4})
 	require.Zero(t, w[0])
-	require.InDelta(t, 0.5, w[1], 1e-9)
-	require.InDelta(t, 0.5, w[2], 1e-9)
+	require.InDelta(t, 0.7, w[1], 1e-9)
+	require.InDelta(t, 0.45, w[2], 1e-9)
 }
 
-// A drag persists shares as fractions of the section area; feeding them back
+// A drag persists a share for every visible section; feeding them back
 // through the allocator must reproduce the dragged heights exactly, so the
 // separator tracks the mouse 1:1.
 func TestFlexSectionHeights_HonorsDraggedFractions(t *testing.T) {
-	sb := testOverviewSidebar(t, SidebarSideLeft, 40)
+	_, sb := testOverviewSidebar(t, SidebarSideLeft, 40)
 	sb.overridesSource = func() LayoutOverrides {
-		return LayoutOverrides{OverviewEnv: 0.2, OverviewConfig: 0.3}
+		return LayoutOverrides{
+			OverviewEnv:     0.2,
+			OverviewConfig:  0.3,
+			OverviewSummary: 0.5,
+		}
 	}
 
 	needs := []int{10, 20, 30}

--- a/core/internal/leet/runoverviewsidebarnav_test.go
+++ b/core/internal/leet/runoverviewsidebarnav_test.go
@@ -1,10 +1,78 @@
 package leet
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+// testOverviewSidebar returns an expanded run overview sidebar with items
+// in every section (2 environment, 1 config, 1 summary).
+func testOverviewSidebar(t *testing.T, side SidebarSide, width int) *RunOverviewSidebar {
+	t.Helper()
+
+	cfg := NewConfigManager(filepath.Join(t.TempDir(), "config.json"), nil)
+	ro := NewRunOverview()
+	sb := NewRunOverviewSidebar(cfg, NewAnimatedValue(true, width), ro, side)
+
+	ro.ProcessRunMsg(RunMsg{
+		Config: &spb.ConfigRecord{
+			Update: []*spb.ConfigItem{
+				{NestedKey: []string{"trainer", "epochs"}, ValueJson: "10"},
+			},
+		},
+	})
+	ro.ProcessSummaryMsg([]*spb.SummaryRecord{
+		{Update: []*spb.SummaryItem{{NestedKey: []string{"acc"}, ValueJson: "0.9"}}},
+	})
+	ro.ProcessSystemInfoMsg(&spb.EnvironmentRecord{WriterId: "writer-1", Os: "linux"})
+	sb.Sync()
+
+	return sb
+}
+
+func TestSectionWeights_DraggedFractions(t *testing.T) {
+	sb := testOverviewSidebar(t, SidebarSideLeft, 40)
+
+	// Without overrides, the built-in weights apply (normalized to sum 1).
+	w := sb.sectionWeights([]int{3, 6, 4})
+	require.InDelta(t, 1.0/4.5, w[0], 1e-9)
+	require.InDelta(t, 1.5/4.5, w[1], 1e-9)
+	require.InDelta(t, 2.0/4.5, w[2], 1e-9)
+
+	// A dragged share is used as-is; the rest of the area divides among the
+	// unset sections by the built-in weights (environment:summary = 1:2).
+	sb.overridesSource = func() LayoutOverrides {
+		return LayoutOverrides{OverviewConfig: 0.5}
+	}
+	w = sb.sectionWeights([]int{3, 6, 4})
+	require.InDelta(t, 0.5/3, w[0], 1e-9)
+	require.InDelta(t, 0.5, w[1], 1e-9)
+	require.InDelta(t, 1.0/3, w[2], 1e-9)
+
+	// Hidden sections get no weight and no share of the leftover.
+	w = sb.sectionWeights([]int{0, 6, 4})
+	require.Zero(t, w[0])
+	require.InDelta(t, 0.5, w[1], 1e-9)
+	require.InDelta(t, 0.5, w[2], 1e-9)
+}
+
+// A drag persists shares as fractions of the section area; feeding them back
+// through the allocator must reproduce the dragged heights exactly, so the
+// separator tracks the mouse 1:1.
+func TestFlexSectionHeights_HonorsDraggedFractions(t *testing.T) {
+	sb := testOverviewSidebar(t, SidebarSideLeft, 40)
+	sb.overridesSource = func() LayoutOverrides {
+		return LayoutOverrides{OverviewEnv: 0.2, OverviewConfig: 0.3}
+	}
+
+	needs := []int{10, 20, 30}
+	got := flexSectionHeights(20, sb.sectionWeights(needs), needs)
+	require.Equal(t, []int{4, 6, 10}, got)
+}
 
 func TestFlexSectionHeights(t *testing.T) {
 	equal := []float64{1, 1, 1}

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -194,6 +194,7 @@ func NewWorkspace(
 		relayout: w.applyLayoutConfig,
 		logger:   logger,
 	}
+	w.runOverviewSidebar.overridesSource = w.layoutOverrides
 	// The runs list starts focused by default.
 	w.focusMgr.SetTarget(FocusTargetRunsList, 1)
 	return w

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -157,13 +157,17 @@ func (w *Workspace) handleMouse(msg tea.MouseMsg) tea.Cmd {
 
 // dragTargets reports which layout boundaries a mouse event may grab.
 func (w *Workspace) dragTargets() dragTargets {
-	return dragTargets{
+	t := dragTargets{
 		width:           w.width,
 		height:          w.height,
 		leftExpanded:    w.runsAnimState.IsExpanded(),
 		rightExpanded:   w.runOverviewSidebar.IsExpanded(),
 		mediaFullscreen: w.mediaPane.IsFullscreen(),
 	}
+	if t.rightExpanded {
+		t.overview = w.runOverviewSidebar
+	}
+	return t
 }
 
 // handleResetLayout resets the view's pane proportions to the defaults.


### PR DESCRIPTION
Description
-----------
The separator rules between the run overview sections are now mouse drag handles, like the sidebar borders and the central stack separators. Dragging one trades rows between the two neighboring sections. Each section keeps at least a title plus one item and stops growing once all its items fit.

Dragged shares persist per view (run and workspace) in wandb-leet.json as fractions of the sidebar's section area, so they survive terminal resizes. The 0 key resets them along with the other pane proportions.

The sidebar records the rule rows as it renders them, and the drag re-reads the live geometry on every motion event (the same shape as the stack-separator drag), so the rule keeps tracking the mouse while a live run streams new data. A drag records a share for every visible section, so a section that appears later still gets its default share.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Unit tests for rule hit-testing, drag clamps, and dragged-share weights.
