### PR TITLE
fix(leet): keep workspace filter and focus state consistent

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,3 +23,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
 - `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)
+- The system-metrics filter in the LEET workspace applied only to the highlighted run, showing stale results after switching runs (@dmitryduev in https://github.com/wandb/wandb/pull/12533)

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -81,6 +81,9 @@ type Workspace struct {
 	systemMetricsFocus  *Focus
 	systemMetricsFilter *Filter
 
+	// currentSystemGrid is the per-run grid the shared filter was last applied to.
+	currentSystemGrid *SystemMetricsGrid
+
 	// Run console logs keyed by run path.
 	consoleLogs     map[string]*RunConsoleLogs
 	consoleLogsPane *ConsoleLogsPane
@@ -474,6 +477,11 @@ func (w *Workspace) syncCurrentRunContext() (
 		currentRunKey = cur.Key
 		runLabel = cur.Key
 		systemGrid = w.systemMetrics[cur.Key]
+	}
+
+	if systemGrid != w.currentSystemGrid {
+		w.currentSystemGrid = systemGrid
+		systemGrid.ApplyFilter()
 	}
 
 	currentStore := w.media[currentRunKey]

--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -392,7 +392,8 @@ func (w *Workspace) applyRunKeys(runKeys []string) {
 }
 
 func (w *Workspace) setRunItems(runKeys []string) {
-	items := w.runs.Items[:0]
+	// FilteredItems aliases Items when no filter is applied.
+	items := make([]KeyValuePair, 0, len(runKeys))
 	for _, key := range runKeys {
 		items = append(items, KeyValuePair{Key: key})
 	}

--- a/core/internal/leet/workspacefilterfocus_test.go
+++ b/core/internal/leet/workspacefilterfocus_test.go
@@ -1,0 +1,53 @@
+package leet
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+// The shared system-metrics filter must be reapplied to a run's grid when the
+// highlighted run changes; each grid caches its own filtered chart set.
+func TestWorkspaceSystemFilterReappliedOnRunSwitch(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := NewConfigManager(filepath.Join(t.TempDir(), "cfg.json"), logger)
+	w := NewWorkspace(t.TempDir(), cfg, logger)
+	w.handleWindowResize(200, 60)
+
+	stats := StatsMsg{Timestamp: 1, Metrics: map[string]float64{
+		"cpu":                   12.0,
+		"gpu.0.memoryAllocated": 40.0,
+	}}
+	gridA := w.getOrCreateSystemMetricsGrid("run-a")
+	gridA.ProcessStats(stats)
+	gridB := w.getOrCreateSystemMetricsGrid("run-b")
+	gridB.ProcessStats(stats)
+
+	// Apply a filter while run A's grid is active.
+	w.systemMetricsFilter.Activate()
+	w.systemMetricsFilter.UpdateDraft(tea.KeyPressMsg{Code: 'g', Text: "gpu"})
+	w.systemMetricsFilter.Commit()
+	gridA.ApplyFilter()
+
+	if gridA.FilteredChartCount() == gridA.ChartCount() {
+		t.Fatalf("filter had no effect on grid A")
+	}
+	if gridB.FilteredChartCount() != gridB.ChartCount() {
+		t.Fatalf("grid B unexpectedly pre-filtered")
+	}
+
+	// Highlight run B; the sync path must reapply the shared filter to B's
+	// grid, which caches its own filtered chart set.
+	w.currentSystemGrid = gridA
+	w.runs.Items = []KeyValuePair{{Key: "run-b"}}
+	w.runs.FilteredItems = w.runs.Items
+	w.syncCurrentRunContext()
+
+	if gridB.FilteredChartCount() != gridA.FilteredChartCount() {
+		t.Fatalf("grid B filtered=%d, want %d after switch",
+			gridB.FilteredChartCount(), gridA.FilteredChartCount())
+	}
+}

--- a/core/internal/leet/workspacerunfilter.go
+++ b/core/internal/leet/workspacerunfilter.go
@@ -27,9 +27,7 @@ func (w *Workspace) handleEnterRunsFilter(msg tea.KeyPressMsg) tea.Cmd {
 		cmd = w.handleToggleRunsSidebar(msg)
 	}
 
-	w.runs.Active = true
-	w.consoleLogsPane.SetActive(false)
-	w.runOverviewSidebar.deactivateAllSections()
+	w.focusMgr.SetTarget(FocusTargetRunsList, 1)
 	w.filter.Activate()
 	w.applyRunFilter()
 


### PR DESCRIPTION
Description
-----------
- All per-run system-metrics grids share one filter, but each grid caches its own filtered chart set, and the filter was only applied to the grid under the cursor. Moving the cursor to another run rendered that run unfiltered while the status bar claimed a filter, and clearing the filter on one run left the others silently filtered until re-entering filter mode there. The shared filter is now reapplied whenever the highlighted run changes.
- Entering the runs filter with f set pane-active flags by hand and bypassed the FocusManager, so after committing a query the visually focused runs list ignored Space and Enter while another pane still held logical focus. Focus now routes through the FocusManager.
- setRunItems rewrote runs.Items in place, but FilteredItems aliases the same backing array when no filter is applied, which corrupted the cursor-preservation read during directory rescans. It builds a fresh slice.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
New test drives the run-switch sync path and asserts the new grid's filtered set matches; full leet suite.
