### PR TITLE
feat: improve .wandb file version error

### DIFF
--- a/core/internal/transactionlog/reader.go
+++ b/core/internal/transactionlog/reader.go
@@ -153,8 +153,13 @@ func (r *Reader) verifyWBHeaderBeforeFirstRead() error {
 		return nil
 	}
 
-	if err := r.reader.VerifyWandbHeader(wandbStoreVersion); err != nil {
+	version, err := r.reader.VerifyWandbHeader()
+	if err != nil {
 		return fmt.Errorf("transactionlog: bad header: %w", err)
+	}
+
+	if err := ensureSupportedVersion(version); err != nil {
+		return err
 	}
 
 	r.needsToVerifyHeader = false

--- a/core/internal/transactionlog/transactionlog.go
+++ b/core/internal/transactionlog/transactionlog.go
@@ -1,8 +1,38 @@
 // Package transactionlog implements reading and writing .wandb files.
 package transactionlog
 
+import "errors"
+
 // wandbStoreVersion is written into .wandb file headers.
 //
-// Incrementing this prevents older clients from attempting to read .wandb
-// files in a new format.
+// Incrementing this prevents older SDKs from attempting to read .wandb
+// files in a new format. It may also prevent the next SDK version from reading
+// old .wandb files, depending on the implementation of ensureSupportedVersion.
+// Update the error messages below.
 const wandbStoreVersion = 0
+
+// ensureSupportedVersion returns an error for an unsupported version.
+//
+// The error does not have the conventional prefix ("transactionlog:") and one
+// should not be added because that would add noise. The message is shown to
+// the user when using `wandb sync`.
+func ensureSupportedVersion(version uint8) error {
+	switch {
+	case version > wandbStoreVersion:
+		// In this case, we can't provide any more useful info unless we
+		// attempt to read the SDK version from the file.
+		//
+		// Hopefully the user knows which version was used to generate it!
+		return errors.New("a newer wandb version is required to read this file")
+
+	case version < wandbStoreVersion:
+		// This is not currently possible, but it's here as a safe default.
+		//
+		// When we do bump `wandbStoreVersion`, we should ensure this message
+		// includes the required wandb Python version.
+		return errors.New("an older wandb version is required to read this file")
+
+	default:
+		return nil
+	}
+}

--- a/core/internal/transactionlog/transactionlog_test.go
+++ b/core/internal/transactionlog/transactionlog_test.go
@@ -76,17 +76,6 @@ func Test_OpenReader_NoFile(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
-func Test_OpenReader_BadHeader(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "run.wandb")
-	require.NoError(t, os.WriteFile(path, []byte{1, 2, 3, 4, 5, 6, 7}, 0o666))
-
-	reader, err := transactionlog.OpenReader(path, observabilitytest.NewTestLogger(t))
-	require.NoError(t, err)
-
-	_, err = reader.Read()
-	assert.ErrorContains(t, err, "bad header")
-}
-
 func Test_Read_AlreadyClosed(t *testing.T) {
 	path := emptyWandbFile(t)
 	reader, err := transactionlog.OpenReader(path, observabilitytest.NewTestLogger(t))
@@ -239,7 +228,7 @@ func Test_EOF(t *testing.T) {
 	})
 }
 
-func Test_ReadVerifiesHeader(t *testing.T) {
+func Test_Read_VerifiesHeader(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "run.wandb")
 	require.NoError(t, os.WriteFile(path, []byte("invalid header"), 0o644))
 
@@ -249,6 +238,20 @@ func Test_ReadVerifiesHeader(t *testing.T) {
 	reader.Close()
 
 	assert.ErrorContains(t, err, "invalid W&B identifier")
+}
+
+func Test_Read_UnsupportedNewVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.wandb")
+	// The file version is the 0x01 byte at the end.
+	require.NoError(t, os.WriteFile(path, []byte(":W&B\xE1\xBE\x01"), 0o644))
+
+	reader, err := transactionlog.OpenReader(path, observabilitytest.NewTestLogger(t))
+	require.NoError(t, err)
+	_, err = reader.Read()
+	reader.Close()
+
+	assert.ErrorContains(t, err,
+		"a newer wandb version is required to read this file")
 }
 
 func Test_ReadAfterSeek_SkipsVerifyingHeader(t *testing.T) {

--- a/core/pkg/leveldb/record.go
+++ b/core/pkg/leveldb/record.go
@@ -349,47 +349,43 @@ func (r *Reader) isShortBlock() bool {
 	return 0 < r.n && r.n < blockSize
 }
 
-// VerifyWandbHeader checks for a W&B header with the correct version.
+// VerifyWandbHeader checks for the presence of a valid W&B header.
 //
 // The reader must be positioned at the start.
 //
 // The error wraps EOF if there's no data at all and ErrUnexpectedEOF
 // if there's not enough data to hold a header.
-func (r *Reader) VerifyWandbHeader(expectedVersion byte) error {
+//
+// On success, returns the file version number in the header.
+func (r *Reader) VerifyWandbHeader() (uint8, error) {
 	if r.blockOffset != 0 {
-		return errors.New("leveldb/record: reader not in first block")
+		return 0, errors.New("leveldb/record: reader not in first block")
 	}
 
 	if r.n == 0 {
 		if r.err = r.readBlock(); r.err != nil {
-			return r.err
+			return 0, r.err
 		}
 	}
 
 	if r.n < wandbHeaderLength {
-		return io.ErrUnexpectedEOF
+		return 0, io.ErrUnexpectedEOF
 	}
 
 	identBytes, magicBytes, version := r.buf[0:4], r.buf[4:6], r.buf[6]
 
 	if string(identBytes) != wandbHeaderIdent {
-		return fmt.Errorf(
+		return 0, fmt.Errorf(
 			"leveldb/record: invalid W&B identifier: %X (%q)",
 			identBytes, identBytes)
 	}
 
 	magic := uint16(magicBytes[0]) + uint16(magicBytes[1])<<8
 	if magic != wandbHeaderMagic {
-		return fmt.Errorf("leveldb/record: invalid W&B magic: %X", magic)
+		return 0, fmt.Errorf("leveldb/record: invalid W&B magic: %X", magic)
 	}
 
-	if version != expectedVersion {
-		return fmt.Errorf(
-			"leveldb/record: expected W&B version %d but got %d",
-			expectedVersion, version)
-	}
-
-	return nil
+	return version, nil
 }
 
 // NextOffset returns the offset from which Next() will start to read.

--- a/core/pkg/leveldb/record_internal_test.go
+++ b/core/pkg/leveldb/record_internal_test.go
@@ -919,10 +919,13 @@ func TestVerifyWandbHeader_Good(t *testing.T) {
 	data := []byte(":W&B\xE1\xBE\x0Dleveldb stuff")
 	r := NewReader(bytes.NewReader(data))
 
-	err := r.VerifyWandbHeader(0x0D)
+	version, err := r.VerifyWandbHeader()
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != 0x0D {
+		t.Fatalf("unexpected version: %d", version)
 	}
 }
 
@@ -930,7 +933,7 @@ func TestVerifyWandbHeader_TooShort(t *testing.T) {
 	data := []byte("short")
 	r := NewReader(bytes.NewReader(data))
 
-	err := r.VerifyWandbHeader(0)
+	_, err := r.VerifyWandbHeader()
 
 	if err != io.ErrUnexpectedEOF {
 		t.Fatalf("wrong error: %v", err)
@@ -941,7 +944,7 @@ func TestVerifyWandbHeader_InvalidIdent(t *testing.T) {
 	data := []byte("oops123")
 	r := NewReader(bytes.NewReader(data))
 
-	err := r.VerifyWandbHeader(0)
+	_, err := r.VerifyWandbHeader()
 
 	if !strings.Contains(err.Error(), `invalid W&B identifier: 6F6F7073 ("oops")`) {
 		t.Fatalf("wrong error: %v", err)
@@ -952,20 +955,9 @@ func TestVerifyWandbHeader_InvalidMagic(t *testing.T) {
 	data := []byte(":W&Bbad")
 	r := NewReader(bytes.NewReader(data))
 
-	err := r.VerifyWandbHeader(0)
+	_, err := r.VerifyWandbHeader()
 
 	if !strings.Contains(err.Error(), "invalid W&B magic") {
-		t.Fatalf("wrong error: %v", err)
-	}
-}
-
-func TestVerifyWandbHeader_InvalidVersion(t *testing.T) {
-	data := []byte(":W&B\xE1\xBE\x01")
-	r := NewReader(bytes.NewReader(data))
-
-	err := r.VerifyWandbHeader(0)
-
-	if !strings.Contains(err.Error(), "expected W&B version 0 but got 1") {
 		t.Fatalf("wrong error: %v", err)
 	}
 }


### PR DESCRIPTION
Improves the error message for a `.wandb` file that's too new (or too old). Syncing a file that's generated with a newer SDK will now print something like:

```
wandb: ERROR Failed to read "wandb/offline-run-20260825_133158-jx6ptvhq": a newer wandb version is required to read this file
```

When we bump the version in the future, we can update the "older version" message to include the expected version, which will be whatever was the latest version at the time the commit is merged. So, for instance, if I were to bump the version in this PR and make version 0 unsupported, I would change the message to

```
wandb<=0.28.2 is required to read this file
```

Though in practice, we'd probably have newer SDKs support both version 0 and version 1 for some time.