### PR TITLE
chore: clean up wandb.save no-args breaking entry

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -83,11 +83,6 @@ When preparing a release that can include breaking changes, consider applying ch
     - Owner: @jacobromero
     - Can do in >=0.21
 
-- Disallow calling `wandb.save` without args:
-    - Owner: @dmitryduev
-    - Deprecated in 0.12.10 (https://github.com/wandb/wandb/pull/3028)
-    - Can do in >=0.14
-
 - Remove `wandb.Run::project_name()`:
     - Owner: @kptkin
     - Deprecated in 0.19.10 (https://github.com/wandb/wandb/pull/8925)


### PR DESCRIPTION
Description
-----------
Cleaning up a stale entry in `BREAKING.md`: this breaking change already shipped in v0.20.0 — https://github.com/wandb/wandb/pull/9962 made the `glob_str` argument to `Run.save` required and removed the deprecation plumbing.