### PR TITLE
fix(leet): make the config editor usable on short terminals

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -39,6 +39,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - `Artifact.new_file` now works for artifacts uploaded with `wandb sync` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12437)
 - At certain pane widths, such as while dragging a sidebar edge, LEET drew metric charts wider than the space available, pushing the right sidebar off screen (@dmitryduev in https://github.com/wandb/wandb/pull/12513)
+- `wandb leet config` now works on short terminal windows: the field list scrolls with the selection and Space toggles boolean settings (@dmitryduev in https://github.com/wandb/wandb/pull/12529)
 
 ### Security
 

--- a/core/internal/leet/configeditor.go
+++ b/core/internal/leet/configeditor.go
@@ -380,7 +380,7 @@ func (m *ConfigEditor) updateBrowse(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	switch msg.String() {
+	switch normalizeKey(msg.String()) {
 	case "up", "k":
 		if m.selected > 0 {
 			m.selected--
@@ -399,7 +399,7 @@ func (m *ConfigEditor) updateBrowse(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "enter":
 		return m.activateSelected()
-	case " ":
+	case "space":
 		// Space toggles bools; otherwise acts like enter.
 		f := &m.fields[m.selected]
 		if f.Kind == fieldBool {
@@ -584,9 +584,11 @@ func (m *ConfigEditor) updateIntEdit(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 // View implements [tea.Model].
 //
-// The layout is a vertical stack: header (title + config path), settings
-// table, footer (status/description/key hints), and an optional sub-editor
-// overlay for enum or int fields. The view uses alt-screen mode.
+// The layout is a vertical stack: header (title + config path), body, and
+// footer (status/description/key hints). In browse mode the body is the
+// settings table, scrolled so the selection stays visible; in enum/int edit
+// modes the sub-editor modal takes the table's place so it always fits on
+// screen. The view uses alt-screen mode.
 func (m *ConfigEditor) View() tea.View {
 	w := m.width
 	if w <= 0 {
@@ -604,28 +606,38 @@ func (m *ConfigEditor) View() tea.View {
 		navInfoStyle.Render(fmt.Sprintf("Path: %s", m.cfg.Path())),
 	)
 
-	table := m.renderTable(w)
 	footer := m.renderFooter(w)
 
-	view := lipgloss.JoinVertical(lipgloss.Left, top, "", table, "", footer)
-
+	var body string
 	switch m.mode {
 	case modeEnumSelect:
-		view = lipgloss.JoinVertical(lipgloss.Left, view, "", m.renderEnumPicker(w))
+		body = m.renderEnumPicker(w)
 	case modeIntEdit:
-		view = lipgloss.JoinVertical(lipgloss.Left, view, "", m.renderIntEditor(w))
+		body = m.renderIntEditor(w)
+	default:
+		maxRows := len(m.fields)
+		if m.height > 0 {
+			// Chrome around the field rows: outer padding (2), header
+			// block, two blank separators, table header row (1), footer.
+			chrome := 2 + lipgloss.Height(top) + 2 + 1 + lipgloss.Height(footer)
+			maxRows = max(m.height-chrome, 1)
+		}
+		body = m.renderTable(w, maxRows)
 	}
+
+	view := lipgloss.JoinVertical(lipgloss.Left, top, "", body, "", footer)
 
 	v := tea.NewView(lipgloss.NewStyle().Padding(1, 2).Render(view))
 	v.AltScreen = true
 	return v
 }
 
-// renderTable renders the two-column settings table (Setting | Value).
+// renderTable renders the two-column settings table (Setting | Value),
+// showing at most maxRows field rows scrolled so the selection is visible.
 //
 // The selected row is highlighted with [colorSelected]. Column widths
 // adapt to the longest label and available terminal width.
-func (m *ConfigEditor) renderTable(width int) string {
+func (m *ConfigEditor) renderTable(width, maxRows int) string {
 	// Column widths.
 	maxLabel := 0
 	for i := range m.fields {
@@ -651,7 +663,13 @@ func (m *ConfigEditor) renderTable(width int) string {
 		return strings.Join(lines, "\n")
 	}
 
-	for i := range m.fields {
+	visible := min(max(maxRows, 1), len(m.fields))
+	start := 0
+	if m.selected >= visible {
+		start = m.selected - visible + 1
+	}
+
+	for i := start; i < start+visible; i++ {
 		f := &m.fields[i]
 		val := fieldValue(f, &m.draft)
 		val = truncateRight(val, valW)

--- a/core/internal/leet/configeditor_test.go
+++ b/core/internal/leet/configeditor_test.go
@@ -173,6 +173,61 @@ func TestConfigEditor_DefaultDescriptionsForGridConfig(t *testing.T) {
 	require.Contains(t, view, "(metrics_grid.rows)")
 }
 
+func TestConfigEditor_SpaceTogglesBool(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	path := filepath.Join(t.TempDir(), "config.json")
+	cfg := leet.NewConfigManager(path, logger)
+
+	var m tea.Model = leet.NewConfigEditor(leet.ConfigEditorParams{Config: cfg, Logger: logger})
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	m = selectField(t, m, "left_sidebar_visible")
+
+	// Space toggles the bool (default true).
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+
+	// Save & quit.
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	require.NotNil(t, cmd)
+	_, ok := cmd().(tea.QuitMsg)
+	require.True(t, ok)
+
+	cfg2 := leet.NewConfigManager(path, logger)
+	require.False(t, cfg2.Snapshot().LeftSidebarVisible)
+}
+
+// firstLines returns the first n lines of the view with ANSI stripped.
+func firstLines(m tea.Model, n int) string {
+	lines := strings.Split(stripANSI(m.View().Content), "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestConfigEditor_Height24_SelectionAndEnumModalVisible(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	var m tea.Model = leet.NewConfigEditor(leet.ConfigEditorParams{Config: cfg, Logger: logger})
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	// Open the largest enum picker (14 color schemes); the whole modal
+	// must render within the 24 visible lines.
+	m = selectField(t, m, "color_scheme")
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	head := firstLines(m, 24)
+	require.Contains(t, head, "Select Color scheme")
+	require.Contains(t, head, "> "+leet.DefaultColorScheme)
+	require.Contains(t, head, "╰") // modal bottom border
+
+	// Back to browse; the selected row must stay within the 24 visible
+	// lines even for the last field.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m = selectField(t, m, "workspace_media_visible")
+	require.Contains(t, firstLines(m, 24), "Workspace media visible")
+}
+
 func TestConfigEditor_ColorSchemePicker_ShowsPalettePreview(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)


### PR DESCRIPTION
Description
-----------
Two fixes for `wandb leet config`:

- Space did nothing on bool fields: Bubble Tea v2 stringifies the space key as "space" and the editor matched " ". It now normalizes keys with the same helper the rest of the package uses.
- The editor rendered a fixed ~37-row field table with modals below it and never scrolled, so on a 24-row terminal the selection could move off screen and enum/int editors opened entirely off screen while capturing every key. The field list now scrolls to keep the selection visible and modals render in the body area.

<img width="1270" height="662" alt="image" src="https://github.com/user-attachments/assets/d8d0c17d-5a38-46fc-a37a-46f8c9943e2b" />

<img width="1454" height="966" alt="image" src="https://github.com/user-attachments/assets/a7710a20-36ec-4f3f-889b-1d33ccb5f0ef" />

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
