### PR TITLE
fix(leet): anchor heatmap wheel zoom on the hovered timestamp

### DIFF
--- a/core/internal/leet/frenchfriestogglechart.go
+++ b/core/internal/leet/frenchfriestogglechart.go
@@ -1,5 +1,7 @@
 package leet
 
+import "math"
+
 // frenchFriesToggleChart keeps the existing time-series line chart as the
 // source of truth for time-window behavior while optionally rendering the same
 // metric as a heatmap-style French Fries chart.
@@ -87,6 +89,14 @@ func (c *frenchFriesToggleChart) GraphStartY() int {
 }
 
 func (c *frenchFriesToggleChart) HandleZoom(direction string, mouseX int) {
+	if c.heatmapMode {
+		// mouseX is in heatmap plot coordinates; the zoom runs on the line chart.
+		ffW := c.frenchFries.GraphWidth()
+		lineW := c.line.GraphWidth()
+		if ffW > 0 && lineW > 0 {
+			mouseX = int(math.Round(float64(mouseX) / float64(ffW) * float64(lineW)))
+		}
+	}
 	c.line.HandleZoom(direction, mouseX)
 	c.syncViewWindow()
 	c.activeChart().DrawIfNeeded()


### PR DESCRIPTION
Description
-----------
Wheel zoom on a system chart in heatmap mode measured the mouse position in the heatmap's plot geometry but executed the zoom on the underlying line chart, whose plot area has a different origin and width, so the zoom anchored on the wrong timestamp. The toggle wrapper now maps the position between the two geometries by fraction before zooming.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Covered by existing zoom tests; verified manually against a symon session.
