### PR TITLE
chore(leet): remove Sentry reporting

### DIFF
--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -239,9 +239,6 @@ func leetMain(args []string) int {
 	}
 	defer stopLeetPprof(pprofStop)
 
-	flushSentry := configureLeetSentry(opts.disableAnalytics, leetSentryMessage(&opts))
-	defer flushSentry()
-
 	recorder, stopTelemetry := leet.ConfigureTelemetry(leet.TelemetryParams{
 		Disabled: opts.disableAnalytics,
 		Mode:     leetMode(&opts),
@@ -455,41 +452,6 @@ func stopLeetPprof(pprofStop func(context.Context) error) {
 	_ = pprofStop(ctx)
 }
 
-func configureLeetSentry(disableAnalytics bool, message string) func() {
-	var sentryDSN string
-	if !disableAnalytics {
-		sentryDSN = observability.LeetSentryDSN
-	}
-
-	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              sentryDSN,
-		AttachStacktrace: true,
-		Release:          version.Version,
-		Dist:             commit,
-		Environment:      version.Environment,
-	})
-	if err != nil {
-		slog.Error("main: failed to init Sentry", "error", err)
-		return func() {}
-	}
-
-	sentry.CaptureMessage(message)
-	return func() { sentry.Flush(2 * time.Second) }
-}
-
-func leetSentryMessage(opts *leetOptions) string {
-	switch {
-	case opts.editConfig:
-		return "wandb-leet-config"
-	case opts.symonMode:
-		return "wandb-symon"
-	case opts.inspect:
-		return "wandb-leet-inspect"
-	default:
-		return "wandb-leet"
-	}
-}
-
 // leetMode names the launch mode for telemetry.
 func leetMode(opts *leetOptions) string {
 	switch {
@@ -530,7 +492,7 @@ func newLeetLogger(
 			logWriter,
 			&slog.HandlerOptions{Level: slog.Level(logLevel)},
 		)),
-		observability.NewSentryContext(sentry.CurrentHub()),
+		nil,
 		recorder,
 	)
 	return logger, closeLogWriter, nil

--- a/core/internal/leet/symonsampler.go
+++ b/core/internal/leet/symonsampler.go
@@ -144,8 +144,8 @@ func (s *SymonSampler) Cleanup() {
 	}
 }
 
-// logSamplingError routes sampling failures either to Sentry or debug logs,
-// depending on whether the monitor package considers them expected.
+// logSamplingError captures unexpected sampling failures and debug-logs
+// expected ones.
 func (s *SymonSampler) logSamplingError(err error) {
 	if monitor.ShouldCaptureSamplingError(err) {
 		s.logger.CaptureError(

--- a/core/internal/observability/sentrydsn.go
+++ b/core/internal/observability/sentrydsn.go
@@ -4,9 +4,6 @@ const (
 	// Sentry DSN for the sdk-core project.
 	WandbCoreDSN = "https://0d0c6674e003452db392f158c42117fb@o151352.ingest.sentry.io/4505513612214272"
 
-	// Sentry DSN for the sdk-leet project.
-	LeetSentryDSN = "https://2fbeaa43dbe0ed35e536adc7f019ba17@o151352.ingest.us.sentry.io/4507273364242432"
-
 	// Use for testing:
 	// testSentryDSN = "https://45bbbb93aacd42cf90785517b66e925b@o151352.ingest.us.sentry.io/6438430"
 )

--- a/wandb/cli/leet.py
+++ b/wandb/cli/leet.py
@@ -17,7 +17,7 @@ from typing import Any
 import click
 from typing_extensions import Never
 
-from wandb.analytics import get_sentry, get_telemetry_recorder
+from wandb.analytics import get_telemetry_recorder
 from wandb.env import error_reporting_enabled, is_debug
 from wandb.errors import WandbCoreNotAvailableError
 from wandb.sdk import wandb_setup
@@ -215,7 +215,6 @@ def _base_args() -> list[str]:
     try:
         core_path = get_core_path()
     except WandbCoreNotAvailableError as e:
-        get_sentry().exception(f"using `wandb leet`. failed with {e}")
         get_telemetry_recorder().exception(
             WandbCoreNotAvailableError(f"using `wandb leet`. failed with {e}")
         )
@@ -241,15 +240,11 @@ def _run_core(args: list[str], env: dict[str, str] | None = None) -> Never:
         result = subprocess.run(args, env=env, close_fds=True)
         sys.exit(result.returncode)
     except Exception as e:
-        # TODO: remove sentry once we no longer support/need it
-        get_sentry().exception(e)
         get_telemetry_recorder().reraise(e)
 
 
 def launch(path: str | None, pprof: str) -> Never:
     """Launch the LEET TUI."""
-    get_sentry().configure_scope(process_context="leet")
-
     if path is not None and (path.startswith("https://") or path.startswith("http://")):
         config = _create_remote_launch_config(path)
     else:
@@ -274,8 +269,6 @@ def launch(path: str | None, pprof: str) -> Never:
 
 def launch_inspect(path: str | None) -> Never:
     """Launch the transaction log record inspector."""
-    get_sentry().configure_scope(process_context="leet-inspect")
-
     config = _resolve_path(path)
     if not isinstance(config, LocalLaunchConfig):
         _fatal("`wandb leet inspect` requires a local .wandb file.")
@@ -289,8 +282,6 @@ def launch_inspect(path: str | None) -> Never:
 
 def launch_config() -> Never:
     """Launch the LEET configuration editor."""
-    get_sentry().configure_scope(process_context="leet-config")
-
     args = _base_args()
     args.append("--config")
 
@@ -299,8 +290,6 @@ def launch_config() -> Never:
 
 def launch_symon(pprof: str = "", interval: str = "") -> Never:
     """Launch the standalone system monitor."""
-    get_sentry().configure_scope(process_context="leet-symon")
-
     args = _base_args()
     args.append("--symon")
 


### PR DESCRIPTION
Description
-----------
**Do not merge until the Datadog dashboards are validated against the Sentry data or Monday, 8/31/2026, whichever happens first lol.** 
The rest of the stack dual-writes to both backends for that comparison; this PR ends it.
