### PR TITLE
chore: remove deprecated video format fallback

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -65,10 +65,6 @@ When preparing a release that can include breaking changes, consider applying ch
     - Owner: @jacobromero
     - Can do in >=0.20
 
-- Require `format` argument when initializing `wandb.Video`
-    - Owner: @jacobromero
-    - Can do in >=0.20
-
 - Remove the `start_method` setting:
     - Owner: @kptkin
     - Deprecated in 0.20.0 (https://github.com/wandb/wandb/pull/9837)

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,6 +17,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Notable Changes
 
 The `.length` property on paginated objects (e.g. `Api.runs()`, `Api.sweeps()`, `run.files()`) has been removed. Use `len(...)` instead.
+`wandb.Video()` now requires the `format` argument when initializing from a numpy array or raw bytes.
 
 ### Added
 
@@ -36,6 +37,7 @@ The `.length` property on paginated objects (e.g. `Api.runs()`, `Api.sweeps()`, 
 - The message format used to communicate between internal processes has slightly changed. If you use `wandb beta core`, restart the service after upgrading `wandb`, as some operations may fail if the SDK and service versions differ. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12374)
 - `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)
 - Registry search methods (`Api.registries()`, `.collections()`, `.versions()`) now validate filter field names, rejecting unsupported field names. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12182)
+- `wandb.Video()` now requires the `format` argument when initializing from a numpy array or an io object. (@jacobromero in https://github.com/wandb/wandb/pull/12579)
 
 ### Removed
 

--- a/tests/system_tests/test_artifacts/test_object_references.py
+++ b/tests/system_tests/test_artifacts/test_object_references.py
@@ -216,7 +216,8 @@ def make_video() -> Callable[[], wandb.Video]:
     def _make_video() -> wandb.Video:
         # time, channel, height, width
         return wandb.Video(
-            np.random.randint(0, high=255, size=(4, 3, 10, 10), dtype=np.uint8)
+            np.random.randint(0, high=255, size=(4, 3, 10, 10), dtype=np.uint8),
+            format="gif",
         )
 
     return _make_video

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -739,7 +739,7 @@ def test_video_numpy_mp4(mock_run):
 def test_video_numpy_multi(mock_run):
     run = mock_run()
     video = np.random.random(size=(2, 10, 3, 28, 28))
-    vid = wandb.Video(video)
+    vid = wandb.Video(video, format="gif")
     vid.bind_to_run(run, "videos", 0)
     assert vid.to_json(run)["path"].endswith(".gif")
 
@@ -747,7 +747,7 @@ def test_video_numpy_multi(mock_run):
 def test_video_numpy_invalid():
     video = np.random.random(size=(3, 28, 28))
     with pytest.raises(ValueError):
-        wandb.Video(video)
+        wandb.Video(video, format="gif")
 
 
 def test_video_path(mock_run):
@@ -764,6 +764,29 @@ def test_video_path_invalid():
         f.write("00000")
     with pytest.raises(ValueError):
         wandb.Video("video.avi")
+
+
+def test_video_path_ignores_explicit_format(mock_run):
+    run = mock_run()
+    with open("video.mp4", "w") as f:
+        f.write("00000")
+    vid = wandb.Video("video.mp4", format="webm")
+    vid.bind_to_run(run, "videos", 0)
+    assert vid._format == "mp4"
+    assert vid.to_json(run)["path"].endswith(".mp4")
+
+
+@pytest.mark.parametrize(
+    "data_or_path",
+    [
+        np.random.randint(255, size=(10, 3, 28, 28)),
+        io.BytesIO(b"00000"),
+    ],
+    ids=["numpy", "bytesio"],
+)
+def test_video_requires_format(data_or_path):
+    with pytest.raises(ValueError, match="requires a `format` argument"):
+        wandb.Video(data_or_path)
 
 
 def test_video_encodes_with_spinner__displays_by_default(monkeypatch):

--- a/tests/unit_tests/test_media/test_media_logging.py
+++ b/tests/unit_tests/test_media/test_media_logging.py
@@ -22,7 +22,7 @@ def audio_media() -> wandb.Audio:
 @pytest.fixture
 def video_media() -> wandb.Video:
     frames = np.random.randint(low=0, high=256, size=(10, 3, 100, 100), dtype=np.uint8)
-    return wandb.Video(frames)
+    return wandb.Video(frames, format="gif")
 
 
 @pytest.fixture

--- a/tools/perf/scripts/bench_run_log.py
+++ b/tools/perf/scripts/bench_run_log.py
@@ -323,7 +323,7 @@ class PayloadGenerator:
                 dtype=np.uint8,
             )
             video_obj = wandb.Video(
-                frames, fps=fps, caption=f"Randomly generated video {i}"
+                frames, format="mp4", fps=fps, caption=f"Randomly generated video {i}"
             )
 
             payloads.append(

--- a/wandb/__init__.pyi
+++ b/wandb/__init__.pyi
@@ -701,7 +701,7 @@ def log(
             size=(10, 3, 100, 100),
             dtype=np.uint8,
         )
-        run.log({"video": wandb.Video(frames, fps=4)})
+        run.log({"video": wandb.Video(frames, format="mp4", fps=4)})
     ```
 
     Matplotlib plot

--- a/wandb/integration/diffusers/resolvers/multimodal.py
+++ b/wandb/integration/diffusers/resolvers/multimodal.py
@@ -752,7 +752,10 @@ class DiffusersMultiModalPipelineResolver:
                 wandb.log(
                     {
                         f"Generated-Video/Pipeline-Call-{self.pipeline_call_count}": wandb.Video(
-                            postprocess_pils_to_np(image), fps=4, caption=caption
+                            postprocess_pils_to_np(image),
+                            format="mp4",
+                            fps=4,
+                            caption=caption,
                         )
                     }
                 )
@@ -806,7 +809,9 @@ class DiffusersMultiModalPipelineResolver:
                 SUPPORTED_MULTIMODAL_PIPELINES[self.pipeline_name]["output-type"]
                 == "video"
             ):
-                table_row.append(wandb.Video(postprocess_pils_to_np(image), fps=4))
+                table_row.append(
+                    wandb.Video(postprocess_pils_to_np(image), format="mp4", fps=4)
+                )
             elif (
                 SUPPORTED_MULTIMODAL_PIPELINES[self.pipeline_name]["output-type"]
                 == "audio"
@@ -844,7 +849,7 @@ class DiffusersMultiModalPipelineResolver:
             wandb.log(
                 {
                     f"Generated-Video/Pipeline-Call-{self.pipeline_call_count}": wandb.Video(
-                        video, fps=4, caption=kwargs["prompt"]
+                        video, format="mp4", fps=4, caption=kwargs["prompt"]
                     )
                 }
             )
@@ -855,7 +860,7 @@ class DiffusersMultiModalPipelineResolver:
                 kwargs[loggable_kwarg_ids[idx]]
                 for idx in range(len(loggable_kwarg_ids))
             ]
-            table_row.append(wandb.Video(video, fps=4))
+            table_row.append(wandb.Video(video, format="mp4", fps=4))
             self.wandb_table.add_data(*table_row)
         else:
             loggable_kwarg_ids = SUPPORTED_MULTIMODAL_PIPELINES[self.pipeline_name][

--- a/wandb/sdk/data_types/video.py
+++ b/wandb/sdk/data_types/video.py
@@ -80,6 +80,26 @@ class Video(BatchableMedia):
     _width: int | None
     _height: int | None
 
+    @staticmethod
+    def _require_format(
+        format: str | None,
+        source_description: str,
+    ) -> str:
+        """Validate a `format` argument that is required for the given source.
+
+        <!-- lazydoc-ignore -->
+        """
+        if format is None:
+            raise ValueError(
+                f"wandb.Video requires a `format` argument when initializing "
+                f"with {source_description}."
+            )
+        if format not in Video.EXTS:
+            raise ValueError(
+                "wandb.Video accepts {} formats".format(", ".join(Video.EXTS))
+            )
+        return format
+
     def __init__(
         self,
         data_or_path: str | pathlib.Path | np.ndarray | TextIO | BytesIO,
@@ -106,7 +126,6 @@ class Video(BatchableMedia):
                 or io object. This parameter will be used to determine the format
                 to use when encoding the video data. Accepted values are "gif",
                 "mp4", "webm", or "ogg".
-                If no value is provided, the default format will be "gif".
 
         Examples:
         Log a numpy array as a video
@@ -125,20 +144,9 @@ class Video(BatchableMedia):
         """
         super().__init__(caption=caption)
 
-        if format is None:
-            wandb.termwarn(
-                "`format` argument was not provided, defaulting to `gif`. "
-                "This parameter will be required in v0.20.0, "
-                "please specify the format explicitly."
-            )
-        self._format = format or "gif"
         self._width = None
         self._height = None
         self._channels = None
-        if self._format not in Video.EXTS:
-            raise ValueError(
-                "wandb.Video accepts {} formats".format(", ".join(Video.EXTS))
-            )
 
         if isinstance(data_or_path, (BytesIO, str)) and fps:
             msg = (
@@ -148,6 +156,7 @@ class Video(BatchableMedia):
             wandb.termwarn(msg)
 
         if isinstance(data_or_path, BytesIO):
+            self._format = self._require_format(format, "raw bytes (an io object)")
             filename = os.path.join(
                 MEDIA_TMP.name, runid.generate_id() + "." + self._format
             )
@@ -163,9 +172,11 @@ class Video(BatchableMedia):
                 raise ValueError(
                     "wandb.Video accepts {} formats".format(", ".join(Video.EXTS))
                 )
+            self._format = ext
             self._set_file(data_or_path, is_tmp=False)
             # ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 data_or_path
         else:
+            self._format = self._require_format(format, "a numpy array")
             if hasattr(data_or_path, "numpy"):  # TF data eager tensors
                 self.data = data_or_path.numpy()
             elif util.is_numpy_array(data_or_path):

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -1949,7 +1949,7 @@ class Run:
                 size=(10, 3, 100, 100),
                 dtype=np.uint8,
             )
-            run.log({"video": wandb.Video(frames, fps=4)})
+            run.log({"video": wandb.Video(frames, format="mp4", fps=4)})
         ```
 
         Matplotlib plot


### PR DESCRIPTION
Description
-----------

What does the PR do? Include a concise description of the PR contents.

For a year, when a `format` value was not provided a warning was printed to the users terminal that this would be required.
This PR not makes the format value required rather than warning and defaulting to `gif`.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
