### PR TITLE
refactor: simplify tensorboard Emitter.SetTFStep

### DIFF
--- a/core/internal/tensorboard/emitter.go
+++ b/core/internal/tensorboard/emitter.go
@@ -20,7 +20,7 @@ type Emitter interface {
 	// SetTFStep sets the TFEvent step for this W&B history step.
 	//
 	// This is only added to the history if EmitHistory is used.
-	SetTFStep(key pathtree.TreePath, step int64)
+	SetTFStep(step int64)
 
 	// SetTFWallTime sets the TFEvent wall time for this W&B history step.
 	//
@@ -54,7 +54,6 @@ type tfEmitter struct {
 	mediaFiles   []string
 
 	hasTFStep bool
-	tfStepKey []string
 	tfStep    int64
 
 	hasWallTime bool
@@ -148,7 +147,7 @@ func (e *tfEmitter) historyRecord() *spb.Record {
 	if e.hasTFStep {
 		items = append(items,
 			&spb.HistoryItem{
-				NestedKey: e.tfStepKey,
+				Key:       "global_step",
 				ValueJson: fmt.Sprintf("%v", e.tfStep),
 			})
 	}
@@ -180,9 +179,8 @@ func (e *tfEmitter) historyRecord() *spb.Record {
 	}
 }
 
-func (e *tfEmitter) SetTFStep(key pathtree.TreePath, step int64) {
+func (e *tfEmitter) SetTFStep(step int64) {
 	e.hasTFStep = true
-	e.tfStepKey = key.Labels()
 	e.tfStep = step
 }
 

--- a/core/internal/tensorboard/emitter_test.go
+++ b/core/internal/tensorboard/emitter_test.go
@@ -73,7 +73,7 @@ func TestAccumulatesHistory(t *testing.T) {
 func TestStepAndWallTime(t *testing.T) {
 	emitter := tensorboard.NewTFEmitter(settings.From(&spb.Settings{}))
 
-	emitter.SetTFStep(pathtree.PathOf("train", "global_step"), 9)
+	emitter.SetTFStep(9)
 	emitter.SetTFWallTime(2.5)
 	emitter.EmitHistory(pathtree.PathOf("x"), "4")
 	fakeRunWork := runworktest.New()
@@ -84,7 +84,7 @@ func TestStepAndWallTime(t *testing.T) {
 	assertProtoEqual(t,
 		localFlushPartialHistory([]*spb.HistoryItem{
 			{NestedKey: []string{"x"}, ValueJson: "4"},
-			{NestedKey: []string{"train", "global_step"}, ValueJson: "9"},
+			{Key: "global_step", ValueJson: "9"},
 			{Key: "_timestamp", ValueJson: "2.5"},
 		}),
 		records[0])

--- a/core/internal/tensorboard/tfeventconverter.go
+++ b/core/internal/tensorboard/tfeventconverter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/wandb/wandb/core/internal/observability"
-	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/tensorboard/tbproto"
 )
 
@@ -32,7 +31,7 @@ func (h *TFEventConverter) ConvertNext(
 	event *tbproto.TFEvent,
 	logger *observability.CoreLogger,
 ) {
-	emitter.SetTFStep(pathtree.PathOf("global_step"), event.Step)
+	emitter.SetTFStep(event.Step)
 	emitter.SetTFWallTime(event.WallTime)
 
 	for _, value := range event.GetSummary().GetValue() {

--- a/core/internal/tensorboard/tfeventconverter_test.go
+++ b/core/internal/tensorboard/tfeventconverter_test.go
@@ -169,17 +169,12 @@ func summaryEvent(
 
 // mockEmitter is a mock of the Emitter interface.
 type mockEmitter struct {
-	SetTFStepCalls     []mockEmitter_SetTFStep
+	SetTFStepCalls     []int64
 	SetTFWallTimeCalls []float64
 	EmitHistoryCalls   []mockEmitter_EmitHistory
 	EmitChartCalls     []mockEmitter_EmitChart
 	EmitTableCalls     []mockEmitter_EmitTable
 	EmitImagesCalls    []mockEmitter_EmitImages
-}
-
-type mockEmitter_SetTFStep struct {
-	Key  pathtree.TreePath
-	Step int64
 }
 
 type mockEmitter_EmitHistory struct {
@@ -202,9 +197,8 @@ type mockEmitter_EmitImages struct {
 	Images []wbvalue.Image
 }
 
-func (e *mockEmitter) SetTFStep(key pathtree.TreePath, step int64) {
-	e.SetTFStepCalls = append(e.SetTFStepCalls,
-		mockEmitter_SetTFStep{key, step})
+func (e *mockEmitter) SetTFStep(step int64) {
+	e.SetTFStepCalls = append(e.SetTFStepCalls, step)
 }
 
 func (e *mockEmitter) SetTFWallTime(wallTime float64) {
@@ -248,12 +242,8 @@ func TestConvertStepAndTimestamp(t *testing.T) {
 		observabilitytest.NewTestLogger(t),
 	)
 
-	assert.Equal(t,
-		[]mockEmitter_SetTFStep{{pathtree.PathOf("global_step"), 123}},
-		emitter.SetTFStepCalls)
-	assert.Equal(t,
-		[]float64{0.345},
-		emitter.SetTFWallTimeCalls)
+	assert.Equal(t, []int64{123}, emitter.SetTFStepCalls)
+	assert.Equal(t, []float64{0.345}, emitter.SetTFWallTimeCalls)
 }
 
 func TestConvertScalar(t *testing.T) {


### PR DESCRIPTION
Since the `global_step` is no longer namespaced after #12372, the method doesn't need to accept a key.