### PR TITLE
chore: clean up wandb login verify breaking entry

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -32,11 +32,6 @@ When preparing a release that can include breaking changes, consider applying ch
 
 ## Changes
 
-- Make `--verify` the default for `wandb login`
-    - PR: https://github.com/wandb/wandb/pull/9230
-    - Owner: @jacobromero
-    - Can do in >=0.20
-
 - Remove `quiet` argument from `run.finish()`
     - Owner: @kptkin
     - Deprecated in 0.18.7 (https://github.com/wandb/wandb/pull/8794)


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

The `--verify` flag became the default in https://github.com/wandb/wandb/pull/12347 but I forgot to clean up this entry, so doing that here 🙂 
