### PR TITLE
fix(sdk): don't time out file transfers and other long-running requests to wandb-core

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -13,3 +13,7 @@ sections:
 Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
+
+### Fixed
+
+- File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)

--- a/wandb/apis/public/service_api.py
+++ b/wandb/apis/public/service_api.py
@@ -96,15 +96,14 @@ class ServiceApi:
         """Send an API request to the backend service.
 
         Creates the backend service connection if it has not been created yet.
-        Falls back to the timeout this API was created with when none is
-        given.
+
+        A timeout of None means to wait indefinitely for the response. This
+        is required for requests that take as long as they take, such as
+        file transfers, which wandb-core acknowledges only on completion.
         """
         session = self._get_api_session()
         request.api_id = session.api_id
-        return session.connection.api_request(
-            request,
-            timeout=self._timeout if timeout is None else timeout,
-        )
+        return session.connection.api_request(request, timeout=timeout)
 
     def finalize(
         self,
@@ -186,7 +185,10 @@ class ServiceApi:
                 rename_fields=rename_fields,
             )
         )
-        resp = self.send_api_request(req, timeout=timeout)
+        resp = self.send_api_request(
+            req,
+            timeout=self._timeout if timeout is None else timeout,
+        )
         return parse(resp.graphql_response.data_json)
 
     def authenticate(
@@ -216,7 +218,10 @@ class ServiceApi:
         req = ApiRequest(
             auth_request=AuthRequest(authenticate_request=AuthenticateRequest())
         )
-        resp = self.send_api_request(req, timeout=timeout)
+        resp = self.send_api_request(
+            req,
+            timeout=self._timeout if timeout is None else timeout,
+        )
         return resp.auth_response.authenticate_response
 
     def access_token(
@@ -250,7 +255,10 @@ class ServiceApi:
         req = ApiRequest(
             auth_request=AuthRequest(get_access_token_request=GetAccessTokenRequest())
         )
-        resp = self.send_api_request(req, timeout=timeout)
+        resp = self.send_api_request(
+            req,
+            timeout=self._timeout if timeout is None else timeout,
+        )
         return resp.auth_response.get_access_token_response.access_token or None
 
     async def send_api_request_async(


### PR DESCRIPTION
## Description

Fixes a 0.29.0 regression where some file transfers routed through wandb-core fail once they take longer than ~20 seconds:

```
CommError: Failed to execute API request: the service process is busy and did not respond in time.
```

Found in Sentry [SDK-MM8](https://weights-biases.sentry.io/issues/7695019481/): a `wandb sync` of a large tfevents file to a GCS signed URL timed out mid-upload.

I got a bit overenthusiastic in #12442: https://github.com/wandb/wandb/pull/12442/changes#diff-5a60fc6890734913eaa626907b60ac851a3c1cf4452706fc990848f4961e18ee, this reverts that change.

