### PR TITLE
fix(artifacts): default artifacts to MD5

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -135,3 +135,8 @@ When preparing a release that can include breaking changes, consider applying ch
   - Owner: @timoffex
   - Deprecated after 0.28.0 (https://github.com/wandb/wandb/pull/12098)
   - Can do a few releases after 0.28.1 or 0.29.0 (whichever comes first)
+
+- Make `digest_algorithm="XXH128"` the default for `wandb.Artifact`:
+  - PR: https://github.com/wandb/wandb/pull/12571
+  - Owner: @art-reg-team
+  - Can do a few releases after 0.29.0, or when we're confident that `artifact.verify` usage on older SDK versions is low.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Drag the separator lines between LEET's run overview sections to resize them with the mouse. The proportions are saved per view; press `0` to reset them along with the other pane sizes (@dmitryduev in https://github.com/wandb/wandb/pull/12525)
 - Registry API version queries (`Api.registries().versions()`, `Api.registries().collections().versions()`, `Registry.versions()`, `Registry.collections().versions()`) now accept an optional `order` string as a keyword argument for organizations with advanced search. The API supports ordering versions by `created_at`, `artifact_size`, and `linked_at` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12489)
 - Added `Artifact.linked_at` which returns when the version was linked to the relevant portfolio. This is valid only for linked versions, and for source artifacts returns `None` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12490)
+- Artifacts can now use XXH128 as the digest algorithm by with `wandb.Artifact(..., digest_algorithm="XXH128")`. If the artifact's existing sequence is using MD5, this artifact will also be uploaded with MD5. On older SDK versions, calling `artifact.verify()` on this artifact will always fail. (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12564)
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Drag the separator lines between LEET's run overview sections to resize them with the mouse. The proportions are saved per view; press `0` to reset them along with the other pane sizes (@dmitryduev in https://github.com/wandb/wandb/pull/12525)
 - Registry API version queries (`Api.registries().versions()`, `Api.registries().collections().versions()`, `Registry.versions()`, `Registry.collections().versions()`) now accept an optional `order` string as a keyword argument for organizations with advanced search. The API supports ordering versions by `created_at`, `artifact_size`, and `linked_at` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12489)
 - Added `Artifact.linked_at` which returns when the version was linked to the relevant portfolio. This is valid only for linked versions, and for source artifacts returns `None` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12490)
-- Artifacts can now use XXH128 as the digest algorithm by with `wandb.Artifact(..., digest_algorithm="XXH128")`. If the artifact's existing sequence is using MD5, this artifact will also be uploaded with MD5. On older SDK versions, calling `artifact.verify()` on this artifact will always fail. (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12564)
+- `wandb.Artifact` now accepts a `digest_algorithm` argument (`"MD5"` or `"XXH128"`, defaulting to `"MD5"`). Passing `digest_algorithm="XXH128"` opts the artifact into XXH128 hashing when possible. Note that `artifact.verify()` will always fail for XXH128 artifacts on older SDK versions (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12564)
 
 ### Changed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,7 +23,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Drag the separator lines between LEET's run overview sections to resize them with the mouse. The proportions are saved per view; press `0` to reset them along with the other pane sizes (@dmitryduev in https://github.com/wandb/wandb/pull/12525)
 - Registry API version queries (`Api.registries().versions()`, `Api.registries().collections().versions()`, `Registry.versions()`, `Registry.collections().versions()`) now accept an optional `order` string as a keyword argument for organizations with advanced search. The API supports ordering versions by `created_at`, `artifact_size`, and `linked_at` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12489)
 - Added `Artifact.linked_at` which returns when the version was linked to the relevant portfolio. This is valid only for linked versions, and for source artifacts returns `None` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12490)
-- `wandb.Artifact` now accepts a `digest_algorithm` argument (`"MD5"` or `"XXH128"`, defaulting to `"MD5"`). Passing `digest_algorithm="XXH128"` opts the artifact into XXH128 hashing when possible. Note that `artifact.verify()` will always fail for XXH128 artifacts on older SDK versions (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12564)
+- `wandb.Artifact` now accepts a `digest_algorithm` argument (`"MD5"` or `"XXH128"`, defaulting to `"MD5"`). Passing `digest_algorithm="XXH128"` opts the artifact into XXH128 hashing when possible. For artifacts created with `digest_algorithm="XXH128"`, `artifact.verify()` will fail for SDK versions older than 0.29.0. (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12564)
 
 ### Changed
 

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -71,10 +71,8 @@ def s3_bucket(s3: BaseClient) -> str:
 
 @fixture
 def artifact(request: FixtureRequest) -> Artifact:
-    digest_algorithm = getattr(request, "param", "MD5")
-    return Artifact(
-        type="dataset", name="data-artifact", digest_algorithm=digest_algorithm
-    )
+    kwargs = {"digest_algorithm": request.param} if hasattr(request, "param") else {}
+    return Artifact(type="dataset", name="data-artifact", **kwargs)
 
 
 def test_unsized_manifest_entry_real_file():

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -19,7 +19,7 @@ import responses
 import wandb
 import wandb.sdk.internal.sender
 from moto import mock_aws
-from pytest import MonkeyPatch, fixture, mark, param, raises
+from pytest import FixtureRequest, MonkeyPatch, fixture, mark, param, raises
 from wandb import Api, Artifact
 from wandb.data_types import ImageMask, PartitionedTable
 from wandb.errors.errors import CommError
@@ -70,8 +70,11 @@ def s3_bucket(s3: BaseClient) -> str:
 
 
 @fixture
-def artifact() -> Artifact:
-    return Artifact(type="dataset", name="data-artifact")
+def artifact(request: FixtureRequest) -> Artifact:
+    digest_algorithm = getattr(request, "param", "MD5")
+    return Artifact(
+        type="dataset", name="data-artifact", digest_algorithm=digest_algorithm
+    )
 
 
 def test_unsized_manifest_entry_real_file():
@@ -88,17 +91,12 @@ def test_unsized_manifest_entry():
     assert "No such file" in str(e.value)
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_one_file(digest_algorithm, artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_one_file(artifact):
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
 
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "fe0d6c1a25b6d98451da9b04ebf6d80c"
         manifest_contents = artifact.manifest.to_manifest_json()["contents"]
         assert manifest_contents == {
@@ -116,17 +114,12 @@ def test_add_one_file(digest_algorithm, artifact):
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_named_file(digest_algorithm, artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_named_file(artifact):
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt", name="great-file.txt")
 
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "5128bda8426a0e35a91082780b668e43"
         manifest_contents = artifact.manifest.to_manifest_json()["contents"]
         assert manifest_contents == {
@@ -144,17 +137,12 @@ def test_add_named_file(digest_algorithm, artifact):
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_new_file(digest_algorithm, artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_new_file(artifact):
     with artifact.new_file("file1.txt") as f:
         f.write("hello")
 
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "fe0d6c1a25b6d98451da9b04ebf6d80c"
         manifest_contents = artifact.manifest.to_manifest_json()["contents"]
         assert manifest_contents == {
@@ -199,18 +187,13 @@ def test_add_file_again_after_edit(overwrite, artifact):
         artifact.add_file(str(filepath), overwrite=overwrite)
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_dir(digest_algorithm, artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_dir(artifact):
     Path("file1.txt").write_text("hello")
 
     artifact.add_dir(".")
 
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "fe0d6c1a25b6d98451da9b04ebf6d80c"
         manifest_contents = artifact.manifest.to_manifest_json()["contents"]
         assert manifest_contents == {
@@ -228,17 +211,12 @@ def test_add_dir(digest_algorithm, artifact):
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_named_dir(digest_algorithm, artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_named_dir(artifact):
     Path("file1.txt").write_text("hello")
     artifact.add_dir(".", name="subdir")
 
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "90433061a33aed87ab6c0ff48c7f983c"
         manifest_contents = artifact.manifest.to_manifest_json()["contents"]
         assert manifest_contents == {
@@ -324,7 +302,7 @@ def test_add_reference_local_file(tmp_path, artifact):
     e = artifact.add_reference(uri)[0]
     assert e.ref_target() == uri
 
-    assert artifact.digest == "db139340fb6c96baea7b5a9764d55b2c"
+    assert artifact.digest == "a00c2239f036fb656c1dcbf9a32d89b4"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "file1.txt": {
@@ -478,7 +456,7 @@ def test_add_reference_local_dir(artifact):
     here = Path.cwd()
     artifact.add_reference(f"file://{here}")
 
-    assert artifact.digest == "1c5e32d843db9099cff8f3d5885a3aed"
+    assert artifact.digest == "72414374bfd4b0f60a116e7267845f71"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "file1.txt": {
@@ -568,7 +546,7 @@ def test_add_reference_local_dir_with_name(artifact):
     here = Path.cwd()
     artifact.add_reference(f"file://{here!s}", name="top")
 
-    assert artifact.digest == "4ed6e3db722bf0d8422ec3cfc5cf2ea1"
+    assert artifact.digest == "f718baf2d4c910dc6ccd0d9c586fa00f"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "top/file1.txt": {
@@ -620,7 +598,7 @@ def test_add_http_reference_path(artifact):
 
     artifact.add_reference("http://example.com/file1.txt")
 
-    assert artifact.digest == "e73d6d2294e0e6a526c56c5a24cfc890"
+    assert artifact.digest == "48237ccc050a88af9dcd869dd5a7e9f4"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "file1.txt": {
@@ -639,7 +617,7 @@ def test_add_reference_named_local_file(tmp_path, artifact):
 
     artifact.add_reference(uri, name="great-file.txt")
 
-    assert artifact.digest == "5222f22abda0a6ff806ca38783edb453"
+    assert artifact.digest == "585b9ada17797e37c9cbab391e69b8c5"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "great-file.txt": {
@@ -653,7 +631,7 @@ def test_add_reference_named_local_file(tmp_path, artifact):
 def test_add_reference_unknown_handler(artifact):
     artifact.add_reference("ref://example.com/somefile.txt", name="ref")
 
-    assert artifact.digest == "4f25da86e90d1b13f582fb81190cfa3c"
+    assert artifact.digest == "410ade94865e89ebe1f593f4379ac228"
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
@@ -802,20 +780,15 @@ def test_add_obj_wbimage_no_classes(im_path: str, artifact: Artifact):
         artifact.add(wb_image, "my-image")
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_obj_wbimage(digest_algorithm, im_path: str, artifact: Artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_obj_wbimage(artifact, im_path: str):
     wb_image = wandb.Image(
         im_path,
         classes=[{"id": 0, "name": "person"}],
     )
     artifact.add(wb_image, "my-image")
 
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "c9a97125b7449fb9a7f7890940b7cde2"
         manifest_contents = artifact.manifest.to_manifest_json()["contents"]
         assert manifest_contents == {
@@ -855,15 +828,10 @@ def test_add_obj_wbimage(digest_algorithm, im_path: str, artifact: Artifact):
 
 
 @mark.parametrize("overwrite", [True, False])
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
 def test_add_obj_wbimage_again_after_edit(
-    tmp_path, assets_path, copy_asset, overwrite, artifact, digest_algorithm
+    tmp_path, assets_path, copy_asset, overwrite, artifact
 ):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
     orig_path1 = assets_path("test.png")
     orig_path2 = assets_path("2x2.png")
     assert filecmp.cmp(orig_path1, orig_path2) is False  # Consistency check
@@ -882,7 +850,7 @@ def test_add_obj_wbimage_again_after_edit(
     manifest_contents1 = artifact.manifest.to_manifest_json()["contents"]
     digest1 = artifact.digest
 
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert digest1 == "1f1ca302bcc7aa196c5b4562daa88c82"
     else:
         assert digest1 == "2a7a8a7f29c929fe05b57983a2944fca"
@@ -906,13 +874,8 @@ def test_add_obj_wbimage_again_after_edit(
     assert manifest_contents1.keys() == manifest_contents2.keys()
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_obj_using_brackets(digest_algorithm, im_path: str, artifact: Artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_obj_using_brackets(artifact, im_path: str):
     wb_image = wandb.Image(
         im_path,
         classes=[{"id": 0, "name": "person"}],
@@ -920,7 +883,7 @@ def test_add_obj_using_brackets(digest_algorithm, im_path: str, artifact: Artifa
     artifact["my-image"] = wb_image
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "c9a97125b7449fb9a7f7890940b7cde2"
         assert manifest_contents == {
             "media/classes/65347c6442e21b09b198d62e080e46ce_cls.classes.json": {
@@ -1017,21 +980,14 @@ def test_deduplicate_wbimagemask_from_array(artifact, add_duplicate):
         assert len(artifact.manifest.entries) == 4
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_obj_wbimage_classes_obj(
-    digest_algorithm, im_path: str, artifact: Artifact
-):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_obj_wbimage_classes_obj(artifact, im_path: str):
     classes = wandb.Classes([{"id": 0, "name": "person"}])
     wb_image = wandb.Image(im_path, classes=classes)
     artifact.add(wb_image, "my-image")
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert manifest_contents == {
             "media/classes/65347c6442e21b09b198d62e080e46ce_cls.classes.json": {
                 "digest": "+xqgbLA2igrfKWtbRYuOPw==",
@@ -1066,22 +1022,15 @@ def test_add_obj_wbimage_classes_obj(
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_obj_wbimage_classes_obj_already_added(
-    digest_algorithm, im_path: str, artifact: Artifact
-):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_obj_wbimage_classes_obj_already_added(artifact, im_path: str):
     classes = wandb.Classes([{"id": 0, "name": "person"}])
     artifact.add(classes, "my-classes")
     wb_image = wandb.Image(im_path, classes=classes)
     artifact.add(wb_image, "my-image")
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert manifest_contents == {
             "my-classes.classes.json": {
                 "digest": "+xqgbLA2igrfKWtbRYuOPw==",
@@ -1125,21 +1074,14 @@ def test_add_obj_wbimage_classes_obj_already_added(
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_obj_wbimage_image_already_added(
-    digest_algorithm, im_path: str, artifact: Artifact
-):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_obj_wbimage_image_already_added(artifact, im_path: str):
     artifact.add_file(im_path)
     wb_image = wandb.Image(im_path, classes=[{"id": 0, "name": "person"}])
     artifact.add(wb_image, "my-image")
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert manifest_contents == {
             "2x2.png": {
                 "digest": "A+ER///ySqfqzroxc022rA==",
@@ -1171,13 +1113,8 @@ def test_add_obj_wbimage_image_already_added(
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_obj_wbtable_images(digest_algorithm, im_path: str, artifact: Artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_obj_wbtable_images(artifact, im_path: str):
     wb_image = wandb.Image(im_path, classes=[{"id": 0, "name": "person"}])
     wb_table = wandb.Table(["examples"])
     wb_table.add_data(wb_image)
@@ -1185,7 +1122,7 @@ def test_add_obj_wbtable_images(digest_algorithm, im_path: str, artifact: Artifa
     artifact.add(wb_table, "my-table")
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert manifest_contents == {
             "media/classes/65347c6442e21b09b198d62e080e46ce_cls.classes.json": {
                 "digest": "+xqgbLA2igrfKWtbRYuOPw==",
@@ -1217,13 +1154,8 @@ def test_add_obj_wbtable_images(digest_algorithm, im_path: str, artifact: Artifa
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_obj_wbtable_images_duplicate_name(digest_algorithm, assets_path, artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_obj_wbtable_images_duplicate_name(artifact, assets_path):
     img_1 = str(assets_path("2x2.png"))
     img_2 = str(assets_path("test2.png"))
 
@@ -1240,7 +1172,7 @@ def test_add_obj_wbtable_images_duplicate_name(digest_algorithm, assets_path, ar
     artifact.add(wb_table, "my-table")
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert manifest_contents == {
             "media/images/641e917f31888a48f546/img.png": {
                 "digest": "A+ER///ySqfqzroxc022rA==",
@@ -1272,20 +1204,15 @@ def test_add_obj_wbtable_images_duplicate_name(digest_algorithm, assets_path, ar
         }
 
 
-@mark.parametrize(
-    "digest_algorithm",
-    ArtifactDigestAlgorithm,
-)
-def test_add_partition_folder(digest_algorithm, artifact):
-    artifact._digest_algorithm = digest_algorithm
-    artifact.manifest.digest_algorithm = digest_algorithm
+@mark.parametrize("artifact", ["MD5", "XXH128"], indirect=True)
+def test_add_partition_folder(artifact):
     table_name = "dataset"
     table_parts_dir = "dataset_parts"
 
     partition_table = PartitionedTable(parts_path=table_parts_dir)
     artifact.add(partition_table, table_name)
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
-    if digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+    if artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
         assert artifact.digest == "297c4e4629f16a087c500de7e66d6d9b"
         assert manifest_contents == {
             "dataset.partitioned-table.json": {

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -956,7 +956,10 @@ def test_draft_inherits_digest_algorithm(api: Api):
 
     parent = api.artifact(f"{project}/my-sample-portfolio:latest")
     draft = parent.new_draft()
-    assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128
+    if server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM):
+        assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128
+    else:
+        assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_MD5
 
 
 def test_artifact_upload_with_fallback(api: Api):

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -330,8 +330,9 @@ def test_uploaded_artifacts_are_unstaged(temp_staging_dir: Path):
     assert dir_size(temp_staging_dir) == 0
 
 
+@mark.parametrize("digest_algorithm", ["MD5", "XXH128"])
 def test_large_manifests_passed_by_file(
-    monkeypatch: MonkeyPatch, mocker: MockerFixture, api: Api
+    monkeypatch: MonkeyPatch, mocker: MockerFixture, api: Api, digest_algorithm: str
 ):
     writer_spy = mocker.spy(
         wandb.sdk.interface.interface.InterfaceBase,
@@ -345,7 +346,9 @@ def test_large_manifests_passed_by_file(
 
     content = "test content\n"
     with wandb.init() as run:
-        artifact = Artifact(name="large-manifest", type="dataset")
+        artifact = Artifact(
+            name="large-manifest", type="dataset", digest_algorithm=digest_algorithm
+        )
         with artifact.new_file("test_file.txt") as f:
             f.write(content)
         artifact.manifest.entries["test_file.txt"].extra["test_key"] = {"x": 1}
@@ -363,7 +366,10 @@ def test_large_manifests_passed_by_file(
         assert len(artifact.manifest) == 1
         entry = artifact.manifest.entries.get("test_file.txt")
         assert entry is not None
-        if server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM):
+        if (
+            server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM)
+            and digest_algorithm == "XXH128"
+        ):
             assert entry.digest == xxh128_string(content)
         else:
             assert entry.digest == md5_string(content)
@@ -939,9 +945,7 @@ def test_artifact_multipart_download_refresh_presigned_url(
 
 
 def test_draft_inherits_digest_algorithm(api: Api):
-    art = Artifact("test-artifact", "test-type")
-    # Simulate a committed artifact with MD5 entries
-    art._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
+    art = Artifact("test-artifact", "test-type", digest_algorithm="XXH128")
     with art.new_file("file.txt", "w") as f:
         f.write("hello")
 
@@ -952,7 +956,7 @@ def test_draft_inherits_digest_algorithm(api: Api):
 
     parent = api.artifact(f"{project}/my-sample-portfolio:latest")
     draft = parent.new_draft()
-    assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_MD5
+    assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128
 
 
 def test_artifact_upload_with_fallback(api: Api):
@@ -970,7 +974,7 @@ def test_artifact_upload_with_fallback(api: Api):
     assert artifact.digest_algorithm == ArtifactDigestAlgorithm.MANIFEST_MD5
 
     # upload a second version of this artifact
-    artifact = Artifact("test-artifact", type="dataset")
+    artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
 
@@ -1003,7 +1007,7 @@ def test_artifact_upload_with_fallback(api: Api):
 
 
 def test_artifact_upload_with_correct_digests(api: Api):
-    artifact = Artifact("test-artifact", type="dataset")
+    artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
 
@@ -1055,7 +1059,7 @@ def test_artifact_new_draft_mixed_digest_algorithms(api: Api):
     if not server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM):
         return
 
-    artifact = Artifact("test-artifact", type="dataset")
+    artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
     assert artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
@@ -1112,7 +1116,7 @@ def test_offline_artifact_legacy_upload_hashes_correctly(
     Path("file2.txt").write_text("hi")
 
     with wandb.init(mode="offline", project="test") as run:
-        artifact = Artifact("test-artifact", type="dataset")
+        artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
         artifact.add_file("file1.txt")
         artifact.add_file("file2.txt")
 

--- a/tests/system_tests/test_artifacts/test_wandb_run_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_run_artifacts.py
@@ -255,12 +255,16 @@ def test_wandb_artifact_config_set_item(user: str, test_settings, api: Api):
     }
 
 
-def test_use_artifact(user, test_settings, api: Api):
+@mark.parametrize("digest_algorithm", ["MD5", "XXH128"])
+def test_use_artifact(user, test_settings, api: Api, digest_algorithm: str):
     with wandb.init(settings=test_settings()) as run:
-        artifact = Artifact("arti", type="dataset")
+        artifact = Artifact("arti", type="dataset", digest_algorithm=digest_algorithm)
         run.use_artifact(artifact)
         artifact.wait()
-        if server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM):
+        if (
+            server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM)
+            and digest_algorithm == "XXH128"
+        ):
             assert artifact.digest == "f13c5dd8602ab5d18a0c87ce730a735e"
         else:
             assert artifact.digest == "64e7c61456b10382e2f3b571ac24b659"

--- a/tests/unit_tests/test_artifacts/test_references_gcs.py
+++ b/tests/unit_tests/test_artifacts/test_references_gcs.py
@@ -67,7 +67,7 @@ def test_add_gs_reference_object(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb")
 
-    assert artifact.digest == "b16609518f60b258cdd4c93f7c6dba0a"
+    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {
@@ -97,7 +97,7 @@ def test_add_gs_reference_object_with_version(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb#2")
 
-    assert artifact.digest == "b16609518f60b258cdd4c93f7c6dba0a"
+    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {
@@ -113,7 +113,7 @@ def test_add_gs_reference_object_with_name(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb", name="renamed.pb")
 
-    assert artifact.digest == "2d4433ec4e23d6623808c271c687f015"
+    assert artifact.digest == "bd85fe009dc9e408a5ed9b55c95f47b2"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "renamed.pb": {
@@ -129,7 +129,7 @@ def test_add_gs_reference_path(capsys, artifact):
     mock_gcs(artifact, path=True)
     artifact.add_reference("gs://my-bucket/")
 
-    assert artifact.digest == "84610ac4c1a560ed3a66ee66a85bd5cc"
+    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {
@@ -153,7 +153,7 @@ def test_add_gs_reference_object_no_md5(artifact):
     mock_gcs(artifact, hash=False)
     artifact.add_reference("gs://my-bucket/my_object.pb")
 
-    assert artifact.digest == "b16609518f60b258cdd4c93f7c6dba0a"
+    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {

--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -360,8 +360,6 @@ def test_wandb_storage_policy_load_file_uses_cache_md5(artifact_file_cache, tmp_
 
     # We need to pass an artifact, but this test doesn't actually use it
     empty_artifact = Artifact("test", type="dataset")
-    empty_artifact._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
-    empty_artifact.manifest.digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
 
     local_path = policy.load_file(empty_artifact, entry)
 
@@ -390,7 +388,7 @@ def test_wandb_storage_policy_load_file_uses_cache_xxh128(
     )
 
     # We need to pass an artifact, but this test doesn't actually use it
-    empty_artifact = Artifact("test", type="dataset")
+    empty_artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
 
     local_path = policy.load_file(empty_artifact, entry)
 

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -746,7 +746,7 @@ def test_artifact_multipart_download_writer_not_on_shared_executor():
 def test_offline_artifact_uses_xxh128():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset")
+    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
 
     artifact.add_file(str(f))
     entry = artifact.manifest.entries["file.txt"]
@@ -755,7 +755,7 @@ def test_offline_artifact_uses_xxh128():
 
 
 def test_digest_algorithm_with_reference_entries():
-    artifact = Artifact("test-artifact", "test-type")
+    artifact = Artifact("test-artifact", "test-type", digest_algorithm="XXH128")
 
     f = Path("file.txt")
     f.write_text("hello")
@@ -779,10 +779,7 @@ def test_digest_algorithm_with_reference_entries():
 def test_manifest_digest_uses_xxh128_for_xxh128_artifact():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset")
-    # Force xxh128 algorithm
-    artifact._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128
-    artifact.manifest.digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128
+    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
     artifact.add_file(str(f))
 
     file_digest = xxh128_string("hello")
@@ -794,10 +791,7 @@ def test_manifest_digest_uses_xxh128_for_xxh128_artifact():
 def test_manifest_digest_uses_md5_for_md5_artifact():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset")
-    # Force MD5 algorithm
-    artifact._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
-    artifact.manifest.digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
+    artifact = Artifact("test", type="dataset", digest_algorithm="MD5")
     artifact.add_file(str(f))
 
     file_digest = md5_string("hello")
@@ -831,9 +825,7 @@ def test_entry_digest_algorithm_reads_extra_tag(tag, expected):
 def test_add_file_tags_xxh128_entries():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset")
-    artifact._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128
-    artifact.manifest.digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128
+    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
 
     entry = artifact.add_file(str(f))
 
@@ -845,8 +837,6 @@ def test_add_file_leaves_md5_entries_untagged():
     f = Path("file.txt")
     f.write_text("hello")
     artifact = Artifact("test", type="dataset")
-    artifact._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
-    artifact.manifest.digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
 
     entry = artifact.add_file(str(f))
 
@@ -860,9 +850,7 @@ def test_mixed_manifest_round_trip_preserves_per_entry_algorithm():
 
     f = Path("xxh.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset")
-    artifact._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128
-    artifact.manifest.digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128
+    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
     artifact.add_file(str(f))
 
     # Simulate an entry carried over untagged from an older (md5) SDK, as
@@ -896,7 +884,7 @@ def test_hash_contents_with_md5_correctly_rehashes_xxh128_entries():
     f2 = Path("file2.txt")
     f2.write_text("hi")
 
-    artifact = Artifact("test", type="dataset")
+    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
     artifact.add_file(str(f))
     artifact.add_file(str(f2))
     assert (

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -397,8 +397,7 @@ def test_image_refs(mock_reference_get_responses):
     }
     manifest_expected = {
         "image_ref.image-file.json": {
-            "digest": "DRQxgg4q+7eL+jn/orhvTA==",
-            "extra": {"alg": "XXH128"},
+            "digest": "SZvdv5ouAEq2DEOgVBwOog==",
             "size": 173,
         },
         str(Path("media/images/75c13e5a637fb8052da9/puppy.jpg")): {

--- a/wandb/sdk/artifacts/_internal_artifact.py
+++ b/wandb/sdk/artifacts/_internal_artifact.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import re
 from base64 import urlsafe_b64encode
-from typing import Any, Final
+from typing import Any, Final, Literal
 from zlib import crc32
 
-from wandb.sdk.artifacts._generated.enums import ArtifactDigestAlgorithm
 from wandb.sdk.artifacts.artifact import Artifact
-from wandb.sdk.artifacts.artifact_manifest_entry import DIGEST_ALGORITHM_TO_STR
 
 PLACEHOLDER: Final[str] = "PLACEHOLDER"
 
@@ -48,15 +46,13 @@ class InternalArtifact(Artifact):
         metadata: dict[str, Any] | None = None,
         incremental: bool = False,
         use_as: str | None = None,
-        digest_algorithm: ArtifactDigestAlgorithm = ArtifactDigestAlgorithm.MANIFEST_MD5,
+        digest_algorithm: Literal["MD5", "XXH128"] = "MD5",
     ) -> None:
         sanitized_name = sanitize_artifact_name(name)
 
-        digest_algorithm_str = DIGEST_ALGORITHM_TO_STR.get(digest_algorithm, "MD5")
-
         if type == "job":
             # Match go-core JobBuilder / ArtifactBuilder, which always uses MD5.
-            digest_algorithm_str = "MD5"
+            digest_algorithm = "MD5"
 
         super().__init__(
             sanitized_name,
@@ -65,6 +61,6 @@ class InternalArtifact(Artifact):
             metadata,
             incremental,
             use_as,
-            digest_algorithm=digest_algorithm_str,
+            digest_algorithm=digest_algorithm,
         )
         self._type = type

--- a/wandb/sdk/artifacts/_internal_artifact.py
+++ b/wandb/sdk/artifacts/_internal_artifact.py
@@ -48,7 +48,7 @@ class InternalArtifact(Artifact):
         metadata: dict[str, Any] | None = None,
         incremental: bool = False,
         use_as: str | None = None,
-        digest_algorithm: ArtifactDigestAlgorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128,
+        digest_algorithm: ArtifactDigestAlgorithm = ArtifactDigestAlgorithm.MANIFEST_MD5,
     ) -> None:
         sanitized_name = sanitize_artifact_name(name)
 
@@ -68,4 +68,3 @@ class InternalArtifact(Artifact):
             digest_algorithm=digest_algorithm_str,
         )
         self._type = type
-

--- a/wandb/sdk/artifacts/_internal_artifact.py
+++ b/wandb/sdk/artifacts/_internal_artifact.py
@@ -7,6 +7,7 @@ from zlib import crc32
 
 from wandb.sdk.artifacts._generated.enums import ArtifactDigestAlgorithm
 from wandb.sdk.artifacts.artifact import Artifact
+from wandb.sdk.artifacts.artifact_manifest_entry import DIGEST_ALGORITHM_TO_STR
 
 PLACEHOLDER: Final[str] = "PLACEHOLDER"
 
@@ -50,15 +51,21 @@ class InternalArtifact(Artifact):
         digest_algorithm: ArtifactDigestAlgorithm = ArtifactDigestAlgorithm.MANIFEST_XXH128,
     ) -> None:
         sanitized_name = sanitize_artifact_name(name)
+
+        digest_algorithm_str = DIGEST_ALGORITHM_TO_STR.get(digest_algorithm, "MD5")
+
+        if type == "job":
+            # Match go-core JobBuilder / ArtifactBuilder, which always uses MD5.
+            digest_algorithm_str = "MD5"
+
         super().__init__(
-            sanitized_name, PLACEHOLDER, description, metadata, incremental, use_as
+            sanitized_name,
+            PLACEHOLDER,
+            description,
+            metadata,
+            incremental,
+            use_as,
+            digest_algorithm=digest_algorithm_str,
         )
         self._type = type
 
-        if self._type == "job":
-            # Match go-core JobBuilder / ArtifactBuilder, which always uses MD5.
-            digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
-
-        self._digest_algorithm = digest_algorithm
-        if self.manifest is not None:
-            self.manifest.digest_algorithm = digest_algorithm

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -258,8 +258,8 @@ class Artifact:
         if self._digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
             termwarn(
                 "Creating an artifact with the XXH128 digest algorithm."
-                + " `artifact.verify()` will always fail for this artifact on wandb"
-                + " versions before 0.28.3."
+                + " Calling `artifact.verify()` for this artifact on wandb"
+                + " versions before 0.29.0 will fail."
             )
 
         self._manifest: ArtifactManifest | None = ArtifactManifestV1(

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -157,7 +157,7 @@ class Artifact:
             existing artifact.
         digest_algorithm: The digest algorithm to use for the artifact. Defaults to MD5.
             If set to XXH128, the artifact will be hashed using the XXH128 algorithm
-            unless it is part of a sequence that is already using MD5. Calls to
+            unless it is part of a collection that is already using MD5. Calls to
             `artifact.verify()` on SDK versions before 0.28.3 will always fail on
             XXH128 artifacts.
         use_as: Deprecated.

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2331,6 +2331,15 @@ class Artifact:
             ArtifactNotLoggedError: If the artifact is not logged.
             ValueError: If the verification fails.
         """
+        from wandb.analytics import TelemetryRecorder
+        from wandb.analytics.opentelemetry.opentelemetry_proxy import (
+            LowCardinalityAttributes,
+        )
+
+        TelemetryRecorder(service_api=self._get_service_api()).increment_counter(
+            "artifact_verify", LowCardinalityAttributes()
+        )
+
         root = root or self._default_root()
 
         for dirpath, _, files in os.walk(root):

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -255,6 +255,12 @@ class Artifact:
         self._digest_algorithm = _STR_TO_DIGEST_ALGORITHM.get(
             digest_algorithm, ArtifactDigestAlgorithm.MANIFEST_MD5
         )
+        if self._digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
+            termwarn(
+                "Creating an artifact with the XXH128 digest algorithm."
+                + " `artifact.verify()` will always fail for this artifact on wandb"
+                + " versions before 0.28.3."
+            )
 
         self._manifest: ArtifactManifest | None = ArtifactManifestV1(
             storage_policy=make_storage_policy(region=storage_region),

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -89,10 +89,10 @@ from .artifact_instance_cache import (
 )
 from .artifact_manifest import ArtifactManifest
 from .artifact_manifest_entry import (
+    _STR_TO_DIGEST_ALGORITHM,
     DIGEST_ALGORITHM_EXTRA_KEY,
     DIGEST_ALGORITHM_TO_STR,
     ArtifactManifestEntry,
-    _STR_TO_DIGEST_ALGORITHM,
 )
 from .artifact_manifests.artifact_manifest_v1 import ArtifactManifestV1
 from .artifact_state import ArtifactState
@@ -155,7 +155,11 @@ class Artifact:
             than 100 total keys.
         incremental: Use `Artifact.new_draft()` method instead to modify an
             existing artifact.
-        digest_algorithm: The digest algorithm to use for the artifact. Defaults to XXH128.
+        digest_algorithm: The digest algorithm to use for the artifact. Defaults to MD5.
+            If set to XXH128, the artifact will be hashed using the XXH128 algorithm
+            unless it is part of a sequence that is already using MD5. Calls to
+            `artifact.verify()` on SDK versions before 0.28.3 will always fail on
+            XXH128 artifacts.
         use_as: Deprecated.
 
     Returns:
@@ -174,7 +178,7 @@ class Artifact:
         incremental: bool = False,
         use_as: str | None = None,
         storage_region: str | None = None,
-        digest_algorithm: Literal["MD5", "XXH128"] = "XXH128",
+        digest_algorithm: Literal["MD5", "XXH128"] = "MD5",
     ) -> None:
         from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 
@@ -249,7 +253,7 @@ class Artifact:
         self._digest: str | None = None
 
         self._digest_algorithm = _STR_TO_DIGEST_ALGORITHM.get(
-            digest_algorithm, ArtifactDigestAlgorithm.MANIFEST_XXH128
+            digest_algorithm, ArtifactDigestAlgorithm.MANIFEST_MD5
         )
 
         self._manifest: ArtifactManifest | None = ArtifactManifestV1(

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -158,7 +158,7 @@ class Artifact:
         digest_algorithm: The digest algorithm to use for the artifact. Defaults to MD5.
             If set to XXH128, the artifact will be hashed using the XXH128 algorithm
             unless it is part of a collection that is already using MD5. Calls to
-            `artifact.verify()` on SDK versions before 0.28.3 will always fail on
+            `artifact.verify()` on SDK versions before 0.29.0 will always fail on
             XXH128 artifacts.
         use_as: Deprecated.
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -92,6 +92,7 @@ from .artifact_manifest_entry import (
     DIGEST_ALGORITHM_EXTRA_KEY,
     DIGEST_ALGORITHM_TO_STR,
     ArtifactManifestEntry,
+    _STR_TO_DIGEST_ALGORITHM,
 )
 from .artifact_manifests.artifact_manifest_v1 import ArtifactManifestV1
 from .artifact_state import ArtifactState
@@ -154,6 +155,7 @@ class Artifact:
             than 100 total keys.
         incremental: Use `Artifact.new_draft()` method instead to modify an
             existing artifact.
+        digest_algorithm: The digest algorithm to use for the artifact. Defaults to XXH128.
         use_as: Deprecated.
 
     Returns:
@@ -172,6 +174,7 @@ class Artifact:
         incremental: bool = False,
         use_as: str | None = None,
         storage_region: str | None = None,
+        digest_algorithm: Literal["MD5", "XXH128"] = "XXH128",
     ) -> None:
         from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 
@@ -244,8 +247,9 @@ class Artifact:
         # populated locally, it should take priority when determining these values.
         self._size: NonNegativeInt | None = None
         self._digest: str | None = None
-        self._digest_algorithm: ArtifactDigestAlgorithm = (
-            ArtifactDigestAlgorithm.MANIFEST_XXH128
+
+        self._digest_algorithm = _STR_TO_DIGEST_ALGORITHM.get(
+            digest_algorithm, ArtifactDigestAlgorithm.MANIFEST_XXH128
         )
 
         self._manifest: ArtifactManifest | None = ArtifactManifestV1(

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -461,7 +461,7 @@ def _make_code_artifact(
         name=artifact_name,
         type="code",
         description="Code artifact for job",
-        digest_algorithm=ArtifactDigestAlgorithm.MANIFEST_MD5,
+        digest_algorithm="MD5",
     )
 
     try:


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

This PR makes calculating the artifact digest with XXH128 opt in since `artifact.verify` on older versions doesn't work with newer artifacts using XXH128. We plan to roll this out as opt in for now and eventually default it to XXH128.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
