### PR TITLE
feat(sweeps): add ask-tell Optimizer package with wandb reference optimizer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,3 +90,5 @@
 /wandb/sdk/wandb_sweep.py                        @wandb/sweeps-launch-team @wandb/sdk-team
 /tools/graphql_codegen/api/sweeps.graphql        @wandb/sweeps-launch-team @wandb/sdk-team
 /tests/unit_tests/test_public_api/test_sweeps.py @wandb/sweeps-launch-team @wandb/sdk-team
+/wandb/sdk/sweeps/                               @wandb/sweeps-launch-team @wandb/sdk-team
+/tests/unit_tests/test_sweep_scheduler.py        @wandb/sweeps-launch-team @wandb/sdk-team

--- a/requirements/requirements_dev.3.10.darwin.txt
+++ b/requirements/requirements_dev.3.10.darwin.txt
@@ -407,12 +407,15 @@ json5==0.15.0
     # via jupyterlab-server
 jsonpointer==3.1.1
     # via jsonschema
+jsonref==1.1.0
+    # via sweeps
 jsonschema==4.26.0
     # via
     #   jupyter-events
     #   jupyterlab-server
     #   litellm
     #   nbformat
+    #   sweeps
     #   wandb
 jsonschema-specifications==2025.9.1
     # via jsonschema
@@ -596,6 +599,7 @@ numpy==1.26.4
     #   shapely
     #   soundfile
     #   stable-baselines3
+    #   sweeps
     #   tensorboard
     #   tensorboardx
     #   torchmetrics
@@ -752,6 +756,7 @@ pydantic==2.13.4
     #   google-genai
     #   litellm
     #   openai
+    #   sweeps
     #   wandb
 pydantic-core==2.46.4
     # via pydantic
@@ -834,6 +839,7 @@ pyyaml==6.0.3
     #   optuna
     #   pytorch-lightning
     #   responses
+    #   sweeps
     #   wandb
 pyzmq==27.2.0
     # via
@@ -902,7 +908,9 @@ rsa==4.7.2
 s3transfer==0.19.2
     # via boto3
 scikit-learn==1.7.2
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   sweeps
 scipy==1.15.3
     # via
     #   catboost
@@ -910,6 +918,7 @@ scipy==1.15.3
     #   jaxlib
     #   lightgbm
     #   scikit-learn
+    #   sweeps
     #   xgboost
 send2trash==2.1.0
     # via jupyter-server
@@ -951,6 +960,8 @@ stack-data==0.6.3
     # via ipython
 starlette==0.46.2
     # via fastapi
+sweeps==0.2.0
+    # via wandb
 sympy==1.14.0
     # via torch
 tabulate==0.10.0
@@ -1111,7 +1122,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.10.linux.txt
+++ b/requirements/requirements_dev.3.10.linux.txt
@@ -1219,7 +1219,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.10.windows.txt
+++ b/requirements/requirements_dev.3.10.windows.txt
@@ -1179,7 +1179,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.13.darwin.txt
+++ b/requirements/requirements_dev.3.13.darwin.txt
@@ -400,12 +400,15 @@ json5==0.15.0
     # via jupyterlab-server
 jsonpointer==3.1.1
     # via jsonschema
+jsonref==1.1.0
+    # via sweeps
 jsonschema==4.26.0
     # via
     #   jupyter-events
     #   jupyterlab-server
     #   litellm
     #   nbformat
+    #   sweeps
     #   wandb
 jsonschema-specifications==2025.9.1
     # via jsonschema
@@ -590,6 +593,7 @@ numpy==2.3.5
     #   shapely
     #   soundfile
     #   stable-baselines3
+    #   sweeps
     #   tensorboard
     #   tensorboardx
     #   torchmetrics
@@ -746,6 +750,7 @@ pydantic==2.13.4
     #   google-genai
     #   litellm
     #   openai
+    #   sweeps
     #   wandb
 pydantic-core==2.46.4
     # via pydantic
@@ -829,6 +834,7 @@ pyyaml==6.0.3
     #   optuna
     #   pytorch-lightning
     #   responses
+    #   sweeps
     #   wandb
 pyzmq==27.2.0
     # via
@@ -897,7 +903,9 @@ rsa==4.7.2
 s3transfer==0.19.2
     # via boto3
 scikit-learn==1.9.0
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   sweeps
 scipy==1.18.1
     # via
     #   catboost
@@ -905,6 +913,7 @@ scipy==1.18.1
     #   jaxlib
     #   lightgbm
     #   scikit-learn
+    #   sweeps
     #   xgboost
 send2trash==2.1.0
     # via jupyter-server
@@ -946,6 +955,8 @@ stack-data==0.6.3
     # via ipython
 starlette==0.46.2
     # via fastapi
+sweeps==0.2.0
+    # via wandb
 sympy==1.14.0
     # via torch
 tabulate==0.10.0
@@ -1084,7 +1095,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.13.linux.txt
+++ b/requirements/requirements_dev.3.13.linux.txt
@@ -1192,7 +1192,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.3.13.windows.txt
+++ b/requirements/requirements_dev.3.13.windows.txt
@@ -1152,7 +1152,9 @@ urllib3==2.7.0
 uvicorn==0.32.1
     # via -r requirements/requirements_test.txt
 .
-    # via -r requirements/requirements_dev.txt
+    # via
+    #   -r requirements/requirements_dev.txt
+    #   -r requirements/requirements_test.txt
 wcwidth==0.8.2
     # via
     #   prompt-toolkit

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -56,5 +56,4 @@ responses
 ariadne-codegen
 
 .[launch]
-.[sweeps] ; sys_platform != 'darwin' or (sys_platform == 'darwin' and platform.machine != 'arm64')
 .[sandbox]

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -34,3 +34,5 @@ pyte~=0.8.1  # Terminal emulator for testing interactions with the terminal.
 hypothesis>=6.131.7
 
 hypothesis-fspaths
+
+.[sweeps]

--- a/tests/system_tests/test_sweep/test_launch_scheduler.py
+++ b/tests/system_tests/test_sweep/test_launch_scheduler.py
@@ -7,7 +7,7 @@ import pytest
 import wandb
 from wandb.apis import internal, public
 from wandb.errors import CommError
-from wandb.sdk.launch.sweeps import SchedulerError, SweepNotFoundError, load_scheduler
+from wandb.sdk.launch.sweeps import SchedulerError, load_scheduler
 from wandb.sdk.launch.sweeps.scheduler import (
     RunState,
     Scheduler,
@@ -16,6 +16,7 @@ from wandb.sdk.launch.sweeps.scheduler import (
 )
 from wandb.sdk.launch.sweeps.scheduler_sweep import SweepScheduler
 from wandb.sdk.launch.sweeps.utils import construct_scheduler_args
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .test_wandb_sweep import SWEEP_CONFIG_RANDOM
 

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -27,9 +27,9 @@ from wandb.sdk.internal.internal_api import (
     _match_org_with_fetched_org_entities,
     _OrgNames,
 )
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib import retry, wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .test_retry import MockTime, mock_time  # noqa: F401
 

--- a/tests/unit_tests/test_sweep_scheduler.py
+++ b/tests/unit_tests/test_sweep_scheduler.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+import pytest
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
+    Optimizer,
+    RunConfig,
+    RunSuggestion,
+    RunWithMetrics,
+)
+from wandb.sdk.sweeps.sweep_info import SweepInfo
+
+SCHEDULER_GRID_SWEEP_CONFIG: dict[str, Any] = {
+    "name": "test-sweep-grid-hyperband",
+    "method": "grid",
+    "early_terminate": {"type": "hyperband", "max_iter": 5, "eta": 2, "s": 2},
+    "metric": {"name": "loss", "goal": "minimize"},
+    "parameters": {"param1": {"values": [1, 2, 3]}},
+}
+
+
+def make_scheduler_grid_sweep() -> SweepInfo:
+    """Return the `SweepInfo` of a grid sweep with hyperband early termination."""
+    return SweepInfo(
+        id="test_sweep",
+        name="test_sweep",
+        entity="test_entity",
+        project="test_project",
+        config=SCHEDULER_GRID_SWEEP_CONFIG,
+    )
+
+
+def make_run(
+    suggestion: RunSuggestion,
+    *,
+    state: RunState,
+    summary: dict[str, Any],
+    history: list[dict[str, Any]] | None = None,
+) -> RunWithMetrics:
+    return RunWithMetrics(
+        config=suggestion.config,
+        state=state,
+        wandb_run_id="wandb-run-id",
+        summary_metrics=summary,
+        history_metrics=history or [],
+    )
+
+
+class OptimizerAcceptanceTests(abc.ABC):
+    """Contract tests every Optimizer implementation must satisfy."""
+
+    @pytest.fixture
+    def sweep(self) -> SweepInfo:
+        return make_scheduler_grid_sweep()
+
+    @abc.abstractmethod
+    @pytest.fixture
+    def optimizer(self, sweep: SweepInfo) -> Optimizer:
+        """Return a fresh, configured Optimizer instance."""
+        ...
+
+    def test_next_2_runs_after_tell_1_run(
+        self, optimizer: Optimizer, sweep: SweepInfo
+    ) -> None:
+        first_run = next(iter(optimizer.ask_n_runs(1)))
+        run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
+        optimizer.tell_run(first_run.run_id, run)
+        suggestions = optimizer.ask_n_runs(2)
+        assert len(suggestions) == 2
+        assert all(isinstance(s, RunSuggestion) for s in suggestions)
+        assert len({s.run_id for s in suggestions}) == 2  # unique ids
+        assert suggestions[0].config["param1"].value == 2
+        assert suggestions[1].config["param1"].value == 3
+
+    def test_next_run_after_tell_existing_finished_run(
+        self, optimizer: Optimizer, sweep: SweepInfo
+    ) -> None:
+        first_run = RunSuggestion(
+            config=RunConfig.from_values({"param1": 1}), run_id="run_id"
+        )
+        run = make_run(first_run, state=RunState.FINISHED, summary={"loss": 1.0})
+        optimizer.tell_existing_finished_run(run)
+        suggestion = next(iter(optimizer.ask_n_runs(1)))
+        assert suggestion.config["param1"].value == 2
+
+    def test_next_run_after_tell_existing_active_run(
+        self, optimizer: Optimizer, sweep: SweepInfo
+    ) -> None:
+        first_run = RunSuggestion(
+            config=RunConfig.from_values({"param1": 1}), run_id="run_id"
+        )
+        run = make_run(first_run, state=RunState.RUNNING, summary={"loss": 1.0})
+        optimizer.tell_existing_active_run(run)
+        suggestion = next(iter(optimizer.ask_n_runs(1)))
+        assert suggestion.config["param1"].value == 2
+
+    def test_ids_unique_across_ask_and_adopt(self, optimizer: Optimizer) -> None:
+        """Adoptions and suggestions must never share an id.
+
+        The scheduler routes tells and prunes by id alone, so a collision
+        would silently cross-wire two runs.
+        """
+        adopted = RunSuggestion(
+            config=RunConfig.from_values({"param1": 1}), run_id="run_id"
+        )
+        run = make_run(adopted, state=RunState.RUNNING, summary={})
+        adopted_id = optimizer.tell_existing_active_run(run)
+        suggestions = optimizer.ask_n_runs(2)
+        ids = [s.run_id for s in suggestions]
+        if adopted_id is not None:
+            ids.append(adopted_id)
+        assert len(set(ids)) == len(ids)
+
+    def test_forget_run_then_ask_still_works(self, optimizer: Optimizer) -> None:
+        """Forgetting a suggestion must not corrupt the search state."""
+        first_run = next(iter(optimizer.ask_n_runs(1)))
+        optimizer.forget_run(first_run.run_id)
+        suggestions = optimizer.ask_n_runs(1)
+        assert suggestions is None or len(suggestions) <= 1
+
+    def test_prune_runs_returns_empty_for_no_candidates(
+        self, optimizer: Optimizer
+    ) -> None:
+        assert optimizer.prune_runs([], []) == []
+
+    # The better running run's final loss. Low enough that the pruner
+    # under test spares that run; subclasses lower it for stricter
+    # pruners.
+    better_running_loss = 7.0
+
+    def test_prune_runs_hyperband_stops_worst_running_run(
+        self, optimizer: Optimizer
+    ) -> None:
+        suggestions = optimizer.ask_n_runs(3)
+        assert len(suggestions) == 3
+
+        optimizer.tell_run(
+            suggestions[0].run_id,
+            make_run(
+                suggestions[0],
+                state=RunState.FINISHED,
+                summary={"loss": 6.0},
+                history=[{"loss": 10.0}, {"loss": 6.0}, {"loss": 6.0}],
+            ),
+        )
+        worst_running = make_run(
+            suggestions[1],
+            state=RunState.RUNNING,
+            summary={"loss": 10.0},
+            history=[{"loss": 10.0}, {"loss": 10.0}],
+        )
+        loss = self.better_running_loss
+        better_running = make_run(
+            suggestions[2],
+            state=RunState.RUNNING,
+            summary={"loss": loss},
+            history=[{"loss": 10.0}, {"loss": loss}, {"loss": loss}],
+        )
+        optimizer.tell_run(suggestions[1].run_id, worst_running)
+        optimizer.tell_run(suggestions[2].run_id, better_running)
+
+        pruned = optimizer.prune_runs(
+            [suggestions[1].run_id, suggestions[2].run_id],
+            [worst_running, better_running],
+        )
+        assert pruned == [suggestions[1].run_id]
+
+    def test_terminal_tell_after_prune_is_noop(self, optimizer: Optimizer) -> None:
+        """A pruned run's terminal tell (and a repeated prune) must not raise.
+
+        The scheduler stops a pruned run asynchronously, so the optimizer
+        sees the run's terminal state on a later poll — after it may have
+        already finalized the run at prune time.
+        """
+        suggestions = optimizer.ask_n_runs(3)
+        runs = []
+        for i, suggestion in enumerate(suggestions):
+            run = make_run(
+                suggestion,
+                state=RunState.RUNNING,
+                summary={"loss": float(10 * (i + 1))},
+                history=[{"loss": float(10 * (i + 1))}] * 2,
+            )
+            optimizer.tell_run(suggestion.run_id, run)
+            runs.append(run)
+        run_ids = [s.run_id for s in suggestions]
+
+        pruned = list(optimizer.prune_runs(run_ids, runs))
+        for run_id, suggestion in zip(run_ids, suggestions, strict=True):
+            if run_id not in pruned:
+                continue
+            optimizer.tell_run(
+                run_id,
+                make_run(suggestion, state=RunState.KILLED, summary={}),
+            )
+        # Offering an already-pruned id again must be tolerated.
+        repruned = optimizer.prune_runs(run_ids, runs)
+        assert set(repruned) <= set(run_ids)
+
+
+class TestWandbOptimizerAcceptance(OptimizerAcceptanceTests):
+    @pytest.fixture
+    def optimizer(self, sweep: SweepInfo) -> Optimizer:
+        from wandb.sdk.sweeps.scheduler.wandb import WandbOptimizer
+
+        return WandbOptimizer(sweep=sweep)
+
+    def test_forget_run_reproposes_grid_point(self, optimizer: Optimizer) -> None:
+        """Forgetting deletes the sample, so grid offers the point again."""
+        first_run = next(iter(optimizer.ask_n_runs(1)))
+        first_value = first_run.config["param1"].value
+        optimizer.forget_run(first_run.run_id)
+        again = next(iter(optimizer.ask_n_runs(1)))
+        assert again.config["param1"].value == first_value

--- a/tests/unit_tests/test_wandb_agent/test_cli_agent.py
+++ b/tests/unit_tests/test_wandb_agent/test_cli_agent.py
@@ -10,8 +10,8 @@ from unittest import mock
 import pytest
 import yaml
 from wandb import env, wandb_agent
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 from wandb.wandb_agent import Agent
 
 from .conftest import (

--- a/tests/unit_tests/test_wandb_agent/test_pyagent.py
+++ b/tests/unit_tests/test_wandb_agent/test_pyagent.py
@@ -8,8 +8,8 @@ import threading
 
 import pytest
 import wandb
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .conftest import (
     DEFAULT_ENTITY,

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -17,9 +17,9 @@ from typing import Any
 
 import wandb
 from wandb.apis import InternalApi
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.lib import config_util
+from wandb.sdk.sweeps import SweepNotFoundError
 
 logger = logging.getLogger(__name__)
 

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -36,10 +36,10 @@ from wandb.sdk.internal.internal_api import Api as SDKInternalApi
 from wandb.sdk.launch import utils as launch_utils
 from wandb.sdk.launch._launch_add import _launch_add
 from wandb.sdk.launch.errors import ExecutionError, LaunchError
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.launch.sweeps.scheduler import Scheduler
 from wandb.sdk.lib import filesystem, settings_file
+from wandb.sdk.sweeps import SweepNotFoundError
 
 from .beta import beta
 from .clean import clean

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -2001,7 +2001,7 @@ class Api:
             SweepNotFoundError: If the server returns a 404, indicating the
                 sweep was likely deleted.
         """
-        from wandb.sdk.launch.sweeps import SweepNotFoundError
+        from wandb.sdk.sweeps import SweepNotFoundError
 
         mutation = """
         mutation Heartbeat(

--- a/wandb/sdk/launch/sweeps/__init__.py
+++ b/wandb/sdk/launch/sweeps/__init__.py
@@ -2,15 +2,15 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+# SweepNotFoundError was moved from this file to sdk.sweeps.
+# Ensure backward-compatible re-export for legacy path.
+from wandb.sdk.sweeps import SweepNotFoundError as SweepNotFoundError
+
 log = logging.getLogger(__name__)
 
 
 class SchedulerError(Exception):
     """Raised when a known error occurs with wandb sweep scheduler."""
-
-
-class SweepNotFoundError(Exception):
-    """Raised when a sweep is not found, typically because it was deleted."""
 
 
 def _import_sweep_scheduler() -> Any:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -34,6 +34,10 @@ from wandb.sdk.launch.utils import (
 )
 from wandb.sdk.lib.runid import generate_id
 
+# RunState was moved from this file to sdk.sweeps.
+# Ensure backward-compatible re-export for legacy path.
+from wandb.sdk.sweeps import RunState as RunState
+
 if TYPE_CHECKING:
     import wandb.apis.public as public
     from wandb.apis.internal import Api
@@ -55,32 +59,6 @@ class SchedulerState(Enum):
     FAILED = 5
     STOPPED = 6
     CANCELLED = 7
-
-
-class RunState(Enum):
-    RUNNING = "running", "alive"
-    PENDING = "pending", "alive"
-    PREEMPTING = "preempting", "alive"
-    CRASHED = "crashed", "dead"
-    FAILED = "failed", "dead"
-    KILLED = "killed", "dead"
-    FINISHED = "finished", "dead"
-    PREEMPTED = "preempted", "dead"
-    # unknown when api.get_run_state fails or returns unexpected state
-    # assumed alive, unless we get unknown 2x then move to failed (dead)
-    UNKNOWN = "unknown", "alive"
-
-    def __new__(cls: Any, *args: list, **kwds: Any) -> RunState:
-        obj: RunState = object.__new__(cls)
-        obj._value_ = args[0]
-        return obj
-
-    def __init__(self, _: str, life: str = "unknown") -> None:
-        self._life = life
-
-    @property
-    def is_alive(self) -> bool:
-        return self._life == "alive"
 
 
 @dataclass

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -7,8 +7,8 @@ from pprint import pformat as pf
 from typing import Any
 
 import wandb
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.launch.sweeps.scheduler import LOG_PREFIX, RunState, Scheduler, SweepRun
+from wandb.sdk.sweeps import SweepNotFoundError
 
 _logger = logging.getLogger(__name__)
 

--- a/wandb/sdk/sweeps/__init__.py
+++ b/wandb/sdk/sweeps/__init__.py
@@ -1,0 +1,3 @@
+from wandb.sdk.sweeps.errors import SweepNotFoundError as SweepNotFoundError
+from wandb.sdk.sweeps.run_state import RunState as RunState
+from wandb.sdk.sweeps.sweep_info import SweepInfo as SweepInfo

--- a/wandb/sdk/sweeps/errors.py
+++ b/wandb/sdk/sweeps/errors.py
@@ -1,0 +1,5 @@
+"""Errors shared by the schedulers that drive sweeps."""
+
+
+class SweepNotFoundError(Exception):
+    """Raised when a sweep is not found, typically because it was deleted."""

--- a/wandb/sdk/sweeps/run_state.py
+++ b/wandb/sdk/sweeps/run_state.py
@@ -19,9 +19,8 @@ class RunState(Enum):
     KILLED = "killed", "dead"
     FINISHED = "finished", "dead"
     PREEMPTED = "preempted", "dead"
-    # unknown when api.get_run_state fails or returns an unexpected state.
-    # Classified alive; the launch scheduler moves a run to FAILED (dead)
-    # itself after two consecutive unknown polls.
+    # Alive, so that a failed or unexpected state lookup does not kill the
+    # run: the launch scheduler fails it after two consecutive unknown polls.
     UNKNOWN = "unknown", "alive"
 
     def __new__(cls: Any, *args: list, **kwds: Any) -> RunState:

--- a/wandb/sdk/sweeps/run_state.py
+++ b/wandb/sdk/sweeps/run_state.py
@@ -1,0 +1,40 @@
+"""The state of a sweep run, shared by the schedulers that drive sweeps."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+__all__ = ["RunState"]
+
+
+class RunState(Enum):
+    """A sweep run's state, paired with whether that state is alive or dead."""
+
+    RUNNING = "running", "alive"
+    PENDING = "pending", "alive"
+    PREEMPTING = "preempting", "alive"
+    CRASHED = "crashed", "dead"
+    FAILED = "failed", "dead"
+    KILLED = "killed", "dead"
+    FINISHED = "finished", "dead"
+    PREEMPTED = "preempted", "dead"
+    # unknown when api.get_run_state fails or returns an unexpected state.
+    # Classified alive; the launch scheduler moves a run to FAILED (dead)
+    # itself after two consecutive unknown polls.
+    UNKNOWN = "unknown", "alive"
+
+    def __new__(cls: Any, *args: list, **kwds: Any) -> RunState:
+        """Use only the first tuple element as the member's value."""
+        obj: RunState = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    def __init__(self, value: str, life: str = "unknown") -> None:
+        """Store the life classification; `value` is consumed by `__new__`."""
+        self._life = life
+
+    @property
+    def is_alive(self) -> bool:
+        """True while a run in this state may still make progress."""
+        return self._life == "alive"

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.sweep_info import SweepInfo
+
+
+@dataclass
+class ConfigValue:
+    """One hyperparameter in the server's wrapped form: `{"value": <v>}`."""
+
+    value: Any
+
+
+@dataclass
+class RunConfig:
+    """A run's hyperparameters, keyed by parameter name.
+
+    Each value is wrapped so that both the flat form callers think in
+    (`flat_dict`) and the form the server and sweep agent exchange
+    (`wire_dict`) are named rather than passed around as bare dicts.
+    """
+
+    config: dict[str, ConfigValue]
+
+    @classmethod
+    def from_values(cls, values: dict[str, Any]) -> RunConfig:
+        """Build a `RunConfig` from a flat `{param: value}` mapping."""
+        return cls({name: ConfigValue(value=value) for name, value in values.items()})
+
+    def flat_dict(self) -> dict[str, Any]:
+        """The flat `{param: value}` mapping."""
+        return {name: cv.value for name, cv in self.config.items()}
+
+    def wire_dict(self) -> dict[str, dict[str, Any]]:
+        """The server/agent wire form `{param: {"value": v}}`."""
+        return {name: {"value": cv.value} for name, cv in self.config.items()}
+
+    def __getitem__(self, key: str) -> ConfigValue:
+        return self.config[key]
+
+
+@dataclass
+class RunSuggestion:
+    """A run the optimizer proposes, with the id it will track it by.
+
+    `run_id` is the optimizer's own id, not a W&B run id: the run does not
+    exist yet when it is proposed.
+    """
+
+    config: RunConfig
+    run_id: str
+
+    def __post_init__(self) -> None:
+        # Optimizers built on third-party frameworks naturally produce the
+        # flat `{param: value}` mapping; accept that and normalize it to a
+        # `RunConfig` here so every suggestion the executor sees serializes
+        # the same way (`config.wire_dict()`), regardless of which optimizer
+        # built it.
+        if not isinstance(self.config, RunConfig):
+            self.config = RunConfig.from_values(self.config)
+
+
+@dataclass
+class Run:
+    """A sweep run as the optimizer sees it, without its metrics.
+
+    `wandb_run_id` is the id W&B assigned the run, which a scheduler maps back
+    to the `RunSuggestion.run_id` the optimizer handed out.
+    """
+
+    config: RunConfig
+    state: RunState
+    wandb_run_id: str
+
+
+@dataclass
+class RunWithMetrics(Run):
+    """A `Run` together with the metrics it has reported so far.
+
+    `summary_metrics` is the run's latest summary; `history_metrics` is the
+    sampled per-step history, which early terminators read.
+    """
+
+    summary_metrics: dict[str, Any]
+    history_metrics: list[dict[str, Any]]
+
+
+def is_terminal_state(state: RunState) -> bool:
+    """Return True if the run has stopped (is terminal), else False.
+
+    In-flight states (running/pending/preempting/preempted/unknown) return
+    False. Used to decide whether a run's result can be reported to the
+    optimizer.
+    """
+    return state in (
+        RunState.FINISHED,
+        RunState.FAILED,
+        RunState.CRASHED,
+        RunState.KILLED,
+        RunState.PREEMPTED,
+    )
+
+
+class Optimizer(ABC):
+    """An external optimizer that supports an ask-tell interface.
+
+    A scheduler asks the optimizer for runs to start, then tells the run
+    results back to the optimizer as they progress.
+
+    Subclasses may read the protected `_sweep` attribute, the `SweepInfo`
+    of the sweep being optimized.
+
+    Run ids handed out by `ask_n_runs` and `tell_existing_active_run` must
+    be unique across both for the optimizer's lifetime: the scheduler routes
+    tells and prunes by id alone.
+    """
+
+    def __init__(self, sweep: SweepInfo):
+        self._sweep = sweep
+        self.validate_sweep_objective()
+
+    @abstractmethod
+    def validate_sweep_objective(self) -> None:
+        """Raise if the optimizer's objective disagrees with the sweep's.
+
+        Called from `__init__`, so a mismatch surfaces before the sweep runs.
+        """
+        ...
+
+    @abstractmethod
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion] | None:
+        """Propose up to `n` runs to start next.
+
+        Fewer than `n` may come back when the search space is nearly
+        exhausted. Returning an empty sequence means the search space is
+        exhausted: a scheduler takes it as the end of the sweep and finishes
+        it. Returning None declines to propose for now (e.g. the strategy
+        needs results from in-flight runs first); the scheduler asks again
+        on a later poll.
+
+        Args:
+            n: The maximum number of runs to propose.
+        """
+        ...
+
+    @abstractmethod
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
+        """Report the latest state and metrics of a run this optimizer proposed.
+
+        Called on each poll while the run is in flight, and once more when it
+        reaches a terminal state. The terminal call also happens for runs this
+        optimizer returned from `prune_runs`: implementations that finalize a
+        run at prune time must treat that call as a no-op rather than raise.
+
+        Args:
+            run_id: The `RunSuggestion.run_id` this optimizer handed out.
+            data: The run's current state, summary metrics and history.
+        """
+        ...
+
+    def forget_run(self, run_id: Any) -> None:
+        """Release a proposed run that will never start.
+
+        Called when the scheduler accepted a suggestion but could not durably
+        schedule it (for example, the enqueue failed or the sweep finished
+        first). No `tell_run` follows for the id. The default reports a
+        failed run with no metrics; override when the search strategy should
+        instead drop the point entirely so it can be proposed again.
+
+        Args:
+            run_id: The `RunSuggestion.run_id` this optimizer handed out.
+        """
+        self.tell_run(
+            run_id,
+            RunWithMetrics(
+                config=RunConfig({}),
+                state=RunState.FAILED,
+                wandb_run_id="",
+                summary_metrics={},
+                history_metrics=[],
+            ),
+        )
+
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        """Report a *terminal* run that already existed in the sweep at startup.
+
+        Unlike `tell_run`, there is no optimizer-side run id because the run was
+        not produced by this optimizer's `ask_n_runs`. Override to warm-start
+        from prior results; the default is a no-op.
+
+        Args:
+            data: The finished run's final state, summary metrics and history.
+        """
+        return None
+
+    def tell_existing_active_run(self, data: Run) -> Any:
+        """Adopt an *in-flight* (RUNNING/PENDING) run that existed at startup.
+
+        Args:
+            data: The existing run's config and state, without metrics.
+
+        Returns:
+            The optimizer-side run id to track the run by, in which case
+            later polls report its metrics via `tell_run`, or None to
+            leave the run untracked. The default adopts nothing.
+        """
+        return None
+
+    def metric_value(self, metrics: dict[str, Any]) -> Any:
+        """Return the objective value for the sweep's configured metric.
+
+        Args:
+            metrics: One run's metrics, keyed by metric name.
+        """
+        return metrics.get(self.metric_key())
+
+    def metric_key(self) -> str:
+        """Return the name of the sweep's objective metric.
+
+        Raises:
+            ValueError: If the sweep config declares no metric name.
+        """
+        metric = self._sweep.config.get("metric")
+        if not metric or "name" not in metric:
+            raise ValueError(
+                "Sweep config has no metric; cannot determine the objective value."
+            )
+        return metric["name"]
+
+    @property
+    def sweep_name(self) -> str:
+        """The name of the sweep this optimizer searches."""
+        return self._sweep.name
+
+    def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
+        """Return True if the run should be pruned.
+
+        Override to stop single runs early, the default prunes nothing.
+        The default `prune_runs` calls this for each polled run.
+
+        Args:
+            run_id: The `RunSuggestion.run_id` the optimizer handed out.
+            data: The run's current state, summary and history metrics.
+        """
+        return False
+
+    def prune_runs(
+        self, run_ids: Sequence[str], runs: Sequence[RunWithMetrics]
+    ) -> Sequence[str]:
+        """Return the optimizer run ids that should be pruned.
+
+        Override to decide early stopping across runs as a batch; the
+        default delegates calls to `prune_run` for each run. An id that was
+        already returned once may be offered again if its run has not stopped
+        yet; implementations must tolerate that rather than raise.
+
+        Args:
+            run_ids: Optimizer run ids to consider for pruning.
+            runs: The corresponding runs' latest state and metrics.
+        """
+        return [
+            run_id
+            for run_id, run in zip(run_ids, runs, strict=True)
+            if self.prune_run(run_id, run)
+        ]
+
+    def should_terminate_sweep(self) -> bool:
+        """Return True if the sweep should be terminated."""
+        return False

--- a/wandb/sdk/sweeps/scheduler/optimizer.py
+++ b/wandb/sdk/sweeps/scheduler/optimizer.py
@@ -20,9 +20,8 @@ class ConfigValue:
 class RunConfig:
     """A run's hyperparameters, keyed by parameter name.
 
-    Each value is wrapped so that both the flat form callers think in
-    (`flat_dict`) and the form the server and sweep agent exchange
-    (`wire_dict`) are named rather than passed around as bare dicts.
+    Values are wrapped so the flat form (`flat_dict`) and the server/agent
+    wire form (`wire_dict`) are named rather than bare dicts.
     """
 
     config: dict[str, ConfigValue]
@@ -56,11 +55,8 @@ class RunSuggestion:
     run_id: str
 
     def __post_init__(self) -> None:
-        # Optimizers built on third-party frameworks naturally produce the
-        # flat `{param: value}` mapping; accept that and normalize it to a
-        # `RunConfig` here so every suggestion the executor sees serializes
-        # the same way (`config.wire_dict()`), regardless of which optimizer
-        # built it.
+        # Accept the flat mapping third-party optimizers produce, so every
+        # suggestion the executor sees serializes the same way.
         if not isinstance(self.config, RunConfig):
             self.config = RunConfig.from_values(self.config)
 
@@ -69,8 +65,8 @@ class RunSuggestion:
 class Run:
     """A sweep run as the optimizer sees it, without its metrics.
 
-    `wandb_run_id` is the id W&B assigned the run, which a scheduler maps back
-    to the `RunSuggestion.run_id` the optimizer handed out.
+    The scheduler maps `wandb_run_id` back to the `RunSuggestion.run_id` the
+    optimizer handed out.
     """
 
     config: RunConfig
@@ -80,23 +76,14 @@ class Run:
 
 @dataclass
 class RunWithMetrics(Run):
-    """A `Run` together with the metrics it has reported so far.
-
-    `summary_metrics` is the run's latest summary; `history_metrics` is the
-    sampled per-step history, which early terminators read.
-    """
+    """A `Run` plus its latest summary and sampled per-step history."""
 
     summary_metrics: dict[str, Any]
     history_metrics: list[dict[str, Any]]
 
 
 def is_terminal_state(state: RunState) -> bool:
-    """Return True if the run has stopped (is terminal), else False.
-
-    In-flight states (running/pending/preempting/preempted/unknown) return
-    False. Used to decide whether a run's result can be reported to the
-    optimizer.
-    """
+    """Return True if the run has stopped, so its result can be reported."""
     return state in (
         RunState.FINISHED,
         RunState.FAILED,
@@ -109,14 +96,11 @@ def is_terminal_state(state: RunState) -> bool:
 class Optimizer(ABC):
     """An external optimizer that supports an ask-tell interface.
 
-    A scheduler asks the optimizer for runs to start, then tells the run
-    results back to the optimizer as they progress.
+    A scheduler asks for runs to start, then tells results back as the runs
+    progress. Subclasses may read the protected `_sweep` attribute.
 
-    Subclasses may read the protected `_sweep` attribute, the `SweepInfo`
-    of the sweep being optimized.
-
-    Run ids handed out by `ask_n_runs` and `tell_existing_active_run` must
-    be unique across both for the optimizer's lifetime: the scheduler routes
+    Run ids handed out by `ask_n_runs` and `tell_existing_active_run` must be
+    unique across both for the optimizer's lifetime: the scheduler routes
     tells and prunes by id alone.
     """
 
@@ -128,7 +112,7 @@ class Optimizer(ABC):
     def validate_sweep_objective(self) -> None:
         """Raise if the optimizer's objective disagrees with the sweep's.
 
-        Called from `__init__`, so a mismatch surfaces before the sweep runs.
+        Called from `__init__` so a mismatch surfaces before the sweep runs.
         """
         ...
 
@@ -136,12 +120,10 @@ class Optimizer(ABC):
     def ask_n_runs(self, n: int) -> Sequence[RunSuggestion] | None:
         """Propose up to `n` runs to start next.
 
-        Fewer than `n` may come back when the search space is nearly
-        exhausted. Returning an empty sequence means the search space is
-        exhausted: a scheduler takes it as the end of the sweep and finishes
-        it. Returning None declines to propose for now (e.g. the strategy
-        needs results from in-flight runs first); the scheduler asks again
-        on a later poll.
+        An empty sequence means the search space is exhausted and the
+        scheduler finishes the sweep. None only declines for now (e.g. the
+        strategy needs in-flight results first) and is retried on a later
+        poll.
 
         Args:
             n: The maximum number of runs to propose.
@@ -153,9 +135,9 @@ class Optimizer(ABC):
         """Report the latest state and metrics of a run this optimizer proposed.
 
         Called on each poll while the run is in flight, and once more when it
-        reaches a terminal state. The terminal call also happens for runs this
-        optimizer returned from `prune_runs`: implementations that finalize a
-        run at prune time must treat that call as a no-op rather than raise.
+        reaches a terminal state. The terminal call also happens for runs
+        returned from `prune_runs`, so implementations that finalize a run at
+        prune time must treat it as a no-op rather than raise.
 
         Args:
             run_id: The `RunSuggestion.run_id` this optimizer handed out.
@@ -166,11 +148,10 @@ class Optimizer(ABC):
     def forget_run(self, run_id: Any) -> None:
         """Release a proposed run that will never start.
 
-        Called when the scheduler accepted a suggestion but could not durably
-        schedule it (for example, the enqueue failed or the sweep finished
-        first). No `tell_run` follows for the id. The default reports a
-        failed run with no metrics; override when the search strategy should
-        instead drop the point entirely so it can be proposed again.
+        Called when the scheduler could not durably schedule a suggestion; no
+        `tell_run` follows for the id. The default reports a failed run with
+        no metrics; override to drop the point entirely so it can be proposed
+        again.
 
         Args:
             run_id: The `RunSuggestion.run_id` this optimizer handed out.
@@ -189,9 +170,9 @@ class Optimizer(ABC):
     def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
         """Report a *terminal* run that already existed in the sweep at startup.
 
-        Unlike `tell_run`, there is no optimizer-side run id because the run was
-        not produced by this optimizer's `ask_n_runs`. Override to warm-start
-        from prior results; the default is a no-op.
+        There is no optimizer-side run id: the run did not come from
+        `ask_n_runs`. Override to warm-start from prior results; the default
+        is a no-op.
 
         Args:
             data: The finished run's final state, summary metrics and history.
@@ -205,9 +186,9 @@ class Optimizer(ABC):
             data: The existing run's config and state, without metrics.
 
         Returns:
-            The optimizer-side run id to track the run by, in which case
-            later polls report its metrics via `tell_run`, or None to
-            leave the run untracked. The default adopts nothing.
+            The optimizer-side run id to track the run by, whose metrics
+            later polls report via `tell_run`, or None to leave the run
+            untracked. The default adopts nothing.
         """
         return None
 
@@ -240,8 +221,8 @@ class Optimizer(ABC):
     def prune_run(self, run_id: Any, data: RunWithMetrics) -> bool:
         """Return True if the run should be pruned.
 
-        Override to stop single runs early, the default prunes nothing.
-        The default `prune_runs` calls this for each polled run.
+        Called by the default `prune_runs` for each polled run. Override to
+        stop single runs early; the default prunes nothing.
 
         Args:
             run_id: The `RunSuggestion.run_id` the optimizer handed out.
@@ -254,10 +235,9 @@ class Optimizer(ABC):
     ) -> Sequence[str]:
         """Return the optimizer run ids that should be pruned.
 
-        Override to decide early stopping across runs as a batch; the
-        default delegates calls to `prune_run` for each run. An id that was
-        already returned once may be offered again if its run has not stopped
-        yet; implementations must tolerate that rather than raise.
+        Override to decide early stopping as a batch; the default delegates to
+        `prune_run`. An already-returned id may be offered again while its run
+        has not stopped, and implementations must tolerate that.
 
         Args:
             run_ids: Optimizer run ids to consider for pruning.

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -1,0 +1,221 @@
+"""Reference optimizer backed by the `sweeps` search algorithms."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import override
+
+from wandb import util
+from wandb.sdk.sweeps.run_state import RunState
+from wandb.sdk.sweeps.scheduler.optimizer import (
+    Optimizer,
+    Run,
+    RunConfig,
+    RunSuggestion,
+    RunWithMetrics,
+    is_terminal_state,
+)
+from wandb.sdk.sweeps.sweep_info import SweepInfo
+
+if TYPE_CHECKING:
+    import sweeps
+else:
+    sweeps = util.get_module(
+        "sweeps",
+        required="wandb[sweeps] is required to use the wandb sweep scheduler. "
+        "Please run `pip install wandb[sweeps]`.",
+    )
+
+
+def _to_sweeps_state(state: RunState) -> Any:
+    """Map the scheduler's `RunState` onto the `sweeps` `RunState` enum."""
+    try:
+        return sweeps.RunState(state.value)
+    except ValueError:
+        return sweeps.RunState.pending
+
+
+class WandbOptimizer(Optimizer):
+    """`Optimizer` driven by the `sweeps` search algorithms.
+
+    The `sweeps` search functions (`grid`/`random`/`bayes` and the hyperband
+    early-terminator) are stateless, so this class keeps the full list of sweep
+    runs in memory.
+    """
+
+    @override
+    def __init__(self, sweep: SweepInfo):
+        super().__init__(sweep)
+        # key: run id, value: the SweepRun we hold for it
+        self._runs: dict[str, sweeps.SweepRun] = {}
+        self._run_counter = 0
+
+    @override
+    def validate_sweep_objective(self) -> None:
+        """No-op: the sweep config is the only objective this optimizer reads.
+
+        Unlike the optuna and Ax optimizers there is no external study or
+        experiment that could disagree with it.
+        """
+        return None
+
+    def _new_run_id(self) -> str:
+        run_id = f"{self._sweep.id}-{self._run_counter}"
+        self._run_counter += 1
+        return run_id
+
+    def _to_sweep_run(self, run_id: str, data: RunWithMetrics) -> Any:
+        sweep_run = sweeps.SweepRun(
+            name=run_id,
+            config=data.config.wire_dict(),
+            state=_to_sweeps_state(data.state),
+        )
+        sweep_run.summary_metrics = data.summary_metrics or {}
+        sweep_run.history = list(data.history_metrics)
+        return sweep_run
+
+    def _record(self, run_id: str, data: RunWithMetrics) -> Any:
+        """Create and store a SweepRun for `run_id` from `data`."""
+        sweep_run = self._to_sweep_run(run_id, data)
+        self._runs[run_id] = sweep_run
+        return sweep_run
+
+    def _sweep_runs_for_stop_runs(
+        self, run_ids: Sequence[str], runs: Sequence[RunWithMetrics]
+    ) -> list[Any]:
+        """Merge in-memory runs with the scheduler's latest poll snapshot."""
+        sweep_runs_by_name = {run.name: run for run in self._runs.values()}
+        for run_id, data in zip(run_ids, runs, strict=True):
+            sweep_runs_by_name[run_id] = self._to_sweep_run(run_id, data)
+        return list(sweep_runs_by_name.values())
+
+    @override
+    def ask_n_runs(self, n: int) -> Sequence[RunSuggestion]:
+        """Ask the `sweeps` search for up to `n` new runs.
+
+        Args:
+            n: The maximum number of runs to propose.
+        """
+        suggested = sweeps.next_runs(self._sweep.config, list(self._runs.values()), n=n)
+        suggestions: list[RunSuggestion] = []
+        for sweep_run in suggested:
+            # grid search returns None once the search space is exhausted.
+            if sweep_run is None:
+                continue
+            run_id = self._new_run_id()
+            sweep_run.name = run_id
+            # Record it (state defaults to pending) so the next search call and
+            # tell_run can find it.
+            self._runs[run_id] = sweep_run
+            # `sweeps` hands back the wire form ({param: {"value": v}}); unwrap
+            # it into the flat mapping `RunConfig.from_values` takes.
+            suggestions.append(
+                RunSuggestion(
+                    config=RunConfig.from_values(
+                        {
+                            name: param["value"]
+                            for name, param in sweep_run.config.items()
+                        }
+                    ),
+                    run_id=run_id,
+                )
+            )
+        return suggestions
+
+    @override
+    def tell_run(self, run_id: Any, data: RunWithMetrics) -> None:
+        """Record a run's latest outcome for the next search call to read.
+
+        Args:
+            run_id: The run id this optimizer handed out.
+            data: The run's current state, summary metrics and history.
+
+        Raises:
+            ValueError: If `run_id` was never proposed by this optimizer.
+        """
+        # Keep the config we suggested — `data.config` may be empty (e.g. a
+        # reaped run) — only the outcome (state, metrics, history) is new here.
+        sweep_run = self._runs.get(run_id)
+        if sweep_run is None:
+            raise ValueError(f"Run {run_id} not found")
+        sweep_run.state = _to_sweeps_state(data.state)
+        sweep_run.summary_metrics = data.summary_metrics or {}
+        sweep_run.history = list(data.history_metrics)
+
+    @override
+    def forget_run(self, run_id: Any) -> None:
+        """Drop a run that will never start from the search's memory.
+
+        Deleting it, rather than recording a failure, lets grid search
+        propose the same point again.
+
+        Args:
+            run_id: The run id this optimizer handed out.
+        """
+        self._runs.pop(run_id, None)
+
+    @override
+    def prune_runs(
+        self, run_ids: Sequence[str], runs: Sequence[RunWithMetrics]
+    ) -> Sequence[str]:
+        """Return the runs hyperband says should stop early.
+
+        Returns nothing unless the sweep config has an `early_terminate` block.
+
+        Args:
+            run_ids: Optimizer run ids to consider for pruning.
+            runs: Corresponding run metrics from the latest poll.
+        """
+        if "early_terminate" not in self._sweep.config:
+            return []
+        try:
+            to_stop = sweeps.stop_runs(
+                self._sweep.config,
+                self._sweep_runs_for_stop_runs(run_ids, runs),
+            )
+        except Exception:
+            return []
+        to_stop_names = {run.name for run in to_stop}
+        return [run_id for run_id in run_ids if run_id in to_stop_names]
+
+    @override
+    def should_terminate_sweep(self) -> bool:
+        """Sweeps library does not implement this, so we return False."""
+        return False
+
+    @override
+    def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
+        """Add a terminal run that predates this optimizer to its memory.
+
+        The search then treats it as a completed sample. Non-terminal runs are
+        ignored.
+
+        Args:
+            data: The existing run's state, summary metrics and history.
+        """
+        if not is_terminal_state(data.state):
+            return
+        self._record(self._new_run_id(), data)
+
+    @override
+    def tell_existing_active_run(self, data: Run) -> Any:
+        """Adopt an in-flight run that predates this optimizer.
+
+        Its config is stored so the search counts it as in flight; the next poll
+        refreshes its metrics via `tell_run` before any suggestion reads them.
+
+        Args:
+            data: The existing run's config and state.
+
+        Returns:
+            The optimizer run id to track the run by.
+        """
+        run_id = self._new_run_id()
+        self._runs[run_id] = sweeps.SweepRun(
+            name=run_id,
+            config=data.config.wire_dict(),
+            state=_to_sweeps_state(data.state),
+        )
+        return run_id

--- a/wandb/sdk/sweeps/scheduler/wandb.py
+++ b/wandb/sdk/sweeps/scheduler/wandb.py
@@ -40,15 +40,13 @@ def _to_sweeps_state(state: RunState) -> Any:
 class WandbOptimizer(Optimizer):
     """`Optimizer` driven by the `sweeps` search algorithms.
 
-    The `sweeps` search functions (`grid`/`random`/`bayes` and the hyperband
-    early-terminator) are stateless, so this class keeps the full list of sweep
-    runs in memory.
+    The `sweeps` search functions are stateless, so this class keeps the full
+    list of sweep runs in memory.
     """
 
     @override
     def __init__(self, sweep: SweepInfo):
         super().__init__(sweep)
-        # key: run id, value: the SweepRun we hold for it
         self._runs: dict[str, sweeps.SweepRun] = {}
         self._run_counter = 0
 
@@ -56,8 +54,7 @@ class WandbOptimizer(Optimizer):
     def validate_sweep_objective(self) -> None:
         """No-op: the sweep config is the only objective this optimizer reads.
 
-        Unlike the optuna and Ax optimizers there is no external study or
-        experiment that could disagree with it.
+        There is no external study or experiment that could disagree with it.
         """
         return None
 
@@ -77,7 +74,6 @@ class WandbOptimizer(Optimizer):
         return sweep_run
 
     def _record(self, run_id: str, data: RunWithMetrics) -> Any:
-        """Create and store a SweepRun for `run_id` from `data`."""
         sweep_run = self._to_sweep_run(run_id, data)
         self._runs[run_id] = sweep_run
         return sweep_run
@@ -106,11 +102,10 @@ class WandbOptimizer(Optimizer):
                 continue
             run_id = self._new_run_id()
             sweep_run.name = run_id
-            # Record it (state defaults to pending) so the next search call and
-            # tell_run can find it.
+            # State defaults to pending, so the next search call and tell_run
+            # can find it.
             self._runs[run_id] = sweep_run
-            # `sweeps` hands back the wire form ({param: {"value": v}}); unwrap
-            # it into the flat mapping `RunConfig.from_values` takes.
+            # Unwrap the wire form `sweeps` returns into a flat mapping.
             suggestions.append(
                 RunSuggestion(
                     config=RunConfig.from_values(
@@ -135,8 +130,8 @@ class WandbOptimizer(Optimizer):
         Raises:
             ValueError: If `run_id` was never proposed by this optimizer.
         """
-        # Keep the config we suggested — `data.config` may be empty (e.g. a
-        # reaped run) — only the outcome (state, metrics, history) is new here.
+        # Keep the config we suggested: `data.config` may be empty for a
+        # reaped run.
         sweep_run = self._runs.get(run_id)
         if sweep_run is None:
             raise ValueError(f"Run {run_id} not found")
@@ -189,7 +184,7 @@ class WandbOptimizer(Optimizer):
     def tell_existing_finished_run(self, data: RunWithMetrics) -> None:
         """Add a terminal run that predates this optimizer to its memory.
 
-        The search then treats it as a completed sample. Non-terminal runs are
+        The search treats it as a completed sample. Non-terminal runs are
         ignored.
 
         Args:
@@ -203,8 +198,8 @@ class WandbOptimizer(Optimizer):
     def tell_existing_active_run(self, data: Run) -> Any:
         """Adopt an in-flight run that predates this optimizer.
 
-        Its config is stored so the search counts it as in flight; the next poll
-        refreshes its metrics via `tell_run` before any suggestion reads them.
+        Only its config is stored, so the search counts it as in flight; the
+        next poll fills in metrics via `tell_run`.
 
         Args:
             data: The existing run's config and state.

--- a/wandb/sdk/sweeps/sweep_info.py
+++ b/wandb/sdk/sweeps/sweep_info.py
@@ -8,8 +8,8 @@ from typing import Any
 class SweepInfo:
     """Static facts about the sweep an optimizer searches.
 
-    A plain value object so that optimizers do not depend on the public API
-    and can be built from scheduler protocol payloads or literals in tests.
+    A plain value object, so optimizers do not depend on the public API and
+    can be built from protocol payloads or literals in tests.
 
     Attributes:
         id: The sweep's short id, unique within the project.

--- a/wandb/sdk/sweeps/sweep_info.py
+++ b/wandb/sdk/sweeps/sweep_info.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SweepInfo:
+    """Static facts about the sweep an optimizer searches.
+
+    A plain value object so that optimizers do not depend on the public API
+    and can be built from scheduler protocol payloads or literals in tests.
+
+    Attributes:
+        id: The sweep's short id, unique within the project.
+        name: The sweep's display name.
+        entity: The entity that owns the sweep.
+        project: The project the sweep belongs to.
+        config: The parsed sweep config. Treat it as read-only.
+    """
+
+    id: str
+    name: str
+    entity: str
+    project: str
+    config: dict[str, Any]

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -20,8 +20,8 @@ from typing import Any
 import wandb
 from wandb import util
 from wandb.sdk import wandb_login, wandb_setup
-from wandb.sdk.launch.sweeps import SweepNotFoundError
 from wandb.sdk.lib import config_util, ipython
+from wandb.sdk.sweeps import SweepNotFoundError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Description
-----------
First PR of a stack that reimplements local sweep scheduling with the loop in wandb-core and the search strategy in Python.

Adds `wandb.sdk.sweeps`: the `RunState` enum, `SweepNotFoundError` (moved out of `wandb.sdk.launch.sweeps`, with a back-compat re-export), the `SweepInfo` value object, and the `scheduler` subpackage holding the ask/tell `Optimizer` ABC plus a reference implementation backed by the `sweeps` search algorithms.

No scheduler runs anything yet: wandb-core owns the loop (later PRs in this stack), so this package is purely the optimizer side of that split. Nothing user-facing yet, so no CHANGELOG entry.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
`OptimizerAcceptanceTests`, the contract every optimizer must satisfy, plus new contract tests for the scheduler's requirements: a pruned run's later terminal tell is a no-op, run ids are unique across asks and adoptions, and `forget_run` releases a suggestion that never started (grid re-proposes the point).
