### PR TITLE
fix(leet): let large remote runs load and stop leaking on restart

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,3 +23,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
 - `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)
+- LEET can now open large runs from the W&B server; history downloads that took longer than 10 seconds used to fail every time (@dmitryduev in https://github.com/wandb/wandb/pull/12531)

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -599,6 +599,7 @@ func runLeetWorkspace(opts *leetOptions, logger *observability.CoreLogger) int {
 		program := tea.NewProgram(m)
 
 		finalModel, err := program.Run()
+		m.Cleanup()
 		if err != nil {
 			logger.CaptureError(
 				"main",

--- a/core/internal/leet/parquethistorysource.go
+++ b/core/internal/leet/parquethistorysource.go
@@ -146,10 +146,11 @@ func InitializeParquetHistorySource(
 			s,
 		)
 		httpClient := api.NewClient(api.ClientOptions{
-			RetryMax:        3,
-			RetryWaitMin:    1 * time.Second,
-			RetryWaitMax:    10 * time.Second,
-			NonRetryTimeout: 10 * time.Second,
+			RetryMax:     3,
+			RetryWaitMin: 1 * time.Second,
+			RetryWaitMax: 10 * time.Second,
+			// Also bounds reading the response body; exports can take minutes.
+			NonRetryTimeout: 10 * time.Minute,
 			Logger:          logger.Logger,
 			PreRetryLayers:  httplayers.LimitTo(baseURL, credentialProvider),
 		})

--- a/core/internal/runhistoryreader/parquet/downloader.go
+++ b/core/internal/runhistoryreader/parquet/downloader.go
@@ -69,13 +69,14 @@ func DownloadRunHistoryFile(
 	fileUrl string,
 	filePath string,
 ) (err error) {
-	file, err := os.Create(filePath)
+	file, err := os.CreateTemp(filepath.Dir(filePath), filepath.Base(filePath)+".tmp")
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = closeErr
+		if err != nil {
+			_ = file.Close()
+			_ = os.Remove(file.Name())
 		}
 	}()
 
@@ -94,8 +95,13 @@ func DownloadRunHistoryFile(
 	}
 	defer resp.Body.Close()
 
-	_, err = io.Copy(file, resp.Body)
-	return err
+	if _, err = io.Copy(file, resp.Body); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), filePath)
 }
 
 func extractStepValuesFromLiveData(liveData []any) ([]int64, error) {

--- a/core/internal/runhistoryreader/parquet/downloader_test.go
+++ b/core/internal/runhistoryreader/parquet/downloader_test.go
@@ -1,0 +1,38 @@
+package parquet_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/internal/api"
+	"github.com/wandb/wandb/core/internal/runhistoryreader/parquet"
+)
+
+func TestDownloadRunHistoryFile_TruncatedBodyLeavesNoFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Length", "100")
+			_, _ = w.Write([]byte("partial"))
+		}))
+	defer server.Close()
+	dir := t.TempDir()
+
+	err := parquet.DownloadRunHistoryFile(
+		context.Background(),
+		api.NewClient(api.ClientOptions{NonRetryTimeout: time.Minute}),
+		server.URL,
+		filepath.Join(dir, "test.runhistory.parquet"),
+	)
+
+	require.Error(t, err)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries, "no partial or temp file left behind")
+}

--- a/core/internal/runhistoryreader/reader.go
+++ b/core/internal/runhistoryreader/reader.go
@@ -88,6 +88,7 @@ func New(
 			historyReader.keys,
 		)
 		if err != nil {
+			historyReader.Release()
 			return nil, err
 		}
 		historyReader.parquetReaders = append(historyReader.parquetReaders, rustReader)


### PR DESCRIPTION
Description
-----------
- The parquet download client set NonRetryTimeout to 10 s, which api.NewClient installs as http.Client.Timeout. That deadline keeps running while the response body is read, so any history export that streamed longer than 10 s died mid-download and was never retried (the request had already returned headers). Large runs could not be opened remotely at all. Bulk downloads now use a 10-minute deadline; the GraphQL client is unchanged.
- Downloads now go to a temp file in the cache dir and rename on success. A failed download used to leave a truncated file at the final cache path, and the cache check is a bare os.Stat, so the poisoned entry persisted for callers that use the cache.
- The Alt+R restart loop now calls Model.Cleanup, matching the symon loop. Restarting leaked file watchers, heartbeat timers, open readers, and any in-flight remote download.
- runhistoryreader.New now releases already-created Rust readers when creating a later one fails.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
New downloader tests cover success, truncated body, and a body that outlives a short client timeout (reproducing the original failure); existing suites pass.
