### PR TITLE
chore(leet): redraw only charts whose content changed

### DIFF
--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -1076,6 +1076,7 @@ func TruncateTitle(title string, maxWidth int) string {
 func (c *EpochLineChart) SetGraphStyle(s *lipgloss.Style) {
 	if top := c.topSeries(); top != nil {
 		top.style.Store(*s)
+		c.dirty = true
 	}
 }
 

--- a/core/internal/leet/metricsgrid.go
+++ b/core/internal/leet/metricsgrid.go
@@ -576,7 +576,7 @@ func (mg *MetricsGrid) drawVisible() {
 	// ProcessHistory's AddData calls on the same chart internals.
 	for ch := range currentCharts {
 		ch.Resize(dims.CellW, dims.CellH)
-		ch.Draw()
+		ch.DrawIfNeeded()
 	}
 }
 

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -917,6 +917,7 @@ func (r *Run) handleRecordsBatch(subMsgs []tea.Msg, suppressRedraw bool) []tea.C
 	if !r.suppressDraw {
 		r.metricsGrid.drawVisible()
 	}
+	r.rightSidebar.metricsGrid.drawVisible()
 
 	return cmds
 }

--- a/core/internal/leet/symon.go
+++ b/core/internal/leet/symon.go
@@ -141,8 +141,8 @@ func (s *Symon) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return s, cmd
 
 	case StatsMsg:
-		// ProcessStats handles pagination and redraw when the chart set changes.
 		s.grid.ProcessStats(msg)
+		s.grid.drawVisible()
 		cmd := s.sampleLaterCmd()
 		return s, cmd
 

--- a/core/internal/leet/systemmetricsgrid.go
+++ b/core/internal/leet/systemmetricsgrid.go
@@ -559,23 +559,14 @@ func (g *SystemMetricsGrid) cycleFocusedChartMode() bool {
 // Resize updates viewport dimensions and resizes/redraws visible charts.
 func (g *SystemMetricsGrid) Resize(width, height int) {
 	if width <= 0 || height <= 0 {
-		g.logger.Debug(fmt.Sprintf(
-			"systemmetricsgrid: Resize: invalid dimensions %dx%d, skipping", width, height))
+		return
+	}
+	if g.width == width && g.height == height {
 		return
 	}
 
 	g.width = width
 	g.height = height
-
-	dims := g.calculateChartDimensions()
-	if dims.CellW <= 0 || dims.CellH <= 0 ||
-		dims.CellW < MinMetricChartWidth ||
-		dims.CellH < MinMetricChartHeight {
-		g.logger.Debug(fmt.Sprintf(
-			"systemmetricsgrid: Resize: calculated dimensions %dx%d invalid, skipping",
-			dims.CellW, dims.CellH))
-		return
-	}
 
 	size := g.effectiveGridSize()
 	g.nav.UpdateTotalPages(len(g.filtered), ItemsPerPage(size))

--- a/core/internal/leet/timeserieslinechart.go
+++ b/core/internal/leet/timeserieslinechart.go
@@ -119,13 +119,11 @@ func (c *TimeSeriesLineChart) AddDataPoint(seriesName string, timestamp int64, v
 	c.applyRanges()
 }
 
-// Park minimizes canvas memory for off-screen charts.
-func (c *TimeSeriesLineChart) Park() {
-	c.EpochLineChart.Park()
-}
-
 // Resize updates the underlying chart size and reapplies the current view policy.
 func (c *TimeSeriesLineChart) Resize(width, height int) {
+	if c.Width() == width && c.Height() == height {
+		return
+	}
 	c.EpochLineChart.Resize(width, height)
 	c.applyRanges()
 }

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -685,6 +685,9 @@ func (w *Workspace) handleWorkspaceChunkedBatch(msg WorkspaceChunkedBatchMsg) te
 		w.handleWorkspaceRecord(run, sub)
 	}
 	w.metricsGrid.drawVisible()
+	if g := w.systemMetrics[msg.RunKey]; g != nil {
+		g.drawVisible()
+	}
 
 	if msg.Batch.HasMore {
 		return w.readAllChunkCmd(run)
@@ -705,6 +708,9 @@ func (w *Workspace) handleWorkspaceBatchedRecords(msg WorkspaceBatchedRecordsMsg
 		w.handleWorkspaceRecord(run, sub)
 	}
 	w.metricsGrid.drawVisible()
+	if g := w.systemMetrics[msg.RunKey]; g != nil {
+		g.drawVisible()
+	}
 
 	// Continue draining while the run is still live.
 	if run.state == RunStateRunning {


### PR DESCRIPTION
Description
-----------
drawVisible called Draw unconditionally, so every data batch re-rasterized every visible chart even when one chart got data. The system-metrics views were worse: TimeSeriesLineChart.Resize marked charts dirty on the same-size resizes the views issue every frame, so all visible system charts fully redrew per frame, defeating the dirty-flag design.

Charts already set their dirty flag on data, zoom, style, guide, and size changes; drawVisible now honors it. Same-size resizes are no-ops, and repaints run once per data batch in the hosting views (run, workspace, symon) instead of piggybacking on per-frame resizes. In the workspace, series styles are applied once when a series is created instead of re-marked dirty on every batch.

Measured on top of #12535 and #12536, frame render on the harness run drops from 7.1 ms to 6.8 ms with allocations from 11.6k to 9.4k, and data batches no longer re-rasterize charts that received nothing.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
New test asserts a same-size resize leaves a chart clean; full leet suite; benchmarks.
