### PR TITLE
feat(leet): send launch telemetry through the W&B OTel proxy

### DIFF
--- a/core/.golangci.yml
+++ b/core/.golangci.yml
@@ -23,7 +23,7 @@ linters:
     gocritic:
       settings:
         hugeParam:
-          sizeThreshold: 144
+          sizeThreshold: 176
       disabled-checks:
         - unnamedResult
       enabled-tags:

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -178,7 +178,7 @@ func serviceMain() int {
 		defer func() { _ = file.Close() }()
 	}
 
-	analytics.ConfigureOTelErrorHandler()
+	analytics.ConfigureOTelErrorHandler(slog.Default())
 
 	// Record certain signals in the log file for debugging.
 	signalCh := make(chan os.Signal, 1)
@@ -241,12 +241,23 @@ func leetMain(args []string) int {
 	flushSentry := configureLeetSentry(opts.disableAnalytics, leetSentryMessage(&opts))
 	defer flushSentry()
 
-	logger, closeLogger, err := newLeetLogger(opts.logLevel)
+	recorder, stopTelemetry := leet.ConfigureTelemetry(leet.TelemetryParams{
+		Disabled: opts.disableAnalytics,
+		Mode:     leetMode(&opts),
+		Commit:   commit,
+		BaseURL:  opts.baseURL,
+	})
+	defer stopTelemetry()
+
+	logger, closeLogger, err := newLeetLogger(opts.logLevel, recorder)
 	if err != nil {
 		fmt.Println("fatal:", err)
 		return exitCodeErrorInternal
 	}
 	defer closeLogger()
+
+	analytics.ConfigureOTelErrorHandler(logger.Logger)
+	logger.RecordTelemetry("leet_launch", nil)
 
 	return runLeetCommand(&opts, logger)
 }
@@ -254,6 +265,7 @@ func leetMain(args []string) int {
 type leetOptions struct {
 	logLevel         int
 	disableAnalytics bool
+	baseURL          string
 	runFile          string
 	pprofAddr        string
 	editConfig       bool
@@ -303,6 +315,13 @@ func bindLeetFlags(fs *flag.FlagSet, opts *leetOptions) {
 		"no-observability",
 		false,
 		"Disables observability features such as metrics and logging analytics.",
+	)
+	fs.StringVar(
+		&opts.baseURL,
+		"base-url",
+		"",
+		"URL of the W&B server to upload telemetry to."+
+			" Defaults to the public W&B API.",
 	)
 	fs.StringVar(
 		&opts.runFile,
@@ -455,7 +474,24 @@ func leetSentryMessage(opts *leetOptions) string {
 	}
 }
 
-func newLeetLogger(logLevel int) (*observability.CoreLogger, func(), error) {
+// leetMode names the launch mode for telemetry.
+func leetMode(opts *leetOptions) string {
+	switch {
+	case opts.editConfig:
+		return "config"
+	case opts.symonMode:
+		return "symon"
+	case opts.inspect:
+		return "inspect"
+	default:
+		return "leet"
+	}
+}
+
+func newLeetLogger(
+	logLevel int,
+	recorder *analytics.TelemetryRecorder,
+) (*observability.CoreLogger, func(), error) {
 	logWriter := io.Discard
 	closeLogWriter := func() {}
 
@@ -479,7 +515,7 @@ func newLeetLogger(logLevel int) (*observability.CoreLogger, func(), error) {
 			&slog.HandlerOptions{Level: slog.Level(logLevel)},
 		)),
 		observability.NewSentryContext(sentry.CurrentHub()),
-		analytics.NewTelemetryRecorder(nil, analytics.NewTelemetryContext()),
+		recorder,
 	)
 	return logger, closeLogWriter, nil
 }

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -47,10 +47,13 @@ const (
 	logsPath    = "/sdk/otel/v1/logs"
 )
 
-// ConfigureOTelErrorHandler routes OpenTelemetry SDK errors to the core logger.
-func ConfigureOTelErrorHandler() {
+// ConfigureOTelErrorHandler routes OpenTelemetry SDK errors to the logger.
+//
+// Without this, the OpenTelemetry SDK prints errors to stderr, which
+// corrupts the display of terminal UIs like leet.
+func ConfigureOTelErrorHandler(logger *slog.Logger) {
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		slog.Error(
+		logger.Error(
 			"analytics: failed to send telemetry to backend proxy",
 			"error", err,
 		)
@@ -63,11 +66,19 @@ type LowCardinalityAttributes struct {
 	GoVersion       string
 	WandbVersion    string
 	OperatingSystem string
+	Architecture    string
 	ErrorOriginator string
 
 	PythonVersion string
 	PythonRuntime string
 	ExceptionType string
+
+	// LeetMode is the leet launch mode: leet, config, inspect or symon.
+	LeetMode string
+
+	// ExecutionContext classifies where the process runs:
+	// kubernetes, container, slurm, ci, ssh or local.
+	ExecutionContext string
 }
 
 // merge overwrites attrs with the non-empty fields of other.
@@ -75,22 +86,29 @@ func (attrs *LowCardinalityAttributes) merge(other LowCardinalityAttributes) {
 	attrs.GoVersion = cmp.Or(other.GoVersion, attrs.GoVersion)
 	attrs.WandbVersion = cmp.Or(other.WandbVersion, attrs.WandbVersion)
 	attrs.OperatingSystem = cmp.Or(other.OperatingSystem, attrs.OperatingSystem)
+	attrs.Architecture = cmp.Or(other.Architecture, attrs.Architecture)
 	attrs.ErrorOriginator = cmp.Or(other.ErrorOriginator, attrs.ErrorOriginator)
 
 	attrs.PythonVersion = cmp.Or(other.PythonVersion, attrs.PythonVersion)
 	attrs.PythonRuntime = cmp.Or(other.PythonRuntime, attrs.PythonRuntime)
 	attrs.ExceptionType = cmp.Or(other.ExceptionType, attrs.ExceptionType)
+
+	attrs.LeetMode = cmp.Or(other.LeetMode, attrs.LeetMode)
+	attrs.ExecutionContext = cmp.Or(other.ExecutionContext, attrs.ExecutionContext)
 }
 
 func (attrs LowCardinalityAttributes) toMap() map[string]string {
 	out := map[string]string{
-		"go_version":       attrs.GoVersion,
-		"operating_system": attrs.OperatingSystem,
-		"error.originator": attrs.ErrorOriginator,
-		"python_version":   attrs.PythonVersion,
-		"python_runtime":   attrs.PythonRuntime,
-		"exception_type":   attrs.ExceptionType,
-		"wandb_version":    attrs.WandbVersion,
+		"go_version":        attrs.GoVersion,
+		"operating_system":  attrs.OperatingSystem,
+		"architecture":      attrs.Architecture,
+		"error.originator":  attrs.ErrorOriginator,
+		"python_version":    attrs.PythonVersion,
+		"python_runtime":    attrs.PythonRuntime,
+		"exception_type":    attrs.ExceptionType,
+		"wandb_version":     attrs.WandbVersion,
+		"leet_mode":         attrs.LeetMode,
+		"execution_context": attrs.ExecutionContext,
 	}
 	maps.DeleteFunc(out, func(_ string, value string) bool {
 		return value == ""
@@ -134,6 +152,7 @@ func NewTelemetryContext() TelemetryContext {
 		WandbVersion:    version.Version,
 		GoVersion:       runtime.Version(),
 		OperatingSystem: runtime.GOOS,
+		Architecture:    runtime.GOARCH,
 	}
 
 	return TelemetryContext{
@@ -401,6 +420,31 @@ func NewOpenTelemetryProxy(
 		return nil
 	}
 
+	return newOpenTelemetryProxy(ctx, wandbSettings, serviceName)
+}
+
+// NewOpenTelemetryProxyUnchecked is like NewOpenTelemetryProxy except that it
+// skips the network probe checking whether the server supports the proxy API.
+//
+// Use it with endpoints known to expose the API when blocking on a network
+// round trip at construction time is not acceptable.
+func NewOpenTelemetryProxyUnchecked(
+	ctx context.Context,
+	wandbSettings *settings.Settings,
+	serviceName string,
+) *OpenTelemetryProxy {
+	if disabled.Load() || wandbSettings.IsOffline() {
+		return nil
+	}
+
+	return newOpenTelemetryProxy(ctx, wandbSettings, serviceName)
+}
+
+func newOpenTelemetryProxy(
+	ctx context.Context,
+	wandbSettings *settings.Settings,
+	serviceName string,
+) *OpenTelemetryProxy {
 	httpClient, err := newOTLPHTTPClient(wandbSettings)
 	if err != nil {
 		slog.Debug(

--- a/core/internal/leet/analytics.go
+++ b/core/internal/leet/analytics.go
@@ -1,0 +1,132 @@
+package leet
+
+import (
+	"cmp"
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/wandb/wandb/core/internal/analytics"
+	"github.com/wandb/wandb/core/internal/settings"
+	"github.com/wandb/wandb/core/internal/version"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// defaultTelemetryBaseURL receives telemetry when no W&B server is
+// configured.
+const defaultTelemetryBaseURL = "https://api.wandb.ai"
+
+// TelemetryParams configures ConfigureTelemetry.
+type TelemetryParams struct {
+	// Disabled turns off telemetry for the whole process.
+	Disabled bool
+
+	// Mode is the launch mode: leet, config, inspect or symon.
+	Mode string
+
+	// Commit is the git commit the binary was built from.
+	Commit string
+
+	// BaseURL is the W&B server to upload telemetry to.
+	// Empty means the public W&B API.
+	BaseURL string
+}
+
+// ConfigureTelemetry builds the recorder that forwards leet telemetry to
+// Datadog through the W&B OpenTelemetry proxy.
+//
+// Telemetry is uploaded, unauthenticated, to the given server so that
+// dedicated instances ingest their own traffic. Servers without the proxy
+// API reject the uploads, which are dropped quietly; construction never
+// touches the network, so leet startup is not delayed.
+//
+// The returned function flushes pending records and stops uploads; call it
+// on exit. The recorder is nil, and telemetry a no-op, when disabled.
+func ConfigureTelemetry(
+	params TelemetryParams,
+) (*analytics.TelemetryRecorder, func()) {
+	if params.Disabled {
+		analytics.Disable()
+		return nil, func() {}
+	}
+
+	baseURL := strings.TrimRight(
+		cmp.Or(params.BaseURL, defaultTelemetryBaseURL),
+		"/",
+	)
+	proxy := analytics.NewOpenTelemetryProxyUnchecked(
+		context.Background(),
+		settings.From(&spb.Settings{
+			BaseUrl: wrapperspb.String(baseURL),
+		}),
+		"wandb-leet",
+	)
+	if proxy == nil {
+		return nil, func() {}
+	}
+
+	highCardinalityAttributes := map[string]string{
+		"commit":      params.Commit,
+		"environment": version.Environment,
+	}
+	if hostname, err := os.Hostname(); err == nil {
+		highCardinalityAttributes["hostname"] = hostname
+	}
+	if terminal := terminalName(); terminal != "" {
+		highCardinalityAttributes["terminal"] = terminal
+	}
+
+	recorder := analytics.NewTelemetryRecorder(
+		proxy,
+		analytics.NewTelemetryContext(),
+	).With(
+		analytics.LowCardinalityAttributes{
+			LeetMode:         params.Mode,
+			ExecutionContext: detectExecutionContext(),
+		},
+		highCardinalityAttributes,
+	)
+
+	return recorder, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = proxy.Shutdown(ctx)
+	}
+}
+
+// detectExecutionContext classifies the environment leet runs in.
+//
+// The result is used as a metric attribute, so it must stay low-cardinality.
+func detectExecutionContext() string {
+	switch {
+	case os.Getenv("KUBERNETES_SERVICE_HOST") != "":
+		return "kubernetes"
+	case fileExists("/.dockerenv") || fileExists("/run/.containerenv"):
+		return "container"
+	case os.Getenv("SLURM_JOB_ID") != "":
+		return "slurm"
+	case os.Getenv("CI") != "":
+		return "ci"
+	case os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "":
+		return "ssh"
+	default:
+		return "local"
+	}
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// terminalName identifies the terminal emulator, or the terminal type when
+// the emulator does not advertise itself.
+func terminalName() string {
+	if termProgram := os.Getenv("TERM_PROGRAM"); termProgram != "" {
+		return termProgram
+	}
+	return os.Getenv("TERM")
+}

--- a/tests/unit_tests/test_cli_leet.py
+++ b/tests/unit_tests/test_cli_leet.py
@@ -7,15 +7,25 @@ from wandb.cli import cli, leet
 from wandb.errors import WandbCoreNotAvailableError
 
 
+_BASE_URL = "https://api.wandb.ai"
+
+
 @pytest.fixture
 def core_calls(monkeypatch) -> list[list[str]]:
     """Stub out wandb-core and record the arguments it would be invoked with."""
     calls: list[list[str]] = []
 
+    class _StubSettings:
+        base_url = _BASE_URL
+
+    class _StubSingleton:
+        settings = _StubSettings()
+
     monkeypatch.setattr(leet, "get_core_path", lambda: "wandb-core")
     monkeypatch.setattr(leet, "error_reporting_enabled", lambda: True)
     monkeypatch.setattr(leet, "is_debug", lambda default: False)
     monkeypatch.setattr(leet, "_run_core", lambda args, env=None: calls.append(args))
+    monkeypatch.setattr(leet.wandb_setup, "singleton", lambda: _StubSingleton())
 
     return calls
 
@@ -68,7 +78,9 @@ def test_leet_defaults_to_run_command(runner, core_calls, tmp_path: pathlib.Path
     result = runner.invoke(cli.cli, ["leet", str(wandb_dir)])
 
     assert result.exit_code == 0
-    assert core_calls == [["wandb-core", "leet", str(wandb_dir.resolve())]]
+    assert core_calls == [
+        ["wandb-core", "leet", "--base-url", _BASE_URL, str(wandb_dir.resolve())]
+    ]
 
 
 def test_leet_resolves_run_directory(runner, core_calls, tmp_path: pathlib.Path):
@@ -84,6 +96,8 @@ def test_leet_resolves_run_directory(runner, core_calls, tmp_path: pathlib.Path)
         [
             "wandb-core",
             "leet",
+            "--base-url",
+            _BASE_URL,
             "--run-file",
             str(run_file.resolve()),
             str((tmp_path / "wandb").resolve()),
@@ -106,6 +120,8 @@ def test_leet_inspect_resolves_run_directory(
         [
             "wandb-core",
             "leet",
+            "--base-url",
+            _BASE_URL,
             "--inspect",
             "--run-file",
             str(run_file.resolve()),
@@ -123,7 +139,16 @@ def test_leet_inspect_wandb_dir_uses_latest_run(
     result = runner.invoke(cli.cli, ["leet", "inspect", str(wandb_dir)])
 
     assert result.exit_code == 0
-    assert core_calls == [["wandb-core", "leet", "--inspect", str(wandb_dir.resolve())]]
+    assert core_calls == [
+        [
+            "wandb-core",
+            "leet",
+            "--base-url",
+            _BASE_URL,
+            "--inspect",
+            str(wandb_dir.resolve()),
+        ]
+    ]
 
 
 def test_beta_leet_is_an_alias(runner, core_calls, tmp_path: pathlib.Path):
@@ -134,4 +159,6 @@ def test_beta_leet_is_an_alias(runner, core_calls, tmp_path: pathlib.Path):
 
     assert result.exit_code == 0
     assert "generally available as `wandb leet`" in result.stderr
-    assert core_calls == [["wandb-core", "leet", str(wandb_dir.resolve())]]
+    assert core_calls == [
+        ["wandb-core", "leet", "--base-url", _BASE_URL, str(wandb_dir.resolve())]
+    ]

--- a/tests/unit_tests/test_cli_leet.py
+++ b/tests/unit_tests/test_cli_leet.py
@@ -6,7 +6,6 @@ import pytest
 from wandb.cli import cli, leet
 from wandb.errors import WandbCoreNotAvailableError
 
-
 _BASE_URL = "https://api.wandb.ai"
 
 

--- a/wandb/cli/leet.py
+++ b/wandb/cli/leet.py
@@ -222,6 +222,9 @@ def _base_args() -> list[str]:
 
     if not error_reporting_enabled():
         args.append("--no-observability")
+    else:
+        # Tell wandb-core which W&B server to upload telemetry to.
+        args.extend(["--base-url", wandb_setup.singleton().settings.base_url])
 
     if is_debug(default="False"):
         args.extend(["--log-level", "-4"])


### PR DESCRIPTION
Description
-----------
Part of the leet Sentry to Datadog migration. Leet currently reports launches only to Sentry, with whatever tags sentry-go collects by default. Wire leet into the existing OpenTelemetry proxy so launches and captured errors also reach Datadog with dimensions we choose:

- a `leet_launch` counter tagged with mode (leet, config, inspect, symon), wandb version, os, architecture, and an execution context detected from the environment (kubernetes, container, slurm, ci, ssh, local)
- a matching log record that adds hostname, commit, environment, and terminal
- captured errors flow through the same recorder and carry the same dimensions

Sentry reporting is unchanged; it will be removed once the Datadog dashboards are validated.