### PR TITLE
feat(artifacts): make XXH128 the default artifact digest algorithm

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -43,6 +43,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)
 - Registry search methods (`Api.registries()`, `.collections()`, `.versions()`) now validate filter field names, rejecting unsupported field names. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12182)
 - `wandb.Video()` now requires the `format` argument when initializing from a numpy array or an io object. (@jacobromero in https://github.com/wandb/wandb/pull/12579)
+- Changed the default behavior of `wandb.Artifact` to use `digest_algorithm="XXH128"` (@amusipatla-wandb in https://github.com/wandb/wandb/pull/12571)
 
 ### Removed
 

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -300,7 +300,7 @@ def test_add_reference_local_file(tmp_path, artifact):
     e = artifact.add_reference(uri)[0]
     assert e.ref_target() == uri
 
-    assert artifact.digest == "a00c2239f036fb656c1dcbf9a32d89b4"
+    assert artifact.digest == "db139340fb6c96baea7b5a9764d55b2c"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "file1.txt": {
@@ -454,7 +454,7 @@ def test_add_reference_local_dir(artifact):
     here = Path.cwd()
     artifact.add_reference(f"file://{here}")
 
-    assert artifact.digest == "72414374bfd4b0f60a116e7267845f71"
+    assert artifact.digest == "1c5e32d843db9099cff8f3d5885a3aed"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "file1.txt": {
@@ -544,7 +544,7 @@ def test_add_reference_local_dir_with_name(artifact):
     here = Path.cwd()
     artifact.add_reference(f"file://{here!s}", name="top")
 
-    assert artifact.digest == "f718baf2d4c910dc6ccd0d9c586fa00f"
+    assert artifact.digest == "4ed6e3db722bf0d8422ec3cfc5cf2ea1"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "top/file1.txt": {
@@ -596,7 +596,7 @@ def test_add_http_reference_path(artifact):
 
     artifact.add_reference("http://example.com/file1.txt")
 
-    assert artifact.digest == "48237ccc050a88af9dcd869dd5a7e9f4"
+    assert artifact.digest == "e73d6d2294e0e6a526c56c5a24cfc890"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "file1.txt": {
@@ -615,7 +615,7 @@ def test_add_reference_named_local_file(tmp_path, artifact):
 
     artifact.add_reference(uri, name="great-file.txt")
 
-    assert artifact.digest == "585b9ada17797e37c9cbab391e69b8c5"
+    assert artifact.digest == "5222f22abda0a6ff806ca38783edb453"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "great-file.txt": {
@@ -629,7 +629,7 @@ def test_add_reference_named_local_file(tmp_path, artifact):
 def test_add_reference_unknown_handler(artifact):
     artifact.add_reference("ref://example.com/somefile.txt", name="ref")
 
-    assert artifact.digest == "410ade94865e89ebe1f593f4379ac228"
+    assert artifact.digest == "4f25da86e90d1b13f582fb81190cfa3c"
 
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts_full.py
@@ -945,7 +945,7 @@ def test_artifact_multipart_download_refresh_presigned_url(
 
 
 def test_draft_inherits_digest_algorithm(api: Api):
-    art = Artifact("test-artifact", "test-type", digest_algorithm="XXH128")
+    art = Artifact("test-artifact", "test-type", digest_algorithm="MD5")
     with art.new_file("file.txt", "w") as f:
         f.write("hello")
 
@@ -956,10 +956,7 @@ def test_draft_inherits_digest_algorithm(api: Api):
 
     parent = api.artifact(f"{project}/my-sample-portfolio:latest")
     draft = parent.new_draft()
-    if server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM):
-        assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128
-    else:
-        assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_MD5
+    assert draft.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_MD5
 
 
 def test_artifact_upload_with_fallback(api: Api):
@@ -967,9 +964,7 @@ def test_artifact_upload_with_fallback(api: Api):
     project = "test"
     Path("test.txt").write_text("test")
     with wandb.init(project=project) as run:
-        artifact = Artifact("test-artifact", type="dataset")
-        artifact._digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
-        artifact.manifest.digest_algorithm = ArtifactDigestAlgorithm.MANIFEST_MD5
+        artifact = Artifact("test-artifact", type="dataset", digest_algorithm="MD5")
         artifact.add_file("test.txt")
         run.log_artifact(artifact)
         artifact.wait()
@@ -977,7 +972,7 @@ def test_artifact_upload_with_fallback(api: Api):
     assert artifact.digest_algorithm == ArtifactDigestAlgorithm.MANIFEST_MD5
 
     # upload a second version of this artifact
-    artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test-artifact", type="dataset")
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
 
@@ -1010,7 +1005,7 @@ def test_artifact_upload_with_fallback(api: Api):
 
 
 def test_artifact_upload_with_correct_digests(api: Api):
-    artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test-artifact", type="dataset")
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
 
@@ -1062,7 +1057,7 @@ def test_artifact_new_draft_mixed_digest_algorithms(api: Api):
     if not server_supports(api._service_api, pb.ARTIFACT_DIGEST_ALGORITHM):
         return
 
-    artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test-artifact", type="dataset")
     assert artifact.digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128
     Path("file1.txt").write_text("hello")
     artifact.add_file("file1.txt")
@@ -1119,7 +1114,7 @@ def test_offline_artifact_legacy_upload_hashes_correctly(
     Path("file2.txt").write_text("hi")
 
     with wandb.init(mode="offline", project="test") as run:
-        artifact = Artifact("test-artifact", type="dataset", digest_algorithm="XXH128")
+        artifact = Artifact("test-artifact", type="dataset")
         artifact.add_file("file1.txt")
         artifact.add_file("file2.txt")
 

--- a/tests/unit_tests/test_artifacts/test_references_gcs.py
+++ b/tests/unit_tests/test_artifacts/test_references_gcs.py
@@ -67,7 +67,7 @@ def test_add_gs_reference_object(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb")
 
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+    assert artifact.digest == "b16609518f60b258cdd4c93f7c6dba0a"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {
@@ -97,7 +97,7 @@ def test_add_gs_reference_object_with_version(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb#2")
 
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+    assert artifact.digest == "b16609518f60b258cdd4c93f7c6dba0a"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {
@@ -113,7 +113,7 @@ def test_add_gs_reference_object_with_name(artifact):
     mock_gcs(artifact)
     artifact.add_reference("gs://my-bucket/my_object.pb", name="renamed.pb")
 
-    assert artifact.digest == "bd85fe009dc9e408a5ed9b55c95f47b2"
+    assert artifact.digest == "2d4433ec4e23d6623808c271c687f015"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "renamed.pb": {
@@ -129,7 +129,7 @@ def test_add_gs_reference_path(capsys, artifact):
     mock_gcs(artifact, path=True)
     artifact.add_reference("gs://my-bucket/")
 
-    assert artifact.digest == "17955d00a20e1074c3bc96c74b724bfe"
+    assert artifact.digest == "84610ac4c1a560ed3a66ee66a85bd5cc"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {
@@ -153,7 +153,7 @@ def test_add_gs_reference_object_no_md5(artifact):
     mock_gcs(artifact, hash=False)
     artifact.add_reference("gs://my-bucket/my_object.pb")
 
-    assert artifact.digest == "8aec0d6978da8c2b0bf5662b3fd043a4"
+    assert artifact.digest == "b16609518f60b258cdd4c93f7c6dba0a"
     manifest_contents = artifact.manifest.to_manifest_json()["contents"]
     assert manifest_contents == {
         "my_object.pb": {

--- a/tests/unit_tests/test_artifacts/test_storage.py
+++ b/tests/unit_tests/test_artifacts/test_storage.py
@@ -359,7 +359,7 @@ def test_wandb_storage_policy_load_file_uses_cache_md5(artifact_file_cache, tmp_
     )
 
     # We need to pass an artifact, but this test doesn't actually use it
-    empty_artifact = Artifact("test", type="dataset")
+    empty_artifact = Artifact("test", type="dataset", digest_algorithm="MD5")
 
     local_path = policy.load_file(empty_artifact, entry)
 
@@ -388,7 +388,7 @@ def test_wandb_storage_policy_load_file_uses_cache_xxh128(
     )
 
     # We need to pass an artifact, but this test doesn't actually use it
-    empty_artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
+    empty_artifact = Artifact("test", type="dataset")
 
     local_path = policy.load_file(empty_artifact, entry)
 

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -746,7 +746,7 @@ def test_artifact_multipart_download_writer_not_on_shared_executor():
 def test_offline_artifact_uses_xxh128():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test", type="dataset")
 
     artifact.add_file(str(f))
     entry = artifact.manifest.entries["file.txt"]
@@ -755,7 +755,7 @@ def test_offline_artifact_uses_xxh128():
 
 
 def test_digest_algorithm_with_reference_entries():
-    artifact = Artifact("test-artifact", "test-type", digest_algorithm="XXH128")
+    artifact = Artifact("test-artifact", "test-type")
 
     f = Path("file.txt")
     f.write_text("hello")
@@ -779,7 +779,7 @@ def test_digest_algorithm_with_reference_entries():
 def test_manifest_digest_uses_xxh128_for_xxh128_artifact():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test", type="dataset")
     artifact.add_file(str(f))
 
     file_digest = xxh128_string("hello")
@@ -791,6 +791,7 @@ def test_manifest_digest_uses_xxh128_for_xxh128_artifact():
 def test_manifest_digest_uses_md5_for_md5_artifact():
     f = Path("file.txt")
     f.write_text("hello")
+    # Force MD5 artifact
     artifact = Artifact("test", type="dataset", digest_algorithm="MD5")
     artifact.add_file(str(f))
 
@@ -825,7 +826,7 @@ def test_entry_digest_algorithm_reads_extra_tag(tag, expected):
 def test_add_file_tags_xxh128_entries():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test", type="dataset")
 
     entry = artifact.add_file(str(f))
 
@@ -836,7 +837,7 @@ def test_add_file_tags_xxh128_entries():
 def test_add_file_leaves_md5_entries_untagged():
     f = Path("file.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset")
+    artifact = Artifact("test", type="dataset", digest_algorithm="MD5")
 
     entry = artifact.add_file(str(f))
 
@@ -850,7 +851,7 @@ def test_mixed_manifest_round_trip_preserves_per_entry_algorithm():
 
     f = Path("xxh.txt")
     f.write_text("hello")
-    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test", type="dataset")
     artifact.add_file(str(f))
 
     # Simulate an entry carried over untagged from an older (md5) SDK, as
@@ -884,7 +885,7 @@ def test_hash_contents_with_md5_correctly_rehashes_xxh128_entries():
     f2 = Path("file2.txt")
     f2.write_text("hi")
 
-    artifact = Artifact("test", type="dataset", digest_algorithm="XXH128")
+    artifact = Artifact("test", type="dataset")
     artifact.add_file(str(f))
     artifact.add_file(str(f2))
     assert (

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -397,7 +397,8 @@ def test_image_refs(mock_reference_get_responses):
     }
     manifest_expected = {
         "image_ref.image-file.json": {
-            "digest": "SZvdv5ouAEq2DEOgVBwOog==",
+            "digest": "DRQxgg4q+7eL+jn/orhvTA==",
+            "extra": {"alg": "XXH128"},
             "size": 173,
         },
         str(Path("media/images/75c13e5a637fb8052da9/puppy.jpg")): {

--- a/wandb/sdk/artifacts/_internal_artifact.py
+++ b/wandb/sdk/artifacts/_internal_artifact.py
@@ -46,7 +46,7 @@ class InternalArtifact(Artifact):
         metadata: dict[str, Any] | None = None,
         incremental: bool = False,
         use_as: str | None = None,
-        digest_algorithm: Literal["MD5", "XXH128"] = "MD5",
+        digest_algorithm: Literal["MD5", "XXH128"] = "XXH128",
     ) -> None:
         sanitized_name = sanitize_artifact_name(name)
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -155,11 +155,11 @@ class Artifact:
             than 100 total keys.
         incremental: Use `Artifact.new_draft()` method instead to modify an
             existing artifact.
-        digest_algorithm: The digest algorithm to use for the artifact. Defaults to MD5.
-            If set to XXH128, the artifact will be hashed using the XXH128 algorithm
-            unless it is part of a collection that is already using MD5. Calls to
-            `artifact.verify()` on SDK versions before 0.29.0 will always fail on
-            XXH128 artifacts.
+        digest_algorithm: The digest algorithm to use for the artifact. Defaults to
+            XXH128. If set to XXH128, the artifact will be hashed using the XXH128
+            algorithm unless it is part of a collection that is already using MD5.
+            Calls to `artifact.verify()` on SDK versions before 0.29.0 will always
+            fail on XXH128 artifacts.
         use_as: Deprecated.
 
     Returns:
@@ -178,7 +178,7 @@ class Artifact:
         incremental: bool = False,
         use_as: str | None = None,
         storage_region: str | None = None,
-        digest_algorithm: Literal["MD5", "XXH128"] = "MD5",
+        digest_algorithm: Literal["MD5", "XXH128"] = "XXH128",
     ) -> None:
         from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 
@@ -253,14 +253,8 @@ class Artifact:
         self._digest: str | None = None
 
         self._digest_algorithm = _STR_TO_DIGEST_ALGORITHM.get(
-            digest_algorithm, ArtifactDigestAlgorithm.MANIFEST_MD5
+            digest_algorithm, ArtifactDigestAlgorithm.MANIFEST_XXH128
         )
-        if self._digest_algorithm is ArtifactDigestAlgorithm.MANIFEST_XXH128:
-            termwarn(
-                "Creating an artifact with the XXH128 digest algorithm."
-                + " Calling `artifact.verify()` for this artifact on wandb"
-                + " versions before 0.29.0 will fail."
-            )
 
         self._manifest: ArtifactManifest | None = ArtifactManifestV1(
             storage_policy=make_storage_policy(region=storage_region),


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

This PR makes the breaking change to default `digest_algorithm` to "XXH128" on artifacts. With this change, all artifacts will be created with XXH128 unless the artifact is part of an existing collection using MD5, or the user is on a server version that does not support XXH128 digests. 

This change is breaking in that `artifact.verify` called on SDK versions before 0.29.0 will not work on artifacts created with XXH128.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
