### PR TITLE
fix(sdk): revert #12543 - fix ansi output to non-TTY

### DIFF
--- a/wandb/errors/term.py
+++ b/wandb/errors/term.py
@@ -323,10 +323,6 @@ def terminput(
         KeyboardInterrupt: If the user pressed Ctrl+C during the prompt.
     """
     prefixed_prompt = f"{LOG_STRING}: {prompt}"
-    if not _sys_stderr_isatty() or _is_term_dumb():
-        # no applying ANSI style if not a terminal; `click` handles this for us
-        # in some cases, but not for `prompt()`
-        prefixed_prompt = click.unstyle(prefixed_prompt)
     return _terminput(prefixed_prompt, timeout=timeout, hide=hide)
 
 


### PR DESCRIPTION
This reverts commit b6e29505884ea60c79ca12091f1f75bd39d2f955.
