### PR TITLE
feat(leet): show labeled wandb dir only when run list is focused

### DIFF
--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -1260,14 +1260,22 @@ func (w *Workspace) buildOverviewFilterStatus() string {
 func (w *Workspace) buildActiveStatus() string {
 	var parts []string
 
+	// The wandb dir answers "which runs am I browsing?", so it belongs to
+	// the run list; other panes put their own context in the status bar.
+	if w.focusMgr.IsTarget(FocusTargetRunsList) {
+		parts = append(parts, "wandb dir: "+w.wandbDir)
+	}
+
 	parts = append(parts, w.activeFilterStatus()...)
 	parts = append(parts, w.activeSelectionStatus()...)
 	parts = append(parts, w.activeFocusStatus()...)
 
+	// Never leave the status bar blank (e.g. Esc cleared focus and no
+	// filters are active).
 	if len(parts) == 0 {
-		return w.wandbDir
+		return "wandb dir: " + w.wandbDir
 	}
-	return w.wandbDir + " • " + strings.Join(parts, " • ")
+	return strings.Join(parts, " • ")
 }
 
 // activeFilterStatus collects status fragments for all active filters.


### PR DESCRIPTION
Description
-----------
The workspace status bar prefixed every state with the bare wandb dir
path. The path is run-list context: once focus moves to a chart or
sidebar pane it competes with that pane's status for width, and without
a label it reads as an unexplained path.

Now the bar shows `wandb dir: <path>` only while the run list owns
focus. Other panes keep their own status (chart name, scale, overview
selection). If the bar would otherwise be empty, e.g. focus cleared
with no active filters, it falls back to the labeled dir so it never
goes blank.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
`go test ./internal/leet/`, plus a manual pass over the focus states in
a live TUI.
