### PR TITLE
feat(leet): delete runs with typed confirmation

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - The automations API now supports team and organization scopes. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12197, https://github.com/wandb/wandb/pull/12194)
 - The automations API now supports creating and editing automations whose scope is a `Registry` object (@tonyyli-wandb in https://github.com/wandb/wandb/pull/10867)
 - Press `g` in LEET to draw guides behind line charts: a dotted background or horizontal lines aligned with the axis ticks. The choice is saved and can also be set with `chart_guides` in `wandb leet config`. (@dmitryduev in https://github.com/wandb/wandb/pull/12463)
+- Press Backspace (or Delete) on a run in LEET's workspace view to delete it from local disk. A confirmation dialog asks you to type DELETE first, so a stray keypress can't destroy anything. (@dmitryduev in https://github.com/wandb/wandb/pull/12567)
 
 ### Changed
 

--- a/core/internal/leet/deleterunmodal.go
+++ b/core/internal/leet/deleterunmodal.go
@@ -1,0 +1,158 @@
+package leet
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// deleteRunModalMinWidth is the minimum inner (content) width of the modal.
+const deleteRunModalMinWidth = 44
+
+// deleteRunConfirmText is what the user must type to confirm a deletion.
+const deleteRunConfirmText = "DELETE"
+
+// DeleteRunModal is the confirmation dialog for permanently deleting a run
+// directory from disk.
+//
+// To guard against accidental deletion, the user must type DELETE and
+// press Enter. While active, the modal captures all key input.
+type DeleteRunModal struct {
+	active   bool
+	blocked  bool   // run is live; deletion is refused
+	deleting bool   // removal is in flight
+	errText  string // non-empty after a failed deletion
+
+	runKey string // run directory name being deleted
+	typed  string
+}
+
+// Open activates the modal for the given run directory.
+//
+// A live run cannot be deleted; the modal then opens in a blocked state
+// that only explains why.
+func (m *DeleteRunModal) Open(runKey string, live bool) {
+	*m = DeleteRunModal{
+		active:  true,
+		blocked: live,
+		runKey:  runKey,
+	}
+}
+
+// Close deactivates the modal and clears its state.
+func (m *DeleteRunModal) Close() { *m = DeleteRunModal{} }
+
+// Active reports whether the modal is visible and capturing key input.
+func (m *DeleteRunModal) Active() bool { return m.active }
+
+// RunKey returns the run directory name the modal is targeting.
+func (m *DeleteRunModal) RunKey() string { return m.runKey }
+
+// Fail keeps the modal open and displays a deletion error.
+func (m *DeleteRunModal) Fail(err error) {
+	m.deleting = false
+	m.errText = fmt.Sprintf("%v", err)
+}
+
+// HandleKey processes a key press while the modal is active.
+//
+// Returns true when the user confirmed the deletion (typed DELETE and
+// pressed Enter); the caller is expected to start the actual deletion.
+func (m *DeleteRunModal) HandleKey(msg tea.KeyPressMsg) bool {
+	if m.deleting {
+		return false
+	}
+	if m.blocked || m.errText != "" {
+		switch msg.Code {
+		case tea.KeyEsc, tea.KeyEnter:
+			m.Close()
+		}
+		return false
+	}
+
+	switch msg.Code {
+	case tea.KeyEsc:
+		m.Close()
+	case tea.KeyEnter:
+		if m.typed == deleteRunConfirmText {
+			m.deleting = true
+			return true
+		}
+	case tea.KeyBackspace:
+		m.typed = trimLastRune(m.typed)
+	default:
+		if msg.Text != "" {
+			m.typed += msg.Text
+		}
+	}
+	return false
+}
+
+// View renders the modal box. The caller positions it on screen.
+func (m *DeleteRunModal) View(maxWidth int) string {
+	innerW := max(lipgloss.Width(m.runKey), deleteRunModalMinWidth)
+	innerW = min(innerW, maxWidth-deleteRunModalBorderStyle.GetHorizontalFrameSize())
+	innerW = max(innerW, 1)
+
+	lines := []string{
+		deleteRunModalTitleStyle.Render("Delete run"),
+		"",
+		deleteRunModalRunStyle.Render(truncateValue(m.runKey, innerW)),
+		"",
+	}
+	lines = append(lines, m.bodyLines()...)
+
+	return deleteRunModalBorderStyle.
+		Width(innerW).
+		Render(strings.Join(lines, "\n"))
+}
+
+// bodyLines renders the state-dependent portion of the modal.
+func (m *DeleteRunModal) bodyLines() []string {
+	switch {
+	case m.blocked:
+		return []string{
+			labelStyle.Render("This run appears to be live and cannot be deleted."),
+			"",
+			navInfoStyle.Render("Esc: close"),
+		}
+	case m.deleting:
+		return []string{labelStyle.Render("Deleting…")}
+	case m.errText != "":
+		return []string{
+			deleteRunModalDangerStyle.Render("Delete failed: " + m.errText),
+			"",
+			navInfoStyle.Render("Esc: close"),
+		}
+	default:
+		hint := "Esc: cancel"
+		if m.typed == deleteRunConfirmText {
+			hint = "Enter: delete • " + hint
+		}
+		return []string{
+			labelStyle.Render("This permanently deletes the run directory from disk."),
+			"",
+			labelStyle.Render(fmt.Sprintf("Type %s to confirm:", deleteRunConfirmText)),
+			deleteRunModalInputStyle.Render("> "+m.typed) + string(mediumShadeBlock),
+			"",
+			navInfoStyle.Render(hint),
+		}
+	}
+}
+
+// overlayCentered composites overlay centered on top of base.
+func overlayCentered(base, overlay string, width, height int) string {
+	x := max((width-lipgloss.Width(overlay))/2, 0)
+	y := max((height-lipgloss.Height(overlay))/2, 0)
+
+	// Layer offsets are resolved by the Compositor; drawing layers directly
+	// onto a canvas would ignore X/Y/Z.
+	canvas := lipgloss.NewCanvas(width, height)
+	canvas.Compose(lipgloss.NewCompositor(
+		lipgloss.NewLayer(base),
+		lipgloss.NewLayer(overlay).X(x).Y(y).Z(1),
+	))
+	return canvas.Render()
+}

--- a/core/internal/leet/deleterunmodal_test.go
+++ b/core/internal/leet/deleterunmodal_test.go
@@ -1,0 +1,167 @@
+package leet_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/internal/leet"
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+const (
+	deleteTestRunKey = "run-20260101_000000-abc123"
+	deleteTestRunID  = "abc123"
+)
+
+// newWorkspaceWithRunDir builds a workspace over a wandb dir that contains a
+// single real run directory, with the runs list focused on it.
+func newWorkspaceWithRunDir(t *testing.T) (*leet.Workspace, string) {
+	t.Helper()
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	wandbDir := t.TempDir()
+	runDir := filepath.Join(wandbDir, deleteTestRunKey)
+	require.NoError(t, os.MkdirAll(runDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(runDir, "run-"+deleteTestRunID+".wandb"), []byte("x"), 0o644))
+
+	w := leet.NewWorkspace(wandbDir, cfg, logger)
+	_ = w.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	_ = w.Update(leet.WorkspaceRunDirsMsg{RunKeys: []string{deleteTestRunKey}})
+	return w, runDir
+}
+
+func pressKey(w *leet.Workspace, code rune) tea.Cmd {
+	return w.Update(tea.KeyPressMsg{Code: code})
+}
+
+func TestWorkspace_DeleteRun_Confirmed(t *testing.T) {
+	w, runDir := newWorkspaceWithRunDir(t)
+
+	require.Nil(t, pressKey(w, tea.KeyBackspace))
+	require.True(t, w.IsConfirmingDelete(), "expected modal open after backspace")
+
+	typeWorkspaceFilter(t, w, "DELETE")
+	cmd := pressKey(w, tea.KeyEnter)
+	require.NotNil(t, cmd, "expected a delete command after typed confirmation")
+
+	msg := cmd()
+	deleted, ok := msg.(leet.WorkspaceRunDeletedMsg)
+	require.True(t, ok, "expected WorkspaceRunDeletedMsg, got %T", msg)
+	require.NoError(t, deleted.Err)
+	require.NoDirExists(t, runDir, "expected run directory removed from disk")
+
+	_ = w.Update(msg)
+	require.False(t, w.IsConfirmingDelete(), "expected modal closed after deletion")
+	require.Empty(t, w.TestFilteredRunKeys(), "expected run dropped from the list")
+	require.Equal(t, 0, w.TestSelectedRunCount())
+}
+
+func TestWorkspace_DeleteRun_WrongTextDoesNotDelete(t *testing.T) {
+	w, runDir := newWorkspaceWithRunDir(t)
+
+	require.Nil(t, pressKey(w, tea.KeyBackspace))
+	require.True(t, w.IsConfirmingDelete())
+
+	// While the modal is open, global bindings must not fire: 'q' is typed
+	// text here, not quit.
+	typeWorkspaceFilter(t, w, "q")
+	require.True(t, w.IsConfirmingDelete())
+
+	require.Nil(t, pressKey(w, tea.KeyEnter), "Enter with wrong text must not delete")
+	require.True(t, w.IsConfirmingDelete(), "modal stays open on mismatched text")
+	require.DirExists(t, runDir)
+}
+
+func TestWorkspace_DeleteRun_EscCancels(t *testing.T) {
+	w, runDir := newWorkspaceWithRunDir(t)
+
+	require.Nil(t, pressKey(w, tea.KeyBackspace))
+	typeWorkspaceFilter(t, w, "DELETE")
+	require.Nil(t, pressKey(w, tea.KeyEsc))
+
+	require.False(t, w.IsConfirmingDelete(), "expected modal closed after Esc")
+	require.DirExists(t, runDir)
+	require.Equal(t, []string{deleteTestRunKey}, w.TestFilteredRunKeys())
+
+	// Global bindings work again: 'q' quits.
+	cmd := w.Update(keyRune('q'))
+	require.NotNil(t, cmd)
+	require.IsType(t, tea.QuitMsg{}, cmd())
+}
+
+func TestWorkspace_DeleteRun_LiveRunBlocked(t *testing.T) {
+	w, runDir := newWorkspaceWithRunDir(t)
+
+	// Mark the run as live: a RunMsg record transitions it to running.
+	run := leet.TestNewWorkspaceRun(deleteTestRunKey)
+	w.TestAttachRun(run, true)
+	w.TestHandleWorkspaceRecord(run, leet.RunMsg{ID: deleteTestRunID})
+
+	require.Nil(t, pressKey(w, tea.KeyBackspace))
+	require.True(t, w.IsConfirmingDelete())
+	require.True(t, w.TestDeleteModalBlocked(), "expected modal blocked for a live run")
+
+	// Typing DELETE and pressing Enter must not delete a live run.
+	typeWorkspaceFilter(t, w, "DELETE")
+	require.Nil(t, pressKey(w, tea.KeyEnter))
+	require.False(t, w.IsConfirmingDelete(), "Enter closes the blocked modal")
+	require.DirExists(t, runDir)
+}
+
+func TestWorkspace_DeleteRun_FailureKeepsModalOpen(t *testing.T) {
+	w, runDir := newWorkspaceWithRunDir(t)
+
+	require.Nil(t, pressKey(w, tea.KeyBackspace))
+	typeWorkspaceFilter(t, w, "DELETE")
+	require.NotNil(t, pressKey(w, tea.KeyEnter))
+
+	// Simulate a failed removal.
+	_ = w.Update(leet.WorkspaceRunDeletedMsg{
+		RunKey: deleteTestRunKey,
+		Err:    os.ErrPermission,
+	})
+	require.True(t, w.IsConfirmingDelete(), "expected modal open after failed delete")
+	require.NotEmpty(t, w.TestDeleteModalError())
+	require.Equal(t, []string{deleteTestRunKey}, w.TestFilteredRunKeys(),
+		"run stays listed after failed delete")
+	require.DirExists(t, runDir)
+
+	// Esc dismisses the error.
+	require.Nil(t, pressKey(w, tea.KeyEsc))
+	require.False(t, w.IsConfirmingDelete())
+}
+
+func TestModel_DeleteRunConfirmEnterDoesNotEnterRunView(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+
+	wandbDir := t.TempDir()
+	runDir := filepath.Join(wandbDir, deleteTestRunKey)
+	require.NoError(t, os.MkdirAll(runDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(runDir, "run-"+deleteTestRunID+".wandb"), []byte("x"), 0o644))
+
+	m := leet.NewModel(leet.ModelParams{
+		WandbDir: wandbDir,
+		Config:   cfg,
+		Logger:   logger,
+	})
+	_, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	_, _ = m.Update(leet.WorkspaceRunDirsMsg{RunKeys: []string{deleteTestRunKey}})
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	for _, r := range "DELETE" {
+		_, _ = m.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	require.False(t, m.TestInRunMode(),
+		"Enter confirming a delete must not switch to the run view")
+}

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -340,6 +340,11 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 					Description: "Clear runs filter",
 					Handler:     (*Workspace).handleClearRunsFilter,
 				},
+				{
+					Keys:        []string{"backspace", "delete"},
+					Description: "Delete run from disk (runs list focused; asks to confirm)",
+					Handler:     (*Workspace).handleDeleteRunKey,
+				},
 			},
 		},
 		{

--- a/core/internal/leet/messages.go
+++ b/core/internal/leet/messages.go
@@ -152,6 +152,13 @@ type WorkspaceRunOverviewPreloadedMsg struct {
 	Err    error
 }
 
+// WorkspaceRunDeletedMsg is emitted after an attempt to delete a run
+// directory from disk.
+type WorkspaceRunDeletedMsg struct {
+	RunKey string
+	Err    error
+}
+
 // WorkspaceInitErrMsg is emitted when a workspace run reader failed to initialize.
 // This keeps errors keyed to the specific run so the workspace can recover cleanly.
 type WorkspaceInitErrMsg struct {

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -291,7 +291,7 @@ func (m *Model) isAwaitingUserInput() bool {
 	}
 	switch m.mode {
 	case viewModeWorkspace:
-		return m.workspace.IsFiltering()
+		return m.workspace.IsFiltering() || m.workspace.IsConfirmingDelete()
 	case viewModeRun:
 		return m.run.IsFiltering()
 	default:

--- a/core/internal/leet/styles.go
+++ b/core/internal/leet/styles.go
@@ -811,6 +811,28 @@ var (
 	selectedRunInactiveStyle = lipgloss.NewStyle().Background(colorSelectedRunInactiveStyle)
 )
 
+// Delete-run confirmation modal styles.
+var (
+	// Color for destructive actions and their warnings.
+	colorDanger = AdaptiveColor{
+		Light: lipgloss.Color("#E85565"),
+		Dark:  lipgloss.Color("#FF7A88"),
+	}
+
+	deleteRunModalBorderStyle = lipgloss.NewStyle().
+					Border(lipgloss.RoundedBorder()).
+					BorderForeground(colorDanger).
+					Padding(1, 2)
+
+	deleteRunModalTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(colorDanger)
+
+	deleteRunModalRunStyle = lipgloss.NewStyle().Bold(true).Foreground(colorItemValue)
+
+	deleteRunModalInputStyle = lipgloss.NewStyle().Foreground(colorSubheading)
+
+	deleteRunModalDangerStyle = lipgloss.NewStyle().Foreground(colorDanger)
+)
+
 // Symon mode styles.
 var (
 	symonContainerStyle = lipgloss.NewStyle().

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -722,3 +722,14 @@ func (w *Workspace) TestFilteredRunKeys() []string {
 	}
 	return keys
 }
+
+// TestDeleteModalBlocked reports whether the delete-run modal refuses to
+// delete because the run is live.
+func (w *Workspace) TestDeleteModalBlocked() bool {
+	return w.deleteModal.blocked
+}
+
+// TestDeleteModalError returns the delete-run modal's error text.
+func (w *Workspace) TestDeleteModalError() string {
+	return w.deleteModal.errText
+}

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -60,6 +60,9 @@ type Workspace struct {
 
 	// TODO: mark live runs upon selection.
 
+	// deleteModal is the delete-run confirmation dialog.
+	deleteModal DeleteRunModal
+
 	// filter drives the runs sidebar search box.
 	filter *Filter
 	// runsFilterIndex caches searchable per-run metadata (name, project, config)
@@ -268,6 +271,9 @@ func (w *Workspace) Update(msg tea.Msg) tea.Cmd {
 	case WorkspaceRunDirsMsg:
 		return w.handleWorkspaceRunDirs(t)
 
+	case WorkspaceRunDeletedMsg:
+		return w.handleWorkspaceRunDeleted(t)
+
 	case WorkspaceRunOverviewPreloadedMsg:
 		return w.handleWorkspaceRunOverviewPreloaded(t)
 
@@ -352,13 +358,15 @@ func (w *Workspace) View() tea.View {
 	statusBar := w.renderStatusBar()
 
 	fullView := lipgloss.JoinVertical(lipgloss.Left, mainView, statusBar)
-	return tea.NewView(
-		lipgloss.Place(
-			w.width, w.height,
-			lipgloss.Left, lipgloss.Top,
-			fullView,
-		),
+	view := lipgloss.Place(
+		w.width, w.height,
+		lipgloss.Left, lipgloss.Top,
+		fullView,
 	)
+	if w.deleteModal.Active() {
+		view = overlayCentered(view, w.deleteModal.View(w.width), w.width, w.height)
+	}
+	return tea.NewView(view)
 }
 
 // Cleanup stops the workspace's heartbeat, file watchers, and open readers.
@@ -391,6 +399,11 @@ func (w *Workspace) IsFiltering() bool {
 		return true
 	}
 	return false
+}
+
+// IsConfirmingDelete reports whether the delete-run confirmation modal is open.
+func (w *Workspace) IsConfirmingDelete() bool {
+	return w.deleteModal.Active()
 }
 
 // SelectedRunWandbFile returns the full path to the .wandb file for the selected run.
@@ -1335,8 +1348,9 @@ func (w *Workspace) activeFocusStatus() []string {
 
 // buildHelpText builds the help text for the status bar.
 func (w *Workspace) buildHelpText() string {
-	// Hide help hint while any workspace-level filter / grid config is active.
-	if w.IsFiltering() || w.config.IsAwaitingGridConfig() {
+	// Hide help hint while any workspace-level filter / grid config / modal
+	// is capturing input.
+	if w.IsFiltering() || w.config.IsAwaitingGridConfig() || w.deleteModal.Active() {
 		return ""
 	}
 	return "h: help"

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -60,6 +61,11 @@ func (w *Workspace) handleMediaMouse(msg tea.MouseMsg, layout Layout) tea.Cmd {
 }
 
 func (w *Workspace) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
+	// The delete-run confirmation modal owns all key input while open.
+	if w.deleteModal.Active() {
+		return w.handleDeleteModalKey(msg)
+	}
+
 	// Filter mode takes priority.
 	if w.filter.IsActive() {
 		w.handleRunFilterKey(msg)
@@ -104,6 +110,11 @@ func (w *Workspace) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 }
 
 func (w *Workspace) handleMouse(msg tea.MouseMsg) tea.Cmd {
+	// Ignore mouse interaction while the delete-run modal is open.
+	if w.deleteModal.Active() {
+		return nil
+	}
+
 	mouse := msg.Mouse()
 	layout := w.computeViewports()
 
@@ -1183,6 +1194,78 @@ func (w *Workspace) handlePinRunKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	w.togglePin(runKey)
+	return nil
+}
+
+// ---- Run Deletion ----
+
+// handleDeleteRunKey opens the delete-run confirmation modal for the
+// highlighted run.
+func (w *Workspace) handleDeleteRunKey(tea.KeyPressMsg) tea.Cmd {
+	if !w.runSelectorActive() {
+		return nil
+	}
+	cur, ok := w.runs.CurrentItem()
+	if !ok {
+		return nil
+	}
+
+	run := w.runsByKey[cur.Key]
+	live := run != nil && run.state == RunStateRunning
+	w.deleteModal.Open(cur.Key, live)
+	return nil
+}
+
+// handleDeleteModalKey routes keys to the delete-run modal and starts the
+// deletion once the user confirms.
+func (w *Workspace) handleDeleteModalKey(msg tea.KeyPressMsg) tea.Cmd {
+	if !w.deleteModal.HandleKey(msg) {
+		return nil
+	}
+
+	runKey := w.deleteModal.RunKey()
+	if runKey == "" {
+		// Defensive: never let an empty key resolve to the wandb dir itself.
+		w.deleteModal.Close()
+		return nil
+	}
+
+	// Release the run's reader and watcher before removing files: open
+	// handles would block deletion on some platforms.
+	w.dropRun(runKey)
+	return w.deleteRunCmd(runKey)
+}
+
+// deleteRunCmd removes the run's directory from disk asynchronously.
+func (w *Workspace) deleteRunCmd(runKey string) tea.Cmd {
+	dir := filepath.Join(w.wandbDir, runKey)
+	return func() tea.Msg {
+		return WorkspaceRunDeletedMsg{RunKey: runKey, Err: os.RemoveAll(dir)}
+	}
+}
+
+// handleWorkspaceRunDeleted finalizes a run deletion attempt.
+func (w *Workspace) handleWorkspaceRunDeleted(msg WorkspaceRunDeletedMsg) tea.Cmd {
+	if msg.Err != nil {
+		w.logger.CaptureError(
+			"leet",
+			fmt.Errorf("workspace: delete run %s: %v", msg.RunKey, msg.Err),
+		)
+		w.deleteModal.Fail(msg.Err)
+		return nil
+	}
+
+	w.deleteModal.Close()
+
+	// Drop the run from the list immediately instead of waiting for the
+	// next directory poll.
+	remaining := make([]string, 0, len(w.runs.Items))
+	for _, item := range w.runs.Items {
+		if item.Key != msg.RunKey {
+			remaining = append(remaining, item.Key)
+		}
+	}
+	w.applyRunKeys(remaining)
 	return nil
 }
 


### PR DESCRIPTION
Description
-----------

Adds run deletion to LEET's workspace view. Press Backspace or Delete with the runs list focused to open a confirmation modal for the highlighted run. Type DELETE and press Enter to remove the run directory from local disk; Esc cancels.

Guardrails:

- Runs known to be live are blocked from deletion.
- The run's reader and watcher are closed before removal.
- A failed deletion keeps the modal open and shows the error.

<img width="2620" height="1404" alt="image" src="https://github.com/user-attachments/assets/47b0f6fa-5ee2-4a87-8499-0cef87e53bd5" />

The modal is composited over the workspace with lipgloss v2 Canvas/Compositor, the first true overlay in LEET, yay.

- [x] I updated CHANGELOG.unreleased.md
