### PR TITLE
feat(leet): show labeled wandb dir only when run list is focused

### DIFF
--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -1260,14 +1260,22 @@ func (w *Workspace) buildOverviewFilterStatus() string {
 func (w *Workspace) buildActiveStatus() string {
 	var parts []string
 
+	// The wandb dir answers "which runs am I browsing?", so it belongs to
+	// the run list; other panes put their own context in the status bar.
+	if w.focusMgr.IsTarget(FocusTargetRunsList) {
+		parts = append(parts, "wandb dir: "+w.wandbDir)
+	}
+
 	parts = append(parts, w.activeFilterStatus()...)
 	parts = append(parts, w.activeSelectionStatus()...)
 	parts = append(parts, w.activeFocusStatus()...)
 
+	// Never leave the status bar blank (e.g. Esc cleared focus and no
+	// filters are active).
 	if len(parts) == 0 {
-		return w.wandbDir
+		return "wandb dir: " + w.wandbDir
 	}
-	return w.wandbDir + " • " + strings.Join(parts, " • ")
+	return strings.Join(parts, " • ")
 }
 
 // activeFilterStatus collects status fragments for all active filters.


### PR DESCRIPTION
Description
-----------
Show `wandb dir: <path>` in the status bar in the workspace mode _only_ while the run list owns focus (now it is always shown, which seems excessive). If the bar would otherwise be empty, e.g. focus cleared with no active filters, it falls back to the labeled dir so it never goes blank.

<img width="2116" height="830" alt="image" src="https://github.com/user-attachments/assets/39d21545-10f5-4468-8ad5-119ededb9124" />

<img width="2114" height="830" alt="image" src="https://github.com/user-attachments/assets/3c351523-4b91-4fed-8102-769e3c271844" />

