### PR TITLE
fix: missing unlock in filestream FinishWithoutExit

### DIFF
--- a/core/internal/filestream/filestream.go
+++ b/core/internal/filestream/filestream.go
@@ -250,6 +250,7 @@ func (fs *fileStream) FinishWithExit(exitCode int32) {
 func (fs *fileStream) FinishWithoutExit() {
 	fs.mu.Lock()
 	if fs.isFinished {
+		fs.mu.Unlock()
 		return
 	}
 	fs.isFinished = true


### PR DESCRIPTION
Description
-----------
I don't think this is reachable anyways in practice, but dis way is more correct.