### PR TITLE
fix(leet): quit reliably from filter inputs and the help screen

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,3 +23,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
 - `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)
+- Ctrl+C now quits LEET even while typing in a filter, and quitting from the help screen releases file watchers and readers cleanly (@dmitryduev in https://github.com/wandb/wandb/pull/12532)

--- a/core/internal/leet/help.go
+++ b/core/internal/leet/help.go
@@ -207,9 +207,6 @@ func (h *HelpModel) Update(msg tea.Msg) (*HelpModel, tea.Cmd) {
 		case "h", "?", "esc":
 			h.Toggle()
 			return h, nil
-		case "q", "ctrl+c":
-			// Allow quitting from help screen
-			return h, tea.Quit
 		default:
 			// Let viewport handle other keys
 			h.viewport, cmd = h.viewport.Update(msg)

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -383,6 +383,13 @@ func (m *Model) handleHelp(msg tea.Msg) (bool, tea.Cmd) {
 
 	// When help is visible, it owns key/mouse events.
 	if m.help.IsActive() {
+		if km, ok := msg.(tea.KeyPressMsg); ok {
+			switch km.String() {
+			case "q", "ctrl+c":
+				m.Cleanup()
+				return true, tea.Quit
+			}
+		}
 		switch msg.(type) {
 		case tea.KeyPressMsg, tea.MouseMsg:
 			updated, cmd := m.help.Update(msg)

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -336,6 +336,11 @@ func (r *Run) handleMainContentMouse(msg tea.MouseMsg, layout Layout) tea.Cmd {
 
 // handleKeyPressMsg processes keyboard events using the centralized key bindings.
 func (r *Run) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
+	// Quit must work even while a filter input owns the keyboard.
+	if msg.String() == "ctrl+c" {
+		return r.handleQuit(msg)
+	}
+
 	// Filter modes take priority.
 	if r.leftSidebar.IsFilterMode() {
 		r.leftSidebar.HandleFilterKey(msg)

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -60,6 +60,11 @@ func (w *Workspace) handleMediaMouse(msg tea.MouseMsg, layout Layout) tea.Cmd {
 }
 
 func (w *Workspace) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
+	// Quit must work even while a filter input owns the keyboard.
+	if msg.String() == "ctrl+c" {
+		return w.handleQuit(msg)
+	}
+
 	// Filter mode takes priority.
 	if w.filter.IsActive() {
 		w.handleRunFilterKey(msg)


### PR DESCRIPTION
Description
-----------
- Ctrl+C did nothing while a filter input owned the keyboard, in both the run and workspace views: filter handling consumed every key before the quit binding was consulted, and the filter ignores keys that carry no text. Ctrl+C is now handled before filter dispatch.
- Quitting from the help overlay returned bare tea.Quit and skipped the cleanup the views' own quit handlers run (stop heartbeats and watchers, close readers). It now goes through Model.Cleanup.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
New test asserts Ctrl+C returns a command in filter mode for both views; full leet suite.
