### PR TITLE
fix(leet): release media pane resources when a view closes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,3 +23,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
 - `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)
+- LEET no longer leaks memory when moving between runs with logged images, and scrubbing through images does not re-read them from disk on every step (@dmitryduev in https://github.com/wandb/wandb/pull/12540)

--- a/core/internal/leet/mediapane.go
+++ b/core/internal/leet/mediapane.go
@@ -139,6 +139,8 @@ type MediaPane struct {
 	renderKeys []mediaRenderKey
 	// prepareCh wakes the Bubble Tea command that prepares visible Kitty images.
 	prepareCh chan struct{}
+	// closed reports that prepareCh has been closed.
+	closed bool
 }
 
 func NewMediaPane(animState *AnimatedValue, gridConfig func() (rows, cols int)) *MediaPane {
@@ -206,19 +208,31 @@ func (p *MediaPane) handlePictureMsg(msg tea.Msg) tea.Cmd {
 
 func (p *MediaPane) waitForPrepare() tea.Cmd {
 	return func() tea.Msg {
-		<-p.prepareCh
+		if _, ok := <-p.prepareCh; !ok {
+			return nil
+		}
 		return mediaPanePrepareMsg{pane: p}
 	}
 }
 
 func (p *MediaPane) requestRenderedMediaPrepare() {
-	if p.renderer.Mode() != picture.PictureKitty {
+	if p.closed || p.renderer.Mode() != picture.PictureKitty {
 		return
 	}
 	select {
 	case p.prepareCh <- struct{}{}:
 	default:
 	}
+}
+
+// Close unblocks the prepare command started by Init and drops cached images.
+func (p *MediaPane) Close() {
+	if p.closed {
+		return
+	}
+	p.closed = true
+	close(p.prepareCh)
+	p.renderer.releaseAll()
 }
 
 func (p *MediaPane) handlePrepareMsg() tea.Cmd {
@@ -1173,6 +1187,10 @@ type mediaImageRenderer struct {
 	pictures   map[mediaRenderKey]*mediaPicture
 }
 
+// mediaDecodedCacheSize is how many decoded images Park keeps before evicting
+// the off-screen ones; scrubbing back and forth then rarely re-decodes.
+const mediaDecodedCacheSize = 16
+
 func newMediaImageRenderer() *mediaImageRenderer {
 	return &mediaImageRenderer{
 		decoded:  make(map[string]image.Image),
@@ -1328,9 +1346,11 @@ func (r *mediaImageRenderer) Park(keys []mediaRenderKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for path := range r.decoded {
-		if _, ok := visiblePaths[path]; !ok {
-			delete(r.decoded, path)
+	if len(r.decoded) > mediaDecodedCacheSize {
+		for path := range r.decoded {
+			if _, ok := visiblePaths[path]; !ok {
+				delete(r.decoded, path)
+			}
 		}
 	}
 	for path := range r.errors {
@@ -1403,6 +1423,15 @@ func (r *mediaImageRenderer) image(path string) (image.Image, mediaRenderError) 
 	r.decoded[path] = loaded
 	delete(r.errors, path)
 	return loaded, mediaRenderError{}
+}
+
+// releaseAll drops every cached decode and render.
+func (r *mediaImageRenderer) releaseAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	clear(r.decoded)
+	clear(r.errors)
+	clear(r.rendered)
 }
 
 func (r *mediaImageRenderer) renderGlyph(path string, width, height int) string {

--- a/core/internal/leet/mediapaneclose_test.go
+++ b/core/internal/leet/mediapaneclose_test.go
@@ -1,0 +1,28 @@
+package leet
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Close must unblock the prepare command and be idempotent.
+func TestMediaPaneCloseUnblocksPrepare(t *testing.T) {
+	p := NewMediaPane(NewAnimatedValue(true, mediaPaneMinHeight), func() (int, int) { return 1, 1 })
+
+	done := make(chan tea.Msg, 1)
+	go func() { done <- p.waitForPrepare()() }()
+
+	p.Close()
+	p.Close() // idempotent
+
+	select {
+	case msg := <-done:
+		if msg != nil {
+			t.Fatalf("expected nil msg from closed prepare wait, got %T", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForPrepare still blocked after Close")
+	}
+}

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -393,6 +393,9 @@ func (r *Run) cleanup() {
 	if r.historySource != nil {
 		r.historySource.Close()
 	}
+	if r.mediaPane != nil {
+		r.mediaPane.Close()
+	}
 }
 
 func (r *Run) handleQuit(msg tea.KeyPressMsg) tea.Cmd {

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -393,6 +393,9 @@ func (w *Workspace) Cleanup() {
 			run.Reader.Close()
 		}
 	}
+	if w.mediaPane != nil {
+		w.mediaPane.Close()
+	}
 }
 
 // IsFiltering reports whether any workspace-level filter UI is active.


### PR DESCRIPTION
Description
-----------
Every MediaPane.Init started a goroutine blocked on an internal prepare channel that nothing closed, and the renderer's decoded-image cache stayed reachable behind it. Browsing runs leaked one goroutine plus on the order of 24 MB of decoded images per run-view visit. Panes now close the channel and drop their caches when the owning view cleans up.

Separately, Park evicted every off-screen decode on each render, so scrubbing through a series re-decoded the previous image from disk on every step and stalled the UI on large files. Park now keeps a small LRU of off-screen decodes.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
New test asserts Close unblocks the prepare command and is idempotent; full leet suite.
