### PR TITLE
feat(leet): record session duration telemetry

### DIFF
--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -262,9 +262,16 @@ func leetMain(args []string) int {
 
 	started := time.Now()
 	exitCode := runLeetCommand(&opts, logger)
+	duration := time.Since(started)
+	recorder.RecordDuration(
+		context.Background(),
+		"leet_session_duration",
+		duration,
+		analytics.LowCardinalityAttributes{},
+	)
 	logger.RecordTelemetry("leet_session", map[string]string{
 		"duration_seconds": strconv.FormatInt(
-			int64(time.Since(started)/time.Second), 10),
+			int64(duration/time.Second), 10),
 		"exit_code": strconv.Itoa(exitCode),
 	})
 	return exitCode

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -259,7 +260,14 @@ func leetMain(args []string) int {
 	analytics.ConfigureOTelErrorHandler(logger.Logger)
 	logger.RecordTelemetry("leet_launch", nil)
 
-	return runLeetCommand(&opts, logger)
+	started := time.Now()
+	exitCode := runLeetCommand(&opts, logger)
+	logger.RecordTelemetry("leet_session", map[string]string{
+		"duration_seconds": strconv.FormatInt(
+			int64(time.Since(started)/time.Second), 10),
+		"exit_code": strconv.Itoa(exitCode),
+	})
+	return exitCode
 }
 
 type leetOptions struct {

--- a/core/internal/analytics/opentelemetryproxy.go
+++ b/core/internal/analytics/opentelemetryproxy.go
@@ -254,6 +254,28 @@ func (r *TelemetryRecorder) IncrementCounter(
 	r.root.incrementCounter(ctx, name, mergedLowCardinalityAttributes)
 }
 
+// RecordDuration records a duration histogram metric in seconds with the
+// telemetry context's low-cardinality attributes.
+func (r *TelemetryRecorder) RecordDuration(
+	ctx context.Context,
+	name string,
+	duration time.Duration,
+	lowCardinalityAttributes LowCardinalityAttributes,
+) {
+	if r == nil {
+		return
+	}
+
+	mergedLowCardinalityAttributes := r.telemetryContext.lowCardinalityAttributes
+	mergedLowCardinalityAttributes.merge(lowCardinalityAttributes)
+	r.root.recordDuration(
+		ctx,
+		name,
+		duration,
+		mergedLowCardinalityAttributes,
+	)
+}
+
 // IncrementCounterAndLogEvent increments a counter metric by 1
 // with the telemetry context's low-cardinality attributes
 //
@@ -656,6 +678,33 @@ func (o *OpenTelemetryProxy) incrementCounter(
 	}
 
 	counter.Add(ctx, 1, toOTelAttrs(lowCardinalityAttributes.toMap()))
+}
+
+// recordDuration records a duration histogram metric in seconds.
+func (o *OpenTelemetryProxy) recordDuration(
+	ctx context.Context,
+	name string,
+	duration time.Duration,
+	lowCardinalityAttributes LowCardinalityAttributes,
+) {
+	if o == nil {
+		return
+	}
+
+	meter := o.meterProvider.Meter(o.serviceName)
+	histogram, err := meter.Float64Histogram(
+		name,
+		otelmetric.WithUnit("s"),
+	)
+	if err != nil {
+		return
+	}
+
+	histogram.Record(
+		ctx,
+		duration.Seconds(),
+		toOTelAttrs(lowCardinalityAttributes.toMap()),
+	)
 }
 
 // log emits an OpenTelemetry log record with the supplied attributes

--- a/core/internal/analytics/opentelemetryproxy_test.go
+++ b/core/internal/analytics/opentelemetryproxy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -309,6 +310,35 @@ func TestTelemetryRecorder_RecordMetricAndLogEvent(t *testing.T) {
 	require.True(t, ok, "expected a log named after the event")
 	assert.Equal(t, otellogapi.SeverityInfo, log.Severity)
 	assert.Equal(t, "value", log.Attributes["custom"])
+}
+
+func TestTelemetryRecorder_RecordDuration(t *testing.T) {
+	proxy := analyticstest.NewOpenTelemetryProxyTest(t)
+	recorder := analytics.NewTelemetryRecorder(
+		proxy.OpenTelemetryProxy,
+		analytics.NewTelemetryContext(),
+	).With(
+		analytics.LowCardinalityAttributes{LeetMode: "inspect"},
+		nil,
+	)
+
+	recorder.RecordDuration(
+		t.Context(),
+		"session_duration",
+		1500*time.Millisecond,
+		analytics.LowCardinalityAttributes{
+			ExecutionContext: "local",
+		},
+	)
+	require.NoError(t, proxy.Shutdown(context.Background()))
+
+	metric, ok := proxy.FindMetric("session_duration")
+	require.True(t, ok, "expected a duration histogram")
+	assert.Equal(t, "s", metric.Unit)
+	assert.Equal(t, uint64(1), metric.HistogramCount)
+	assert.InDelta(t, 1.5, metric.HistogramSum, 0.0001)
+	assert.Equal(t, "inspect", metric.Attributes["leet_mode"])
+	assert.Equal(t, "local", metric.Attributes["execution_context"])
 }
 
 func TestTelemetryRecorder_SendsAPIKeyAuth(t *testing.T) {

--- a/core/internal/analyticstest/opentelemetryproxy.go
+++ b/core/internal/analyticstest/opentelemetryproxy.go
@@ -33,9 +33,12 @@ type Log struct {
 // Metric is a OTLP metric data point received by an OpenTelemetryProxyTest,
 // with its name, value, and attributes extracted.
 type Metric struct {
-	Name       string
-	Value      int64
-	Attributes map[string]string
+	Name           string
+	Unit           string
+	Value          int64
+	HistogramCount uint64
+	HistogramSum   float64
+	Attributes     map[string]string
 }
 
 // Request is an HTTP request received by an OpenTelemetryProxyTest.
@@ -181,6 +184,16 @@ func (s *OpenTelemetryProxyTest) addMetrics(body []byte) error {
 						Name:       metric.GetName(),
 						Value:      dataPoint.GetAsInt(),
 						Attributes: keyValuesToMap(dataPoint.GetAttributes()),
+					})
+				}
+				for _, dataPoint := range metric.GetHistogram().GetDataPoints() {
+					s.metrics = append(s.metrics, Metric{
+						Name:           metric.GetName(),
+						Unit:           metric.GetUnit(),
+						HistogramCount: dataPoint.GetCount(),
+						HistogramSum:   dataPoint.GetSum(),
+						Attributes: keyValuesToMap(
+							dataPoint.GetAttributes()),
 					})
 				}
 			}


### PR DESCRIPTION
Description
-----------
Launch counts say nothing about whether a session is five seconds of curiosity or an hour of monitoring. Emit a `leet_session` event when the TUI exits, carrying the session duration and exit code on top of the launch dimensions. Sentry had no equivalent signal.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Pointed the endpoint at a local OTLP collector and verified the event reports duration and exit code.
