### PR TITLE
fix(leet): make console logs bounded, ANSI-safe, and cheap to update

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,3 +23,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
 - `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)
+- Colored console output in LEET wrapped too early and could garble lines; ANSI escapes are now handled correctly, and console scrollback is capped at 100,000 lines by default (`console_scrollback_lines` in `wandb leet config`) instead of growing without bound (@dmitryduev in https://github.com/wandb/wandb/pull/12528)

--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -59,6 +59,8 @@ const (
 
 	DefaultHeartbeatInterval = 15 // seconds
 
+	DefaultConsoleScrollbackLines = 100_000
+
 	ChartGuidesOff        = "off"
 	ChartGuidesDots       = "dots"
 	ChartGuidesHorizontal = "horizontal"
@@ -145,6 +147,9 @@ type Config struct {
 	// Heartbeats are used to trigger .wandb file read attempts if no file watcher
 	// events have been seen for a long time for a live file.
 	HeartbeatInterval int `json:"heartbeat_interval_seconds" leet:"label=Heartbeat interval (sec),desc=Polling heartbeat for live runs.,min=1"`
+
+	// Console log lines kept per run; the oldest are dropped past this.
+	ConsoleScrollbackLines int `json:"console_scrollback_lines" leet:"label=Console scrollback (lines),desc=Console log lines kept per run before the oldest are dropped.,min=1"`
 
 	// Single-run view sidebar visibility states.
 	LeftSidebarVisible  bool `json:"left_sidebar_visible"  leet:"desc=Show left sidebar in single run view by default."`
@@ -263,6 +268,7 @@ func NewConfigManager(path string, logger *observability.CoreLogger) *ConfigMana
 			SystemColorMode:               DefaultSystemColorMode,
 			SystemTailWindowMinutes:       DefaultSystemTailWindowMins,
 			HeartbeatInterval:             DefaultHeartbeatInterval,
+			ConsoleScrollbackLines:        DefaultConsoleScrollbackLines,
 			LeftSidebarVisible:            true,
 			RightSidebarVisible:           true,
 			MetricsGridVisible:            true,
@@ -366,6 +372,10 @@ func (cm *ConfigManager) normalizeConfig() {
 
 	if cm.config.HeartbeatInterval <= 0 {
 		cm.config.HeartbeatInterval = DefaultHeartbeatInterval
+	}
+
+	if cm.config.ConsoleScrollbackLines <= 0 {
+		cm.config.ConsoleScrollbackLines = DefaultConsoleScrollbackLines
 	}
 
 	if cm.config.SystemTailWindowMinutes <= 0 {
@@ -801,6 +811,14 @@ func (cm *ConfigManager) SetHeartbeatInterval(seconds int) error {
 		return fmt.Errorf("heartbeat interval must be a positive integer")
 	}
 	return cm.set(func(c *Config) { c.HeartbeatInterval = seconds })
+}
+
+// ConsoleScrollbackLines returns how many console log lines to keep per run.
+func (cm *ConfigManager) ConsoleScrollbackLines() int {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	return cm.config.ConsoleScrollbackLines
 }
 
 // LeftSidebarVisible returns whether the left sidebar should be visible.

--- a/core/internal/leet/consolelogs_internal_test.go
+++ b/core/internal/leet/consolelogs_internal_test.go
@@ -1,0 +1,38 @@
+package leet
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunConsoleLogs_CapsScrollback(t *testing.T) {
+	const maxLines = 100
+	cl := NewRunConsoleLogs(maxLines)
+	ts := time.Date(2026, time.February, 18, 10, 11, 12, 0, time.UTC)
+
+	total := maxLines + 5
+	var b strings.Builder
+	for i := range total - 1 {
+		fmt.Fprintf(&b, "line %d\n", i)
+	}
+	b.WriteString("tail")
+	cl.ProcessRaw(b.String(), false, ts)
+
+	items := cl.Items()
+	require.Len(t, items, maxLines, "scrollback should be capped")
+	require.Equal(t, "line 5", items[0].Value, "oldest lines evicted first")
+	require.Equal(t, "tail", items[len(items)-1].Value)
+	require.Equal(t, ts.Format(consoleTimestampFormat), items[0].Key,
+		"timestamp keys survive eviction")
+
+	// A carriage-return overwrite of the live line must update the
+	// correct entry even though eviction shifted slice indices.
+	cl.ProcessRaw("\rOVERWRITTEN", false, ts)
+	items = cl.Items()
+	require.Len(t, items, maxLines)
+	require.Equal(t, "OVERWRITTEN", items[len(items)-1].Value)
+}

--- a/core/internal/leet/consolelogspane.go
+++ b/core/internal/leet/consolelogspane.go
@@ -545,17 +545,38 @@ func wrappedLineCount(text string, maxWidth int) int {
 	if maxWidth <= 0 {
 		return 1
 	}
-	parts := strings.Split(text, "\n")
 	total := 0
-	for _, p := range parts {
-		w := runewidth.StringWidth(p)
-		if w == 0 {
-			total++
-			continue
-		}
-		total += (w + maxWidth - 1) / maxWidth
+	for part := range strings.SplitSeq(text, "\n") {
+		total += wrappedSegmentCount(part, maxWidth)
 	}
 	return max(total, 1)
+}
+
+// wrappedSegmentCount counts the chunks [wrapSingleLine] produces for a
+// single line, using the same greedy walk without building the strings.
+func wrappedSegmentCount(s string, maxWidth int) int {
+	lines := 0
+	w := 0
+	chunkRunes := 0
+
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if w+rw > maxWidth && chunkRunes > 0 {
+			lines++
+			w, chunkRunes = 0, 0
+		}
+		w += rw
+		chunkRunes++
+		if w >= maxWidth {
+			lines++
+			w, chunkRunes = 0, 0
+		}
+	}
+	if chunkRunes > 0 {
+		lines++
+	}
+
+	return max(lines, 1)
 }
 
 // WrapText soft-wraps text into multiple lines at maxWidth, preserving

--- a/core/internal/leet/consolelogspane_test.go
+++ b/core/internal/leet/consolelogspane_test.go
@@ -214,6 +214,23 @@ func TestConsoleLogsPane_Down_CyclesAndWraps(t *testing.T) {
 	require.Contains(t, out, "[3-5 of 5]", "reaching last entry should re-enable auto-scroll")
 }
 
+func TestConsoleLogsPane_AutoScrollShowsNewestWideRuneLine(t *testing.T) {
+	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
+	expandConsoleLogsPane(t, clp, 6) // header + padding + 4 content lines
+
+	// Width 7 leaves a 4-column value area. The CJK line greedy-wraps
+	// to 4 rows ("a漢a" "漢a" "漢a" "漢"): a naive width/4 estimate
+	// says 3 and makes autoscroll truncate the newest rows.
+	clp.SetConsoleLogs([]leet.KeyValuePair{
+		{Key: "10:11:12", Value: "log"},
+		{Key: "10:11:13", Value: "a漢a漢a漢a漢"},
+	})
+
+	out := stripANSI(clp.View(7, "", ""))
+	require.Contains(t, out, "[2-2 of 2]", "newest entry alone fills the viewport")
+	require.NotContains(t, out, "...", "newest entry must not be truncated")
+}
+
 func TestConsoleLogsPane_Down_EmptyLogs(t *testing.T) {
 	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
 	expandConsoleLogsPane(t, clp, 5)

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -165,7 +165,7 @@ func NewRun(
 		runOverview:          ro,
 		leftSidebar:          NewRunOverviewSidebar(cfg, runOverviewAnimState, ro, SidebarSideLeft),
 		rightSidebar:         NewRightSidebar(cfg, focus, logger),
-		consoleLogs:          NewRunConsoleLogs(),
+		consoleLogs:          NewRunConsoleLogs(cfg.ConsoleScrollbackLines()),
 		consoleLogsPane:      NewConsoleLogsPane(consoleLogsPaneAnimState),
 		mediaStore:           mediaStore,
 		mediaPane:            NewMediaPane(mediaPaneAnimState, cfg.MediaGrid),

--- a/core/internal/leet/runconsolelogs.go
+++ b/core/internal/leet/runconsolelogs.go
@@ -58,12 +58,22 @@ type RunConsoleLogs struct {
 	// It is updated incrementally so View does not need to reformat every line on
 	// every render.
 	items []KeyValuePair
+
+	// maxLines caps the retained scrollback; the oldest lines are evicted past it.
+	maxLines int
+
+	// evicted counts lines dropped from the front; appendLine indices are absolute.
+	evicted int
+
+	// One filter per stream: an escape sequence may be split across raw records.
+	stdoutFilter ansiFilter
+	stderrFilter ansiFilter
 }
 
 // NewRunConsoleLogs creates an empty console log store with terminal
-// emulators for stdout and stderr.
-func NewRunConsoleLogs() *RunConsoleLogs {
-	cl := &RunConsoleLogs{}
+// emulators for stdout and stderr, keeping at most maxLines lines.
+func NewRunConsoleLogs(maxLines int) *RunConsoleLogs {
+	cl := &RunConsoleLogs{maxLines: maxLines}
 
 	cl.stdoutTerm = terminalemulator.NewTerminal(
 		&consoleLineSupplier{owner: cl, isStderr: false},
@@ -87,9 +97,9 @@ func (cl *RunConsoleLogs) ProcessRaw(text string, isStderr bool, ts time.Time) {
 	cl.currentTimestamp = ts
 
 	if isStderr {
-		cl.stderrTerm.Write(text)
+		cl.stderrTerm.Write(cl.stderrFilter.strip(text))
 	} else {
-		cl.stdoutTerm.Write(text)
+		cl.stdoutTerm.Write(cl.stdoutFilter.strip(text))
 	}
 }
 
@@ -115,9 +125,8 @@ func (cl *RunConsoleLogs) Items() []KeyValuePair {
 }
 
 // appendLine is called by the line supplier when a new terminal line is
-// created. Returns the index for future PutChar callbacks.
+// created. Returns the absolute index for future PutChar callbacks.
 func (cl *RunConsoleLogs) appendLine(isStderr bool) int {
-	idx := len(cl.lines)
 	cl.lines = append(cl.lines, ConsoleLogLine{
 		Timestamp: cl.currentTimestamp,
 		IsStderr:  isStderr,
@@ -125,12 +134,22 @@ func (cl *RunConsoleLogs) appendLine(isStderr bool) int {
 	cl.items = append(cl.items, KeyValuePair{
 		Key: cl.currentTimestamp.Format(consoleTimestampFormat),
 	})
-	return idx
+
+	if len(cl.lines) > cl.maxLines {
+		n := len(cl.lines) - cl.maxLines
+		cl.lines = cl.lines[n:]
+		cl.items = cl.items[n:]
+		cl.evicted += n
+	}
+
+	return cl.evicted + len(cl.lines) - 1
 }
 
 // onLineChanged is called when the terminal emulator modifies a
-// character on an existing line via PutChar.
+// character on an existing line via PutChar. idx is the absolute
+// index returned by appendLine; evicted lines are silently dropped.
 func (cl *RunConsoleLogs) onLineChanged(idx int, content []rune) {
+	idx -= cl.evicted
 	if idx < 0 || idx >= len(cl.lines) {
 		return
 	}
@@ -170,5 +189,102 @@ type consoleLine struct {
 func (l *consoleLine) PutChar(c rune, offset int) {
 	if l.content.PutChar(c, offset) {
 		l.owner.onLineChanged(l.index, l.content.Content)
+	}
+}
+
+// ---- ANSI filtering ----
+
+// ansiFilterState tracks progress through an escape sequence across strip calls.
+type ansiFilterState int
+
+const (
+	ansiGround ansiFilterState = iota
+	ansiEsc                    // seen ESC
+	ansiCSI                    // seen ESC [
+	ansiOSC                    // seen ESC ]
+	ansiOSCEsc                 // seen ESC inside an OSC string
+)
+
+// ansiFilter drops escape sequences the terminal emulator does not interpret
+// (SGR colors, erase-line, OSC, ...); the cursor moves it does understand
+// (ESC[A, ESC[B) pass through. A newline inside a sequence aborts it.
+type ansiFilter struct {
+	state ansiFilterState
+
+	// csiParams is set once the current CSI sequence has parameter bytes.
+	csiParams bool
+}
+
+func (f *ansiFilter) strip(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		f.feed(r, &b)
+	}
+	return b.String()
+}
+
+// feed advances the filter by one rune, writing whatever should be kept.
+func (f *ansiFilter) feed(r rune, b *strings.Builder) {
+	switch f.state {
+	case ansiGround:
+		if r == '\x1b' {
+			f.state = ansiEsc
+		} else {
+			b.WriteRune(r)
+		}
+	case ansiEsc:
+		switch r {
+		case '[':
+			f.state = ansiCSI
+			f.csiParams = false
+		case ']':
+			f.state = ansiOSC
+		default:
+			f.state = ansiGround
+			if r == '\n' || r == '\r' {
+				b.WriteRune(r)
+			}
+		}
+	case ansiCSI:
+		f.feedCSI(r, b)
+	case ansiOSC:
+		f.feedOSC(r, b)
+	case ansiOSCEsc:
+		if r == '\\' {
+			f.state = ansiGround
+		} else {
+			f.state = ansiOSC
+		}
+	}
+}
+
+func (f *ansiFilter) feedCSI(r rune, b *strings.Builder) {
+	switch {
+	case r >= 0x40 && r <= 0x7e:
+		if !f.csiParams && (r == 'A' || r == 'B') {
+			b.WriteString("\x1b[")
+			b.WriteRune(r)
+		}
+		f.state = ansiGround
+	case r == '\x1b':
+		f.state = ansiEsc
+	case r == '\n' || r == '\r':
+		b.WriteRune(r)
+		f.state = ansiGround
+	default:
+		f.csiParams = true
+	}
+}
+
+func (f *ansiFilter) feedOSC(r rune, b *strings.Builder) {
+	switch r {
+	case '\a':
+		f.state = ansiGround
+	case '\x1b':
+		f.state = ansiOSCEsc
+	case '\n', '\r':
+		b.WriteRune(r)
+		f.state = ansiGround
 	}
 }

--- a/core/internal/leet/runconsolelogs_test.go
+++ b/core/internal/leet/runconsolelogs_test.go
@@ -20,7 +20,7 @@ func findKV(items []leet.KeyValuePair, valueSubstr string) (leet.KeyValuePair, i
 }
 
 func TestRunConsoleLogs_AssemblesAcrossCallsAndPreservesTimestamps(t *testing.T) {
-	cl := leet.NewRunConsoleLogs()
+	cl := leet.NewRunConsoleLogs(leet.DefaultConsoleScrollbackLines)
 
 	// Use fixed UTC times for deterministic HH:MM:SS keys.
 	ts1 := time.Date(2026, time.February, 18, 10, 11, 12, 0, time.UTC)
@@ -50,4 +50,46 @@ func TestRunConsoleLogs_AssemblesAcrossCallsAndPreservesTimestamps(t *testing.T)
 		"second line should use the second record timestamp")
 
 	require.Less(t, i1, i2, "expected log lines to preserve arrival order")
+}
+
+func TestRunConsoleLogs_StripsNonCursorANSI(t *testing.T) {
+	cl := leet.NewRunConsoleLogs(leet.DefaultConsoleScrollbackLines)
+	ts := time.Date(2026, time.February, 18, 10, 11, 12, 0, time.UTC)
+
+	// SGR colors and erase-line must not leak into assembled content.
+	cl.ProcessRaw("\x1b[31mred\x1b[0m plain\x1b[K\n", false, ts)
+	// OSC (BEL-terminated) must be dropped entirely.
+	cl.ProcessRaw("\x1b]0;window title\aafter osc\n", false, ts)
+
+	items := cl.Items()
+	require.Len(t, items, 2)
+	require.Equal(t, "red plain", items[0].Value)
+	require.Equal(t, "after osc", items[1].Value)
+}
+
+func TestRunConsoleLogs_StripsEscapeSplitAcrossRecords(t *testing.T) {
+	cl := leet.NewRunConsoleLogs(leet.DefaultConsoleScrollbackLines)
+	ts := time.Date(2026, time.February, 18, 10, 11, 12, 0, time.UTC)
+
+	// An SGR sequence split between two raw records must still be dropped.
+	cl.ProcessRaw("\x1b[3", false, ts)
+	cl.ProcessRaw("1mred\x1b[0m", false, ts)
+
+	items := cl.Items()
+	require.Len(t, items, 1)
+	require.Equal(t, "red", items[0].Value)
+}
+
+func TestRunConsoleLogs_KeepsCursorMovementSequences(t *testing.T) {
+	cl := leet.NewRunConsoleLogs(leet.DefaultConsoleScrollbackLines)
+	ts := time.Date(2026, time.February, 18, 10, 11, 12, 0, time.UTC)
+
+	// tqdm-style progress: cursor-up plus carriage return overwrites
+	// the previous line and must keep working through the ANSI filter.
+	cl.ProcessRaw("progress 10%\nnext\x1b[A\rprogress 90%", false, ts)
+
+	items := cl.Items()
+	require.Len(t, items, 2)
+	require.Equal(t, "progress 90%", items[0].Value)
+	require.Equal(t, "next", items[1].Value)
 }

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -596,7 +596,7 @@ func (w *Workspace) TestConsoleLogs() map[string]*RunConsoleLogs {
 func (w *Workspace) TestSeedConsoleLogs(runKey string, lines ...string) {
 	cl := w.consoleLogs[runKey]
 	if cl == nil {
-		cl = NewRunConsoleLogs()
+		cl = NewRunConsoleLogs(DefaultConsoleScrollbackLines)
 		w.consoleLogs[runKey] = cl
 	}
 	for _, line := range lines {

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -963,7 +963,7 @@ func (w *Workspace) getOrCreateConsoleLogs(runKey string) *RunConsoleLogs {
 	if cl != nil {
 		return cl
 	}
-	cl = NewRunConsoleLogs()
+	cl = NewRunConsoleLogs(w.config.ConsoleScrollbackLines())
 	w.consoleLogs[runKey] = cl
 	return cl
 }


### PR DESCRIPTION
Description
-----------
Three console-log fixes:

- Colored output (colorama, rich, tqdm) was stored with its ANSI escapes as literal line content. Width measurement counted the escapes as visible characters, so colored lines wrapped early, wrapping could split an escape in half and garble the row, and colors bled across lines. Non-cursor sequences (SGR, OSC, erase) are now stripped before the terminal emulator; cursor up/down still passes through so tqdm-style progress bars keep overwriting in place. The filter is per-stream and stateful, so sequences split across records are handled.
- Retained scrollback grew without bound (a run printing at ~50 Hz for a day retained on the order of 1 GB, per run in the workspace). Scrollback is now capped at 10,000 lines, evicting the oldest while keeping carriage-return overwrites working across the eviction shift.
- The wrapped-line count estimated ceil(width/maxWidth) while the renderer wraps greedily, so lines with wide runes (CJK, emoji) rendered more rows than counted and autoscroll hid the newest line. The count now walks the line exactly like the renderer. SetConsoleLogs also detects append-only updates and skips the full scroll recompute that used to run per record during boot load.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
New unit tests for each fix (all failed before the fix); full leet suite.
