### PR TITLE
fix(leet): stop reporting expected workspace errors to telemetry

### DIFF
--- a/core/internal/leet/watchermanager.go
+++ b/core/internal/leet/watchermanager.go
@@ -43,7 +43,7 @@ func (wm *WatcherManager) Start(runPath string) error {
 		case wm.outChan <- FileChangedMsg{}:
 			wm.logger.Debug("watcher: FileChangedMsg sent")
 		default:
-			wm.logger.CaptureWarn("watcher: outChan full, dropping FileChangedMsg")
+			wm.logger.Warn("watcher: outChan full, dropping FileChangedMsg")
 		}
 	})
 

--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -169,10 +169,9 @@ func (w *Workspace) handleWorkspaceRunDirs(msg WorkspaceRunDirsMsg) tea.Cmd {
 	pollCmd := w.pollWandbDirCmd(wandbDirPollInterval)
 
 	if msg.Err != nil {
-		w.logger.CaptureError(
-			"leet",
-			fmt.Errorf("workspace: wandb dir scan: %v", msg.Err),
-		)
+		// The poll loop retries and re-reports on every tick, so keep this
+		// out of error telemetry.
+		w.logger.Error(fmt.Sprintf("workspace: wandb dir scan: %v", msg.Err))
 		return pollCmd
 	}
 
@@ -297,13 +296,10 @@ func (w *Workspace) handleWorkspaceRunOverviewPreloaded(
 		ro.SetRunState(RunStateUnknown)
 
 	case msg.Err != nil && !errors.Is(msg.Err, errRunRecordNotFound) && !os.IsNotExist(msg.Err):
-		// Best-effort logging for unexpected failures; avoid spamming for
-		// "file not ready yet" or missing run records.
-		err := fmt.Errorf("workspace: preload run overview for %s: %v", msg.RunKey, msg.Err)
-		w.logger.CaptureError(
-			"leet",
-			err,
-		)
+		// Truncated or partially written .wandb files fail here on every
+		// scan, so keep this out of error telemetry.
+		w.logger.Error(fmt.Sprintf(
+			"workspace: preload run overview for %s: %v", msg.RunKey, msg.Err))
 	}
 
 	// Keep draining the queue.

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -807,10 +807,10 @@ func (w *Workspace) handleHeartbeat() tea.Cmd {
 // stream, so mark it failed instead of leaving it silently frozen in
 // whatever state it was in.
 func (w *Workspace) handleRunReadErr(msg WorkspaceRunReadErrMsg) tea.Cmd {
-	w.logger.CaptureError(
-		"leet",
-		fmt.Errorf("workspace: run %s read failed: %v", msg.RunKey, msg.Err),
-	)
+	// A dead run's file often ends mid-record, so keep this out of error
+	// telemetry.
+	w.logger.Error(fmt.Sprintf(
+		"workspace: run %s read failed: %v", msg.RunKey, msg.Err))
 
 	run := w.runsByKey[msg.RunKey]
 	if run == nil {


### PR DESCRIPTION
Description
-----------
Did some quick analysis of event in sentry pre-shutdown, and these three expected file-state error signatures account for like 97% of the sdk-leet Sentry project volume (about 200k events in the last 90 days: the run overview preload, the wandb dir scan, and live run reads. Log these locally instead of capturing them to error telemetry.
