### PR TITLE
chore: remove deprecated image normalization parameter

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -60,10 +60,6 @@ When preparing a release that can include breaking changes, consider applying ch
     - Deprecated in 0.17.6 (https://github.com/wandb/wandb/pull/8064)
     - Can do in >=0.20
 
-- Remove normalization of image data on `wandb.Image`
-    - Owner: @jacobromero
-    - Can do in >=0.21
-
 - Make `wandb.apis.public.runs.Run::load()` private:
     - Owner: @jacobromero
     - Can do in >=0.22

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,6 +22,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Removed the deprecated `summary="best"` option and `goal` argument of `run.define_metric()`. Use `summary="min"` or `summary="max"` instead.
 - Removed the deprecated `quiet` argument of `run.finish()` and `wandb.finish()`. Use `wandb.Settings(quiet=...)` instead.
 - Removed the deprecated `run.project_name()`, `run.get_url()`, `run.get_project_url()`, and `run.get_sweep_url()` methods. Use the `run.project`, `run.url`, `run.project_url`, and `run.sweep_url` properties instead.
+`wandb.Image` no longer normalizes pixel values. Callers must now ensure their data already falls within the range [0, 255].
 
 ### Added
 
@@ -51,6 +52,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - The deprecated `summary="best"` option and `goal` argument of `run.define_metric()`; use `summary="min"` or `summary="max"` instead (@dmitryduev in https://github.com/wandb/wandb/pull/12583)
 - The deprecated `quiet` argument of `run.finish()` and `wandb.finish()`; use `wandb.Settings(quiet=...)` instead (@dmitryduev in https://github.com/wandb/wandb/pull/12584)
 - The deprecated `run.project_name()`, `run.get_url()`, `run.get_project_url()`, and `run.get_sweep_url()` methods; use the `run.project`, `run.url`, `run.project_url`, and `run.sweep_url` properties instead (@dmitryduev in https://github.com/wandb/wandb/pull/12585)
+- Removed deprecated `normalize` argument from `wandb.Image`; callers should ensure pixel values for NumPy arrays and PyTorch tensors already fall in the range [0, 255] (@jacobromero in https://github.com/wandb/wandb/pull/12574)
 
 ### Fixed
 

--- a/tests/system_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/system_tests/test_artifacts/test_wandb_artifacts.py
@@ -939,8 +939,8 @@ def test_duplicate_wbimage_from_file(assets_path, artifact, add_duplicate):
 
 
 def test_deduplicate_wbimage_from_array():
-    im_data_1 = np.random.rand(300, 300, 3)
-    im_data_2 = np.random.rand(300, 300, 3)
+    im_data_1 = np.random.randint(0, 256, size=(300, 300, 3))
+    im_data_2 = np.random.randint(0, 256, size=(300, 300, 3))
 
     artifact = Artifact(type="dataset", name="artifact")
     wb_image_1 = wandb.Image(im_data_1)

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -499,37 +499,8 @@ def test_image_masks_with_pytorch_tensors():
     wandb.Image(image, masks={"predictions": {"mask_data": mask}})
 
 
-def test_image_normalize_neg1_to_1():
-    # Sometimes images are represented with values in range [-1, 1].
-    data = np.array([[-0.2, 0.6]])
-
-    transformed_data = wandb.Image(data).to_data_array()
-
-    assert transformed_data == [[102, 204]]
-
-
-def test_image_normalize_0_to_1():
-    data = np.array([[0.2, 0.3]])
-
-    transformed_data = wandb.Image(data).to_data_array()
-
-    assert transformed_data == [[51, 76]]
-
-
-def test_image_normalize_clips_bad_range():
-    data = np.array([[-9, 0.1, 100, 254.5, 270]])
-
-    transformed_data = wandb.Image(data).to_data_array()
-
-    assert transformed_data == [[0, 0, 100, 254, 255]]
-
-
-@pytest.mark.parametrize(
-    "scale",
-    [1e-8, 1e-5, 1e0, 1e1, -1e-8, -1e-5, -1e0, -1e1],
-)
-def test_image_normalization_numpy_pytorch_equal(scale):
-    img = np.random.uniform(low=0, high=1, size=[4, 4, 3]) * scale
+def test_image_numpy_pytorch_equal():
+    img = np.random.randint(0, 256, size=[4, 4, 3]).astype(np.uint8)
     torch_img = torch.from_numpy(img.transpose(2, 0, 1))
 
     wb_image = wandb.Image(img)
@@ -1254,9 +1225,9 @@ def test_table_column_style():
     rand_1 = np.random.randint(256, size=(2, 2, 3))
     rand_2 = np.random.randint(256, size=(2, 2, 3))
     rand_3 = np.random.randint(256, size=(2, 2, 3))
-    img_1 = wandb.Image(rand_1, normalize=False)
-    img_2 = wandb.Image(rand_2, normalize=False)
-    img_3 = wandb.Image(rand_3, normalize=False)
+    img_1 = wandb.Image(rand_1)
+    img_2 = wandb.Image(rand_2)
+    img_3 = wandb.Image(rand_3)
 
     table2 = wandb.Table(columns=[], data=[])
     table2.add_column("np_data", [rand_1, rand_2])

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -38,62 +38,6 @@ if TYPE_CHECKING:  # pragma: no cover
     ImageDataOrPathType: TypeAlias = "str | pathlib.Path | Image | ImageDataType"
 
 
-def _warn_on_invalid_data_range(
-    data: np.ndarray,
-    normalize: bool = True,
-) -> None:
-    if not normalize:
-        return
-
-    np = util.get_module(
-        "numpy",
-        required="wandb.Image requires numpy if not supplying PIL Images: pip install numpy",
-    )
-
-    if np.min(data) < 0 or np.max(data) > 255:
-        wandb.termwarn(
-            "Data passed to `wandb.Image` should consist of values in the range [0, 255], "
-            "image data will be normalized to this range, "
-            "but behavior will be removed in a future version of wandb.",
-            repeat=False,
-        )
-
-
-def _guess_and_rescale_to_0_255(data: np.ndarray) -> np.ndarray:
-    """Guess the image's format and rescale its values to the range [0, 255].
-
-    This is an unfortunate design flaw carried forward for backward
-    compatibility. A better design would have been to document the expected
-    data format and not mangle the data provided by the user.
-
-    If given data in the range [0, 1], we multiply all values by 255
-    and round down to get integers.
-
-    If given data in the range [-1, 1], we rescale it by mapping -1 to 0 and
-    1 to 255, then round down to get integers.
-
-    We clip and round all other data.
-    """
-    try:
-        import numpy as np
-    except ImportError:
-        raise wandb.Error(
-            "wandb.Image requires numpy if not supplying PIL images: pip install numpy"
-        ) from None
-
-    data_min: float = data.min()
-    data_max: float = data.max()
-
-    if 0 <= data_min and data_max <= 1:
-        return (data * 255).astype(np.uint8)
-
-    elif -1 <= data_min and data_max <= 1:
-        return (255 * 0.5 * (data + 1)).astype(np.uint8)
-
-    else:
-        return data.clip(0, 255).astype(np.uint8)
-
-
 def _convert_to_uint8(data: np.ndarray) -> np.ndarray:
     np = util.get_module(
         "numpy",
@@ -160,20 +104,8 @@ class Image(BatchableMedia):
         boxes: dict[str, BoundingBoxes2D] | dict[str, dict] | None = None,
         masks: dict[str, ImageMask] | dict[str, dict] | None = None,
         file_type: str | None = None,
-        normalize: bool = True,
     ) -> None:
         """Initialize a `wandb.Image` object.
-
-        This class handles various image data formats and automatically normalizes
-        pixel values to the range [0, 255] when needed, ensuring compatibility
-        with the W&B backend.
-
-        * Data in range [0, 1] is multiplied by 255 and converted to uint8
-        * Data in range [-1, 1] is rescaled from [-1, 1] to [0, 255] by mapping
-            -1 to 0 and 1 to 255, then converted to uint8
-        * Data outside [-1, 1] but not in [0, 255] is clipped to [0, 255] and
-            converted to uint8 (with a warning if values fall outside [0, 255])
-        * Data already in [0, 255] is converted to uint8 without modification
 
         When you log an image to a run, W&B saves the file under a generated
         name that includes a content hash, such as
@@ -187,9 +119,7 @@ class Image(BatchableMedia):
                 a PIL image object, or a path to an image file. If a NumPy
                 array or pytorch tensor is provided,
                 the image data will be saved to the given file type.
-                If the values are not in the range [0, 255] or all values are in the range [0, 1],
-                the image pixel values will be normalized to the range [0, 255]
-                unless `normalize` is set to `False`.
+                Values are expected to already be in the range [0, 255].
             - pytorch tensor should be in the format (channel, height, width)
             - NumPy array should be in the format (height, width, channel)
             mode: The PIL mode for an image. Most common are "L", "RGB", "RGBA".
@@ -204,8 +134,6 @@ class Image(BatchableMedia):
                 see https://docs.wandb.ai/models/ref/python/data-types/imagemask
             file_type: The file type to save the image as.
                 This parameter has no effect if `data_or_path` is a path to an image file.
-            normalize: If `True`, normalize the image pixel values to fall within the range of [0, 255].
-                Normalize is only applied if `data_or_path` is a numpy array or pytorch tensor.
 
         Examples:
         Create a wandb.Image from a numpy array
@@ -284,7 +212,7 @@ class Image(BatchableMedia):
             else:
                 self._initialize_from_path(data_or_path)
         else:
-            self._initialize_from_data(data_or_path, mode, file_type, normalize)
+            self._initialize_from_data(data_or_path, mode, file_type)
         self._set_initialization_meta(
             grouping, caption, classes, boxes, masks, file_type
         )
@@ -403,7 +331,6 @@ class Image(BatchableMedia):
         data: ImageDataType,
         mode: str | None = None,
         file_type: str | None = None,
-        normalize: bool = True,
     ) -> None:
         pil_image = util.get_module(
             "PIL.Image",
@@ -431,10 +358,6 @@ class Image(BatchableMedia):
                 data = data.to(float)  # type: ignore [union-attr]
             mode = mode or self.guess_mode(data, file_type)
             data = data.permute(1, 2, 0).cpu().numpy()  # type: ignore [union-attr]
-
-            _warn_on_invalid_data_range(data, normalize)
-
-            data = _guess_and_rescale_to_0_255(data) if normalize else data  # type: ignore [arg-type]
             data = _convert_to_uint8(data)
 
             if data.ndim > 2:
@@ -448,10 +371,7 @@ class Image(BatchableMedia):
                 # get rid of trivial dimensions as a convenience
                 data = data.squeeze()  # type: ignore [union-attr]
 
-            _warn_on_invalid_data_range(data, normalize)  # type: ignore [arg-type]
-
             mode = mode or self.guess_mode(data, file_type)
-            data = _guess_and_rescale_to_0_255(data) if normalize else data  # type: ignore [arg-type]
             data = _convert_to_uint8(data)  # type: ignore [arg-type]
             self._image = pil_image.fromarray(data).convert(mode)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

The normalization code for `Image` media files was deprecated a while ago. The code was very buggy with many edge cases that manipulated user data. In some cases user data logged would not be what they see.

Since it has been many releases since this was deprecated, this PR removes that parameter and the code around it.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
