### PR TITLE
chore: raise macOS wheel deployment target to 13

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -215,8 +215,12 @@ jobs:
               --ignore-missing-dependencies \
               -w {dest_dir} \
               -v {wheel}
+          # Sets the minimum macOS version for the wheels. Must be at least
+          # the minimum supported by the Go toolchain (go1.27 stamps a
+          # minimum of macOS 13 into wandb-core), or delocate fails the
+          # wheel repair step.
           CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=12
+            MACOSX_DEPLOYMENT_TARGET=13.0
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -23,6 +23,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Removed the deprecated `quiet` argument of `run.finish()` and `wandb.finish()`. Use `wandb.Settings(quiet=...)` instead.
 - Removed the deprecated `run.project_name()`, `run.get_url()`, `run.get_project_url()`, and `run.get_sweep_url()` methods. Use the `run.project`, `run.url`, `run.project_url`, and `run.sweep_url` properties instead.
 - `wandb.Image` no longer normalizes pixel values. Callers must now ensure their data already falls within the range [0, 255].
+- On macOS, `wandb` now requires macOS 13 (Ventura) or newer.
 
 ### Added
 
@@ -44,6 +45,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 - `wandb.sandbox` now allows GPU resource requests for sandboxes instead of rejecting `resources.gpu` client-side (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12455)
 - Registry search methods (`Api.registries()`, `.collections()`, `.versions()`) now validate filter field names, rejecting unsupported field names. (@tonyyli-wandb in https://github.com/wandb/wandb/pull/12182)
 - `wandb.Video()` now requires the `format` argument when initializing from a numpy array or an io object. (@jacobromero in https://github.com/wandb/wandb/pull/12579)
+- The macOS wheels now require macOS 13 (Ventura) or newer; macOS 12 reached end of life in 2024 (@dmitryduev in https://github.com/wandb/wandb/pull/12599)
 
 ### Removed
 


### PR DESCRIPTION
Description
-----------
Both macOS wheel jobs in the [0.29.0 release run](https://github.com/wandb/wandb/actions/runs/33022027743) failed in the wheel-repair step:

```
delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 12:
.../wheel/wandb/bin/wandb-core has a minimum target of 13.0
```

Go 1.27 (#12508) raised the minimum macOS version it stamps into darwin binaries from 12.0 to 13.0, so `wandb-core` no longer satisfies the `MACOSX_DEPLOYMENT_TARGET=12` pinned in the release workflow. This PR raises the target to 13.0, which changes the published wheel tags from `macosx_12_0_*` to `macosx_13_0_*` — i.e., pip on macOS 12 (EOL since late 2024) will no longer pick up new wheels. It couldn't have run them anyway: the Go binary inside refuses to run below 13.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Reproduced the root cause locally: a trivial `CGO_ENABLED=0 go1.27.0 build` produces a binary with `LC_BUILD_VERSION minos 13.0` (`otool -l`), while v0.28.2 (built with go1.26.5, minos 12.0) released fine with the previous target. delocate's error message itself suggests `MACOSX_DEPLOYMENT_TARGET=13.0`. Will verify by re-running the release workflow once this lands.