### PR TITLE
feat(leet): report run and UI feature usage in session telemetry

### DIFF
--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -269,11 +269,12 @@ func leetMain(args []string) int {
 		duration,
 		analytics.LowCardinalityAttributes{},
 	)
-	logger.RecordTelemetry("leet_session", map[string]string{
-		"duration_seconds": strconv.FormatInt(
-			int64(duration/time.Second), 10),
-		"exit_code": strconv.Itoa(exitCode),
-	})
+
+	sessionAttributes := leet.SessionAttributes()
+	sessionAttributes["duration_seconds"] = strconv.FormatInt(
+		int64(duration/time.Second), 10)
+	sessionAttributes["exit_code"] = strconv.Itoa(exitCode)
+	logger.RecordTelemetry("leet_session", sessionAttributes)
 	return exitCode
 }
 

--- a/core/internal/leet/analytics.go
+++ b/core/internal/leet/analytics.go
@@ -3,6 +3,7 @@ package leet
 import (
 	"cmp"
 	"context"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -95,6 +96,16 @@ func ConfigureTelemetry(
 		defer cancel()
 		_ = proxy.Shutdown(ctx)
 	}
+}
+
+// SessionAttributes summarizes the runs and UI features seen during this
+// session for the leet_session telemetry event. One leet process is one
+// session; the collectors are only touched from the Bubble Tea update loop
+// and read after it exits, so they are unsynchronized.
+func SessionAttributes() map[string]string {
+	attrs := sessionFeatures.attributes()
+	maps.Copy(attrs, sessionRuns.attributes())
+	return attrs
 }
 
 // detectExecutionContext classifies the environment leet runs in.

--- a/core/internal/leet/dragresize.go
+++ b/core/internal/leet/dragresize.go
@@ -188,6 +188,7 @@ func (d *paneDragger) finish() {
 	if !drag.dirty {
 		return // Click without motion: nothing changed.
 	}
+	sessionFeatures.mark("pane_resize")
 	if err := d.persist(drag.overrides); err != nil {
 		d.logger.Error(fmt.Sprintf("leet: failed to save layout: %v", err))
 	}

--- a/core/internal/leet/featuretelemetry.go
+++ b/core/internal/leet/featuretelemetry.go
@@ -1,0 +1,64 @@
+package leet
+
+import (
+	"maps"
+	"reflect"
+	"runtime"
+	"slices"
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// sessionFeatures records the UI features used during this process.
+var sessionFeatures = &usedFeatures{names: map[string]struct{}{}}
+
+type usedFeatures struct {
+	names map[string]struct{}
+}
+
+func (f *usedFeatures) mark(name string) {
+	f.names[name] = struct{}{}
+}
+
+// attributes returns the used features as one sorted, comma-joined value.
+func (f *usedFeatures) attributes() map[string]string {
+	attrs := map[string]string{}
+	if len(f.names) > 0 {
+		attrs["features_used"] = strings.Join(slices.Sorted(maps.Keys(f.names)), ",")
+	}
+	return attrs
+}
+
+// recordFeatureUsage wraps a key handler to record its use, naming the
+// feature after the handler method (run.toggle_metrics_grid).
+func recordFeatureUsage[T any](
+	handler func(*T, tea.KeyPressMsg) tea.Cmd,
+) func(*T, tea.KeyPressMsg) tea.Cmd {
+	feature := featureName(handler)
+	return func(t *T, msg tea.KeyPressMsg) tea.Cmd {
+		sessionFeatures.mark(feature)
+		return handler(t, msg)
+	}
+}
+
+func featureName[T any](handler func(*T, tea.KeyPressMsg) tea.Cmd) string {
+	name := runtime.FuncForPC(reflect.ValueOf(handler).Pointer()).Name()
+	_, method, _ := strings.Cut(name, ").handle")
+	return camelToSnake(reflect.TypeFor[T]().Name()) + "." + camelToSnake(method)
+}
+
+func camelToSnake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			r = unicode.ToLower(r)
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/core/internal/leet/featuretelemetry_test.go
+++ b/core/internal/leet/featuretelemetry_test.go
@@ -1,0 +1,13 @@
+package leet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureName_DerivedFromHandlerMethod(t *testing.T) {
+	assert.Equal(t,
+		"run.toggle_metrics_grid",
+		featureName((*Run).handleToggleMetricsGrid))
+}

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -654,8 +654,9 @@ func buildKeyMap[T any](
 			if binding.Handler == nil {
 				continue
 			}
+			handler := recordFeatureUsage(binding.Handler)
 			for _, key := range binding.Keys {
-				keyMap[normalizeKey(key)] = binding.Handler
+				keyMap[normalizeKey(key)] = handler
 			}
 		}
 	}

--- a/core/internal/leet/leveldbhistorysource.go
+++ b/core/internal/leet/leveldbhistorysource.go
@@ -161,15 +161,21 @@ func (hs *LevelDBHistorySource) Read(
 func (hs *LevelDBHistorySource) recordToMsg(record *spb.Record) tea.Msg {
 	switch rec := record.RecordType.(type) {
 	case *spb.Record_Run:
-		return RunMsg{
+		msg := RunMsg{
 			RunPath:     hs.runPath,
 			ID:          rec.Run.GetRunId(),
+			Entity:      rec.Run.GetEntity(),
 			DisplayName: rec.Run.GetDisplayName(),
 			Project:     rec.Run.GetProject(),
 			Notes:       rec.Run.GetNotes(),
 			Tags:        slices.Clone(rec.Run.GetTags()),
 			Config:      rec.Run.GetConfig(),
+			Telemetry:   rec.Run.GetTelemetry(),
 		}
+		if ts := rec.Run.GetStartTime(); ts != nil {
+			msg.StartTime = ts.AsTime()
+		}
+		return msg
 	case *spb.Record_History:
 		return ParseHistory(hs.runPath, rec.History)
 	case *spb.Record_Stats:

--- a/core/internal/leet/messages.go
+++ b/core/internal/leet/messages.go
@@ -24,11 +24,14 @@ type HistoryMsg struct {
 type RunMsg struct {
 	RunPath     string
 	ID          string
+	Entity      string
 	Project     string
 	DisplayName string
 	Notes       string
 	Tags        []string
 	Config      *spb.ConfigRecord
+	StartTime   time.Time
+	Telemetry   *spb.TelemetryRecord
 }
 
 // SummaryMsg contains summary data from the wandb run.

--- a/core/internal/leet/parquethistorysource.go
+++ b/core/internal/leet/parquethistorysource.go
@@ -214,6 +214,7 @@ func (s *ParquetHistorySource) Read(
 			RunMsg{
 				RunPath:     s.runPath,
 				ID:          s.runInfo.runId,
+				Entity:      s.runInfo.entity,
 				Project:     s.runInfo.project,
 				DisplayName: s.runInfo.displayName,
 				Config:      nil,

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -29,6 +29,7 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 	case RunMsg:
 		r.logger.Debug("model: processing RunMsg")
 		r.lastError = ""
+		sessionRuns.observe(msg, true)
 		r.runOverview.ProcessRunMsg(msg)
 		r.leftSidebar.Sync()
 		r.runState = RunStateRunning

--- a/core/internal/leet/runtelemetry.go
+++ b/core/internal/leet/runtelemetry.go
@@ -1,0 +1,180 @@
+package leet
+
+import (
+	"cmp"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// sessionRuns collects facts about the runs loaded during this process.
+var sessionRuns = &observedRuns{byID: map[string]*observedRun{}}
+
+type observedRuns struct {
+	byID map[string]*observedRun
+}
+
+type observedRun struct {
+	entity     string
+	sdkVersion string
+	frameworks []string
+	startTime  time.Time
+	offline    bool
+	viewed     bool
+}
+
+// observe records telemetry-relevant facts about a loaded run.
+func (rs *observedRuns) observe(msg RunMsg, viewed bool) {
+	if msg.ID == "" {
+		return
+	}
+
+	run := rs.byID[msg.ID]
+	if run == nil {
+		run = &observedRun{}
+		rs.byID[msg.ID] = run
+	}
+	run.viewed = run.viewed || viewed
+	run.offline = run.offline || msg.Telemetry.GetFeature().GetOffline()
+	if msg.Entity != "" {
+		run.entity = msg.Entity
+	}
+	if !msg.StartTime.IsZero() {
+		run.startTime = msg.StartTime
+	}
+	if v := msg.Telemetry.GetCliVersion(); v != "" {
+		run.sdkVersion = v
+	}
+	frameworks := importNames(
+		msg.Telemetry.GetImportsInit(), msg.Telemetry.GetImportsFinish())
+	if len(frameworks) > 0 {
+		run.frameworks = frameworks
+	}
+}
+
+func (rs *observedRuns) attributes() map[string]string {
+	if len(rs.byID) == 0 {
+		return nil
+	}
+
+	var viewed, offline int
+	var newestStart time.Time
+	entityCounts := map[string]int{}
+	sdkVersions := map[string]struct{}{}
+	frameworks := map[string]struct{}{}
+	for _, run := range rs.byID {
+		if run.viewed {
+			viewed++
+		}
+		if run.offline {
+			offline++
+		}
+		if run.startTime.After(newestStart) {
+			newestStart = run.startTime
+		}
+		if run.entity != "" {
+			entityCounts[run.entity]++
+		}
+		if run.sdkVersion != "" {
+			sdkVersions[run.sdkVersion] = struct{}{}
+		}
+		for _, framework := range run.frameworks {
+			frameworks[framework] = struct{}{}
+		}
+	}
+
+	attrs := map[string]string{
+		"run_count":         strconv.Itoa(len(rs.byID)),
+		"run_viewed_count":  strconv.Itoa(viewed),
+		"run_offline_count": strconv.Itoa(offline),
+	}
+	if entity := topEntity(entityCounts); entity != "" {
+		attrs["entity"] = entity
+	}
+	if len(sdkVersions) > 0 {
+		versions := slices.SortedFunc(maps.Keys(sdkVersions), compareVersions)
+		attrs["run_sdk_version_oldest"] = versions[0]
+		attrs["run_sdk_version_newest"] = versions[len(versions)-1]
+	}
+	if len(frameworks) > 0 {
+		attrs["run_frameworks"] = strings.Join(slices.Sorted(maps.Keys(frameworks)), ",")
+	}
+	if !newestStart.IsZero() {
+		attrs["run_age_newest"] = ageBucket(time.Since(newestStart))
+	}
+	return attrs
+}
+
+// importNames returns the sorted names of the frameworks set in the given
+// telemetry import records.
+func importNames(records ...*spb.Imports) []string {
+	names := map[string]struct{}{}
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		record.ProtoReflect().Range(
+			func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+				if fd.Kind() == protoreflect.BoolKind && v.Bool() {
+					names[string(fd.Name())] = struct{}{}
+				}
+				return true
+			})
+	}
+	return slices.Sorted(maps.Keys(names))
+}
+
+// topEntity returns the most frequent entity, breaking ties alphabetically.
+func topEntity(counts map[string]int) string {
+	var top string
+	var topCount int
+	for entity, count := range counts {
+		if count > topCount || (count == topCount && entity < top) {
+			top, topCount = entity, count
+		}
+	}
+	return top
+}
+
+// compareVersions orders wandb version strings like "0.10.20.dev1" by
+// their leading numeric fields, then by the full string.
+func compareVersions(a, b string) int {
+	return cmp.Or(
+		slices.Compare(versionFields(a), versionFields(b)),
+		strings.Compare(a, b),
+	)
+}
+
+func versionFields(version string) []int {
+	var fields []int
+	for part := range strings.SplitSeq(version, ".") {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			break
+		}
+		fields = append(fields, n)
+	}
+	return fields
+}
+
+// ageBucket buckets an age into lt_1h, lt_1d, lt_7d, lt_30d or ge_30d.
+func ageBucket(age time.Duration) string {
+	switch {
+	case age < time.Hour:
+		return "lt_1h"
+	case age < 24*time.Hour:
+		return "lt_1d"
+	case age < 7*24*time.Hour:
+		return "lt_7d"
+	case age < 30*24*time.Hour:
+		return "lt_30d"
+	default:
+		return "ge_30d"
+	}
+}

--- a/core/internal/leet/workspacedirwatcher.go
+++ b/core/internal/leet/workspacedirwatcher.go
@@ -278,6 +278,10 @@ func (w *Workspace) handleWorkspaceRunOverviewPreloaded(
 ) tea.Cmd {
 	w.overviewPreloader.MarkDone(msg.RunKey)
 
+	if msg.Run != nil {
+		sessionRuns.observe(*msg.Run, false)
+	}
+
 	_, streaming := w.runsByKey[msg.RunKey]
 
 	switch {

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -727,6 +727,7 @@ func (w *Workspace) handleWorkspaceRecord(run *WorkspaceRun, msg tea.Msg) {
 
 	switch m := msg.(type) {
 	case RunMsg:
+		sessionRuns.observe(m, true)
 		w.getOrCreateRunOverview(run.Key).ProcessRunMsg(m)
 		w.indexRunFilterData(run.Key, m)
 		if w.filter.Query() != "" {


### PR DESCRIPTION
Description
-----------
LEET's launch telemetry says who starts it, but nothing about what leet is used for. This enriches the `leet_session` event with two summaries collected during the session and reported at exit.

Runs: for every run loaded (workspace preloads and viewed runs), keep the entity, project, SDK version, frameworks, start time and offline flag from the RunRecord. Reported attributes: run counts (discovered, viewed, offline), capped distinct entity and project lists, the most frequent entity (for attribution that survives ephemeral hosts), oldest and newest SDK versions among the runs (the in-the-wild compat matrix), the frameworks from the telemetry import bits, and the age bucket of the newest run (live monitoring vs archaeology).

UI features: `buildKeyMap` wraps every key handler to count its use, naming features after the handler methods (`run.toggle_metrics_grid`), so the vocabulary tracks the key-binding tables with no separate hand-maintained list. Mouse pane resizing is counted at the end of a drag. Counts land as `feature.<name>` attributes.
