### PR TITLE
feat(leet): plot metrics against custom x-axes from define_metric

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Added
+
+- LEET charts metrics against the custom x-axes set with `run.define_metric()`. A metric defined with a `step_metric`, directly or through a glob like `run.define_metric("train/*", step_metric="train/step")`, is plotted against that metric instead of the step counter, with the axis name shown as `[x: train/step]` in the chart header. Applies to runs viewed from local `.wandb` files (@dmitryduev in https://github.com/wandb/wandb/pull/12568)
+
 ### Changed
 
 - LEET is faster on long runs: a 50k-step run loads in about half the time, frames render about 30 percent faster, and live chart updates no longer re-render every point (@dmitryduev in https://github.com/wandb/wandb/pull/12535, https://github.com/wandb/wandb/pull/12536, https://github.com/wandb/wandb/pull/12537, https://github.com/wandb/wandb/pull/12538, https://github.com/wandb/wandb/pull/12539)

--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -183,6 +183,9 @@ type EpochLineChart struct {
 	// title is the metric name shown in the chart header.
 	title string
 
+	// xAxisMetric is the metric plotted on the x-axis, or "" for _step.
+	xAxisMetric string
+
 	// dirty marks the chart as needing a redraw on the next DrawIfNeeded call.
 	dirty bool
 
@@ -410,10 +413,16 @@ func (c *EpochLineChart) updateRanges() {
 		dataXMax = 0
 	}
 	niceMax := dataXMax
-	if niceMax < defaultMaxX {
+	switch {
+	case c.xAxisMetric != "":
+		// Custom axes fit the data.
+		if niceMax <= dataXMin {
+			niceMax = dataXMin + 1
+		}
+	case niceMax < defaultMaxX:
 		// Keep a decent default domain early in a run.
 		niceMax = defaultMaxX
-	} else {
+	default:
 		// Round to nearest 10.
 		niceMax = float64(((int(math.Ceil(niceMax)) + 9) / 10) * 10)
 	}
@@ -1039,6 +1048,16 @@ func (c *EpochLineChart) DrawIfNeeded() {
 // Title returns the chart title.
 func (c *EpochLineChart) Title() string {
 	return c.title
+}
+
+// SetXAxisMetric sets the metric plotted on the x-axis.
+func (c *EpochLineChart) SetXAxisMetric(name string) {
+	c.xAxisMetric = name
+}
+
+// XAxisMetric returns the metric plotted on the x-axis, or "" for _step.
+func (c *EpochLineChart) XAxisMetric() string {
+	return c.xAxisMetric
 }
 
 // SetFocused sets the chart's focus state.

--- a/core/internal/leet/historysource.go
+++ b/core/internal/leet/historysource.go
@@ -74,6 +74,7 @@ func concatenateHistory(messages []HistoryMsg, runPath string) HistoryMsg {
 			existing := h.Metrics[metricName]
 			existing.X = append(existing.X, data.X...)
 			existing.Y = append(existing.Y, data.Y...)
+			existing.XAxisMetric = data.XAxisMetric
 			h.Metrics[metricName] = existing
 		}
 		for mediaKey, points := range msg.Media {

--- a/core/internal/leet/leveldbhistorysource.go
+++ b/core/internal/leet/leveldbhistorysource.go
@@ -14,6 +14,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runmetric"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -25,6 +26,10 @@ type LevelDBHistorySource struct {
 
 	// store is a W&B LevelDB-style transaction log that may be actively written.
 	store *LiveStore
+	// metricHandler accumulates define_metric records to resolve custom
+	// x-axes. Definitions apply only to later history records; points
+	// parsed before a definition arrives stay on the default axis.
+	metricHandler *runmetric.MetricHandler
 	// exitSeen is true if the exit record has been seen.
 	exitSeen bool
 	// exitCode is the exit code of the run if the exit record has been seen.
@@ -42,8 +47,9 @@ func NewLevelDBHistorySource(
 		return nil, err
 	}
 	return &LevelDBHistorySource{
-		runPath: runPath,
-		store:   store,
+		runPath:       runPath,
+		store:         store,
+		metricHandler: runmetric.New(),
 	}, nil
 }
 
@@ -90,7 +96,7 @@ func (hs *LevelDBHistorySource) Read(
 	}
 
 	var msgs []tea.Msg
-	var history historyAccumulator
+	history := historyAccumulator{metricHandler: hs.metricHandler}
 	var summaries []SummaryMsg
 	scannedCount := 0
 	startTime := time.Now()
@@ -179,6 +185,9 @@ func (hs *LevelDBHistorySource) recordToMsg(record *spb.Record) tea.Msg {
 			msg.StartTime = ts.AsTime()
 		}
 		return msg
+	case *spb.Record_Metric:
+		_ = hs.metricHandler.ProcessRecord(rec.Metric)
+		return nil
 	case *spb.Record_Stats:
 		return ParseStats(hs.runPath, rec.Stats)
 	case *spb.Record_Summary:
@@ -204,8 +213,14 @@ func (hs *LevelDBHistorySource) Close() {
 
 // historyAccumulator merges a chunk's history records into per-metric series.
 type historyAccumulator struct {
+	// metricHandler resolves custom x-axes and must be non-nil.
+	metricHandler *runmetric.MetricHandler
+
 	metrics map[string]MetricData
 	media   map[string][]MediaPoint
+
+	// values holds one record's numeric items and is reused across records.
+	values map[string]float64
 }
 
 func (acc *historyAccumulator) addRecord(runPath string, history *spb.HistoryRecord) {
@@ -216,6 +231,10 @@ func (acc *historyAccumulator) addRecord(runPath string, history *spb.HistoryRec
 	step := int(historyStep(history))
 	var mediaFieldsByKey map[string]map[string]string
 
+	if acc.values == nil {
+		acc.values = make(map[string]float64)
+	}
+	clear(acc.values)
 	for _, item := range history.GetItem() {
 		if item == nil {
 			continue
@@ -235,19 +254,38 @@ func (acc *historyAccumulator) addRecord(runPath string, history *spb.HistoryRec
 		}
 
 		key := historyItemKey(item)
-		if key == "" || strings.HasPrefix(key, "_") {
+		if key == "" {
 			continue
 		}
-		val, err := strconv.ParseFloat(trimJSONString(item.ValueJson), 64)
-		if err != nil {
+		if val, err := strconv.ParseFloat(trimJSONString(item.ValueJson), 64); err == nil {
+			acc.values[key] = val
+		}
+	}
+
+	for key, val := range acc.values {
+		// Internal keys get no chart but may serve as an x-axis (e.g. _runtime).
+		if strings.HasPrefix(key, "_") {
 			continue
+		}
+		x, xAxisMetric := float64(step), acc.metricHandler.StepMetric(key)
+		switch xAxisMetric {
+		case "", "_step":
+			xAxisMetric = ""
+		default:
+			// Rows without a finite x value are not plotted, as in the UI.
+			sx, ok := acc.values[xAxisMetric]
+			if !ok || !isFinite(sx) {
+				continue
+			}
+			x = sx
 		}
 		if acc.metrics == nil {
 			acc.metrics = make(map[string]MetricData)
 		}
 		md := acc.metrics[key]
-		md.X = append(md.X, float64(step))
+		md.X = append(md.X, x)
 		md.Y = append(md.Y, val)
+		md.XAxisMetric = xAxisMetric
 		acc.metrics[key] = md
 	}
 
@@ -275,8 +313,14 @@ func historyItemKey(item *spb.HistoryItem) string {
 }
 
 // ParseHistory extracts metrics and media from a history record.
-func ParseHistory(runPath string, history *spb.HistoryRecord) tea.Msg {
-	var acc historyAccumulator
+//
+// metricHandler resolves custom x-axes and must be non-nil.
+func ParseHistory(
+	runPath string,
+	history *spb.HistoryRecord,
+	metricHandler *runmetric.MetricHandler,
+) tea.Msg {
+	acc := historyAccumulator{metricHandler: metricHandler}
 	acc.addRecord(runPath, history)
 	msg, ok := acc.toMsg(runPath)
 	if !ok {

--- a/core/internal/leet/leveldbhistorysource_test.go
+++ b/core/internal/leet/leveldbhistorysource_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/wandb/wandb/core/internal/leet"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runmetric"
 	"github.com/wandb/wandb/core/internal/transactionlog"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -35,9 +36,10 @@ func TestParseHistory_StepAndMetrics(t *testing.T) {
 		{NestedKey: []string{"loss"}, ValueJson: "0.5"},
 		{NestedKey: []string{"_runtime"}, ValueJson: "1.2"},
 	}}
-	msg := leet.ParseHistory("/some/run/path", h).(leet.HistoryMsg)
+	msg := leet.ParseHistory("/some/run/path", h, runmetric.New()).(leet.HistoryMsg)
 	require.Equal(t, 2.0, msg.Metrics["loss"].X[0])
 	require.Equal(t, 0.5, msg.Metrics["loss"].Y[0])
+	require.NotContains(t, msg.Metrics, "_runtime")
 }
 
 func TestReadAllRecordsChunked_HistoryThenExit(t *testing.T) {
@@ -74,6 +76,55 @@ func TestReadAllRecordsChunked_HistoryThenExit(t *testing.T) {
 	assert.EqualValues(t, 0.42, batch.Msgs[0].(leet.HistoryMsg).Metrics["loss"].Y[0])
 	assert.IsType(t, leet.FileCompleteMsg{}, batch.Msgs[1])
 	assert.EqualValues(t, 0, batch.Msgs[1].(leet.FileCompleteMsg).ExitCode)
+}
+
+func TestLevelDBHistorySource_CustomXAxis(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom-x.wandb")
+
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(&spb.Record{
+		RecordType: &spb.Record_Metric{
+			Metric: &spb.MetricRecord{
+				GlobName:   "train/*",
+				StepMetric: "train/step",
+			},
+		},
+	}))
+	require.NoError(t, w.Write(&spb.Record{
+		RecordType: &spb.Record_History{
+			History: &spb.HistoryRecord{
+				Item: []*spb.HistoryItem{
+					{NestedKey: []string{"_step"}, ValueJson: "0"},
+					{NestedKey: []string{"train/step"}, ValueJson: "100"},
+					{NestedKey: []string{"train/loss"}, ValueJson: "0.5"},
+				},
+			},
+		},
+	}))
+	require.NoError(t, w.Write(&spb.Record{
+		RecordType: &spb.Record_History{
+			History: &spb.HistoryRecord{
+				Item: []*spb.HistoryItem{
+					{NestedKey: []string{"_step"}, ValueJson: "1"},
+					{NestedKey: []string{"train/loss"}, ValueJson: "0.4"},
+				},
+			},
+		},
+	}))
+	require.NoError(t, w.Close())
+
+	s, err := leet.NewLevelDBHistorySource(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
+	defer s.Close()
+
+	msg, err := s.Read(leet.BootLoadChunkSize, leet.BootLoadMaxTime)
+	require.NoError(t, err)
+	batch := msg.(leet.ChunkedBatchMsg)
+	require.Len(t, batch.Msgs, 1)
+	hist := batch.Msgs[0].(leet.HistoryMsg)
+	require.Equal(t, []float64{100}, hist.Metrics["train/loss"].X)
+	require.Equal(t, "train/step", hist.Metrics["train/loss"].XAxisMetric)
 }
 
 func TestLevelDBHistorySource_FileCompleteEmittedOnce(t *testing.T) {

--- a/core/internal/leet/liveread_test.go
+++ b/core/internal/leet/liveread_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/wandb/wandb/core/internal/leet"
 	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runmetric"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -120,7 +121,7 @@ func TestParseHistory_UsesHistoryStepFallback(t *testing.T) {
 		Item: []*spb.HistoryItem{
 			{NestedKey: []string{"loss"}, ValueJson: "0.5"},
 		},
-	}).(leet.HistoryMsg)
+	}, runmetric.New()).(leet.HistoryMsg)
 
 	require.Equal(t, 7.0, msg.Metrics["loss"].X[0])
 }

--- a/core/internal/leet/media_test.go
+++ b/core/internal/leet/media_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/leet"
+	"github.com/wandb/wandb/core/internal/runmetric"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
@@ -26,7 +27,7 @@ func TestParseHistory_ImageFile(t *testing.T) {
 		},
 	}
 
-	msg, ok := leet.ParseHistory(runPath, history).(leet.HistoryMsg)
+	msg, ok := leet.ParseHistory(runPath, history, runmetric.New()).(leet.HistoryMsg)
 	require.True(t, ok)
 	require.Contains(t, msg.Media, "media/generated_sample")
 	require.Len(t, msg.Media["media/generated_sample"], 1)
@@ -56,7 +57,7 @@ func TestParseHistory_ImageFile_NormalizesRelativePathWithinFilesDir(t *testing.
 		},
 	}
 
-	msg, ok := leet.ParseHistory(runPath, history).(leet.HistoryMsg)
+	msg, ok := leet.ParseHistory(runPath, history, runmetric.New()).(leet.HistoryMsg)
 	require.True(t, ok)
 	require.Contains(t, msg.Media, "media/generated_sample")
 	require.Len(t, msg.Media["media/generated_sample"], 1)
@@ -88,7 +89,7 @@ func TestParseHistory_ImagesSeparated(t *testing.T) {
 		},
 	}
 
-	msg, ok := leet.ParseHistory(runPath, history).(leet.HistoryMsg)
+	msg, ok := leet.ParseHistory(runPath, history, runmetric.New()).(leet.HistoryMsg)
 	require.True(t, ok)
 	require.Len(t, msg.Media, 2)
 	require.Contains(t, msg.Media, "attention_maps[0]")
@@ -123,7 +124,7 @@ func TestParseHistory_ImagesSeparated_NoCaptions(t *testing.T) {
 		},
 	}
 
-	msg, ok := leet.ParseHistory(runPath, history).(leet.HistoryMsg)
+	msg, ok := leet.ParseHistory(runPath, history, runmetric.New()).(leet.HistoryMsg)
 	require.True(t, ok)
 	require.Len(t, msg.Media, 1)
 	require.Contains(t, msg.Media, "samples[0]")

--- a/core/internal/leet/messages.go
+++ b/core/internal/leet/messages.go
@@ -11,6 +11,9 @@ import (
 type MetricData struct {
 	X []float64
 	Y []float64
+
+	// XAxisMetric is the metric whose values X holds, or "" for _step.
+	XAxisMetric string
 }
 
 // HistoryMsg contains metrics data from a wandb history record.

--- a/core/internal/leet/metricsgrid.go
+++ b/core/internal/leet/metricsgrid.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	tea "charm.land/bubbletea/v2"
@@ -161,12 +162,21 @@ func (mg *MetricsGrid) focusedChart() *EpochLineChart {
 	return mg.currentPage[mg.focus.Row][mg.focus.Col]
 }
 
-func (mg *MetricsGrid) focusedChartScaleLabel() string {
+// focusedChartLabels returns the focused chart's status-bar decorations,
+// e.g. " [log] [x: train/step]", or an empty string if it has none.
+func (mg *MetricsGrid) focusedChartLabels() string {
 	chart := mg.focusedChart()
 	if chart == nil {
 		return ""
 	}
-	return chart.ScaleLabel()
+	labels := ""
+	if chart.IsLogY() {
+		labels += " [log]"
+	}
+	if m := chart.XAxisMetric(); m != "" {
+		labels += " [x: " + m + "]"
+	}
+	return labels
 }
 
 func (mg *MetricsGrid) toggleFocusedChartLogY() bool {
@@ -228,6 +238,9 @@ func (mg *MetricsGrid) ProcessHistory(msg HistoryMsg) bool {
 			if mg.logger != nil && len(mg.all)%1000 == 0 {
 				mg.logger.Debug(fmt.Sprintf("metricsgrid: created %d charts", len(mg.all)))
 			}
+		}
+		if data.XAxisMetric != "" {
+			chart.SetXAxisMetric(data.XAxisMetric)
 		}
 		chart.AddData(msg.RunPath, data)
 		if seriesStyle != nil {
@@ -480,10 +493,24 @@ func (mg *MetricsGrid) renderGridCell(row, col int, dims GridDims) string {
 		if chart.IsLogY() {
 			titleSuffix = " [log]"
 		}
+		xLabel := ""
+		if m := chart.XAxisMetric(); m != "" {
+			xLabel = "[x: " + m + "]"
+		}
 
-		availableTitleWidth := max(dims.CellWWithPadding-4-lipgloss.Width(titleSuffix), 10)
-		displayTitle := TruncateTitle(chart.Title(), availableTitleWidth)
+		titleWidth := dims.CellWWithPadding - 4 - lipgloss.Width(titleSuffix)
+		if w := titleWidth - lipgloss.Width(xLabel); w >= 10 {
+			titleWidth = w
+		}
+		displayTitle := TruncateTitle(chart.Title(), max(titleWidth, 10))
 		titleText := titleStyle.Render(displayTitle) + navInfoStyle.Render(titleSuffix)
+
+		if xLabel != "" {
+			gap := chart.Width() - lipgloss.Width(titleText) - lipgloss.Width(xLabel)
+			if gap >= 1 {
+				titleText += strings.Repeat(" ", gap) + navInfoStyle.Render(xLabel)
+			}
+		}
 
 		boxContent := lipgloss.JoinVertical(
 			lipgloss.Left,
@@ -868,7 +895,7 @@ func (mg *MetricsGrid) StartInspection(adjustedX, row, col int, dims GridDims, s
 	if synced {
 		mg.syncInspectActive = true
 		if x, _, active := chart.InspectionData(); active {
-			mg.broadcastInspectAtDataX(x)
+			mg.broadcastInspectAtDataX(x, chart.XAxisMetric())
 		}
 	}
 }
@@ -888,7 +915,7 @@ func (mg *MetricsGrid) UpdateInspection(adjustedX, row, col int, dims GridDims) 
 
 	if mg.syncInspectActive {
 		if x, _, active := chart.InspectionData(); active {
-			mg.broadcastInspectAtDataX(x)
+			mg.broadcastInspectAtDataX(x, chart.XAxisMetric())
 		}
 	}
 }
@@ -920,15 +947,16 @@ func (mg *MetricsGrid) EndInspection() {
 	}
 }
 
-// broadcastInspectAtDataX applies InspectAtDataX to all visible charts on the current page.
-func (mg *MetricsGrid) broadcastInspectAtDataX(anchorX float64) {
+// broadcastInspectAtDataX applies InspectAtDataX to the visible charts on
+// the current page that share the source chart's x-axis.
+func (mg *MetricsGrid) broadcastInspectAtDataX(anchorX float64, xAxisMetric string) {
 	mg.mu.RLock()
 	page := mg.currentPage
 	mg.mu.RUnlock()
 
 	for r := range page {
 		for c := range page[r] {
-			if ch := page[r][c]; ch != nil {
+			if ch := page[r][c]; ch != nil && ch.XAxisMetric() == xAxisMetric {
 				ch.InspectAtDataX(anchorX)
 				ch.DrawIfNeeded()
 			}

--- a/core/internal/leet/metricsgrid_test.go
+++ b/core/internal/leet/metricsgrid_test.go
@@ -64,6 +64,19 @@ func TestMetricsGrid_View_FitsPaneWidth(t *testing.T) {
 	}
 }
 
+func TestMetricsGrid_XAxisMetricInChartHeader(t *testing.T) {
+	grid := newMetricsGrid(t, 1, 1, 80, 24, nil)
+	grid.ProcessHistory(leet.HistoryMsg{
+		Metrics: map[string]leet.MetricData{
+			"train/loss": {X: []float64{9}, Y: []float64{0.5}, XAxisMetric: "custom_step"},
+		},
+	})
+	grid.UpdateDimensions(80, 24)
+
+	dims := grid.CalculateChartDimensions(80, 24)
+	require.Contains(t, grid.View(dims), "[x: custom_step]")
+}
+
 func TestMetricsGrid_Render_EmptyGridShowsSectionHeader(t *testing.T) {
 	grid := newMetricsGrid(t, 2, 2, 200, 80, nil)
 
@@ -276,7 +289,7 @@ func TestMetricsGrid_Inspection_FocusedOnly(t *testing.T) {
 
 func TestMetricsGrid_Inspection_Synchronized_BroadcastAndEnd(t *testing.T) {
 	w, h := 240, 60
-	grid := newMetricsGrid(t, 1, 2, w, h, nil)
+	grid := newMetricsGrid(t, 1, 3, w, h, nil)
 
 	// alpha has dense steps, beta has sparse to exercise nearestIndex tie-breaks.
 	hist := map[string]leet.MetricData{
@@ -288,6 +301,11 @@ func TestMetricsGrid_Inspection_Synchronized_BroadcastAndEnd(t *testing.T) {
 			X: []float64{0, 2, 4, 6, 8},
 			Y: []float64{20, 40, 60, 80, 100},
 		},
+		"gamma": {
+			X:           []float64{0, 2, 4, 6, 8},
+			Y:           []float64{20, 40, 60, 80, 100},
+			XAxisMetric: "custom_step",
+		},
 	}
 	m := leet.HistoryMsg{Metrics: hist}
 	require.True(t, grid.ProcessHistory(m))
@@ -297,8 +315,10 @@ func TestMetricsGrid_Inspection_Synchronized_BroadcastAndEnd(t *testing.T) {
 
 	chA := grid.TestChartAt(0, 0)
 	chB := grid.TestChartAt(0, 1)
+	chC := grid.TestChartAt(0, 2)
 	require.NotNil(t, chA)
 	require.NotNil(t, chB)
+	require.NotNil(t, chC)
 
 	// Start synchronized at X=3 on alpha.
 	relPX := int(math.Round(
@@ -314,6 +334,7 @@ func TestMetricsGrid_Inspection_Synchronized_BroadcastAndEnd(t *testing.T) {
 	xB, _, bActive := chB.InspectionData()
 	require.True(t, aActive)
 	require.True(t, bActive)
+	require.False(t, chC.IsInspecting(), "gamma is on another x-axis")
 	require.InDelta(t, 3.0, xA, 1e-6) // alpha matches anchor exactly
 
 	// For beta (X: {0,2,4,6,8}), nearest to 3 is a tie (2 and 4). Implementation picks the lower (2).

--- a/core/internal/leet/parquethistorysource.go
+++ b/core/internal/leet/parquethistorysource.go
@@ -62,6 +62,10 @@ type historyStepReader interface {
 // ParquetHistorySource reads a remote run's history from its parquet
 // exports on the W&B backend.
 //
+// TODO: resolve custom x-axes like LevelDBHistorySource does for
+// Record_Metric. For remote runs the define_metric definitions live in
+// the run config under _wandb.m, which is not fetched yet.
+//
 // Implements HistorySource.
 type ParquetHistorySource struct {
 	logger *observability.CoreLogger

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -666,9 +666,7 @@ func (r *Run) buildActiveStatus() string {
 		parts = append(parts, focusedTitle)
 		switch r.focus.Type {
 		case FocusMainChart:
-			if scaleLabel := r.metricsGrid.focusedChartScaleLabel(); scaleLabel != "" {
-				parts = append(parts, scaleLabel)
-			}
+			parts[len(parts)-1] += r.metricsGrid.focusedChartLabels()
 		case FocusSystemChart:
 			if detail := r.rightSidebar.metricsGrid.FocusedChartTitleDetail(); detail != "" {
 				parts = append(parts, detail)

--- a/core/internal/leet/units.go
+++ b/core/internal/leet/units.go
@@ -164,8 +164,6 @@ var scales = []struct {
 	factor float64
 	suffix string
 }{
-	{1e-6, "μ"},
-	{1e-3, "m"},
 	{1.0, ""},
 	{1e3, "k"},
 	{1e6, "M"},

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -1361,9 +1361,7 @@ func (w *Workspace) activeFocusStatus() []string {
 
 	switch w.focus.Type {
 	case FocusMainChart:
-		if scaleLabel := w.metricsGrid.focusedChartScaleLabel(); scaleLabel != "" {
-			parts = append(parts, scaleLabel)
-		}
+		parts[0] += w.metricsGrid.focusedChartLabels()
 	case FocusSystemChart:
 		if g := w.activeSystemMetricsGrid(); g != nil {
 			if detail := g.FocusedChartTitleDetail(); detail != "" {

--- a/core/internal/runmetric/runmetric.go
+++ b/core/internal/runmetric/runmetric.go
@@ -32,6 +32,23 @@ func (mh *MetricHandler) Exists(key string) bool {
 	return exists
 }
 
+// StepMetric returns the name of a metric's custom X axis, or "" if it
+// has none.
+//
+// A metric matching a glob is defined on first lookup.
+func (mh *MetricHandler) StepMetric(key string) string {
+	if metric, ok := mh.definedMetrics[key]; ok {
+		return metric.Step
+	}
+
+	metric, ok := mh.matchGlobMetric(key)
+	if !ok {
+		return ""
+	}
+	mh.definedMetrics[key] = metric
+	return metric.Step
+}
+
 // ProcessRecord updates metric definitions.
 func (mh *MetricHandler) ProcessRecord(record *spb.MetricRecord) error {
 	if record.StepMetric != "" {

--- a/core/internal/runmetric/runmetric_test.go
+++ b/core/internal/runmetric/runmetric_test.go
@@ -2,7 +2,43 @@ package runmetric
 
 import (
 	"testing"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+func TestStepMetric(t *testing.T) {
+	mh := New()
+	_ = mh.ProcessRecord(&spb.MetricRecord{Name: "custom_step"})
+	_ = mh.ProcessRecord(&spb.MetricRecord{
+		GlobName:   "train/*",
+		StepMetric: "custom_step",
+	})
+
+	if got := mh.StepMetric("train/loss"); got != "custom_step" {
+		t.Errorf("expected custom_step, got %q", got)
+	}
+	if got := mh.StepMetric("other"); got != "" {
+		t.Errorf("expected no step metric, got %q", got)
+	}
+	// An explicit definition without a step metric shadows globs,
+	// even an all-matching one.
+	_ = mh.ProcessRecord(&spb.MetricRecord{
+		GlobName:   "*",
+		StepMetric: "custom_step",
+	})
+	if got := mh.StepMetric("custom_step"); got != "" {
+		t.Errorf("expected no step metric, got %q", got)
+	}
+	// Glob matches are materialized on first lookup: redefining the
+	// glob doesn't move already-resolved metrics to a different axis.
+	_ = mh.ProcessRecord(&spb.MetricRecord{
+		GlobName:   "train/*",
+		StepMetric: "other_step",
+	})
+	if got := mh.StepMetric("train/loss"); got != "custom_step" {
+		t.Errorf("expected custom_step, got %q", got)
+	}
+}
 
 func TestGlobMetricWildcard(t *testing.T) {
 	mh := New()


### PR DESCRIPTION
Description
-----------
<!--<img width="3440" height="2028" alt="image" src="https://github.com/user-attachments/assets/9ccf66d9-d1f1-4dd9-af9b-584aea229ee4" />-->

<img width="3032" height="1782" alt="image" src="https://github.com/user-attachments/assets/cdd0b802-0f8a-4a99-9287-5405f22d388e" />


LEET plotted every metric against `_step`, ignoring `define_metric(step_metric=...)`. Charts now use the step metric's value from the same history row as the x value, so custom x-axes work like in the W&B UI (https://docs.wandb.ai/models/track/log/customize-logging-axes).

The transaction-log reader feeds `Record_Metric` records into a `runmetric.MetricHandler` and resolves each metric's x-axis at parse time. Globs are matched in LEET because the SDK now defaults to server-side expansion, so the log contains only the glob definition.

Not covered in here:

- Remote (parquet) runs: definitions live in the run config, which LEET will need to learn to digest.
- Non-monotonic step metrics degrade rendering (the UI has the same requirement).

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
