### PR TITLE
fix: defer wandb-xpu startup until first use

### DIFF
--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -509,6 +509,13 @@ func (sm *SystemMonitor) sample() {
 //
 // Use to filter out expected/transient failures. Keep this intentionally small and specific.
 func ShouldCaptureSamplingError(err error) bool {
+	// The wandb-xpu sidecar failed to start. The first failure per run is
+	// returned unwrapped and captured; repeats carry this sentinel and are
+	// logged at debug level.
+	if errors.Is(err, ErrXPUInitReported) {
+		return false
+	}
+
 	// Transient gRPC connectivity to the wandb-xpu sidecar.
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
 		return false

--- a/core/internal/monitor/xpu.go
+++ b/core/internal/monitor/xpu.go
@@ -3,31 +3,64 @@ package monitor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
 // XPUManager manages access to the shared wandb-xpu sidecar.
 type XPUManager interface {
-	Acquire() (spb.SystemMonitorServiceClient, XPUResourceManagerRef, error)
+	// Acquire starts the sidecar if it is not running and registers a
+	// reference to it. It aborts early with an error if ctx is canceled.
+	Acquire(ctx context.Context) (spb.SystemMonitorServiceClient, XPUResourceManagerRef, error)
+
+	// Release unregisters a reference returned by Acquire, stopping the
+	// sidecar once no references remain.
 	Release(XPUResourceManagerRef)
 }
 
+// ErrXPUInitReported wraps a sidecar startup error that Sample already
+// returned once, letting the monitoring loop log repeats at debug level
+// (see ShouldCaptureSamplingError) instead of capturing each one.
+var ErrXPUInitReported = errors.New("wandb-xpu startup failure already reported")
+
+var errXPUClosed = errors.New("monitor: xpu resource is closed")
+
+// maxXPUInitAttempts bounds how many times a startup attempt that was cut
+// short by a caller's deadline or by shutdown may be retried before the
+// failure is cached for the lifetime of the resource.
+const maxXPUInitAttempts = 3
+
+type xpuInitState int
+
+const (
+	xpuInitNotStarted xpuInitState = iota
+	xpuInitInFlight
+	xpuInitDone
+)
+
 // XPU monitors GPUs (Nvidia, AMD, Apple) and Google TPUs via the
 // wandb-xpu sidecar binary.
+//
+// The sidecar is started lazily by the first Sample or Probe call.
 type XPU struct {
-	mu              sync.Mutex
 	resourceManager XPUManager
-	resourceRef     XPUResourceManagerRef
-	initialized     bool
-	closed          bool
-	initErr         error
-	initErrReported bool
 
 	pid          int32
 	gpuDeviceIds []int32
+
+	mu           sync.Mutex
+	closed       bool
+	initState    xpuInitState
+	initDone     chan struct{} // closed when the in-flight attempt finishes
+	initAttempts int
 	client       spb.SystemMonitorServiceClient
+	resourceRef  XPUResourceManagerRef
+	initErr      error
+
+	initErrReported atomic.Bool
 }
 
 func NewXPU(
@@ -47,20 +80,16 @@ func NewXPU(
 }
 
 func (a *XPU) Sample() (*spb.StatsRecord, error) {
-	client, err := a.getClient()
-	if err != nil {
-		a.mu.Lock()
-		shouldReport := !a.initErrReported
-		a.initErrReported = true
-		a.mu.Unlock()
-		if shouldReport {
-			return nil, err
-		}
-		return nil, nil
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultSamplingInterval)
 	defer cancel()
+
+	client, err := a.getClient(ctx)
+	if err != nil {
+		if a.initErrReported.Swap(true) {
+			return nil, fmt.Errorf("%w: %v", ErrXPUInitReported, err)
+		}
+		return nil, err
+	}
 
 	stats, err := client.GetStats(
 		ctx,
@@ -77,7 +106,7 @@ func (a *XPU) Sample() (*spb.StatsRecord, error) {
 }
 
 func (a *XPU) Probe(ctx context.Context) *spb.EnvironmentRecord {
-	client, err := a.getClient()
+	client, err := a.getClient(ctx)
 	if err != nil {
 		return nil
 	}
@@ -89,6 +118,11 @@ func (a *XPU) Probe(ctx context.Context) *spb.EnvironmentRecord {
 	return e.GetRecord().GetEnvironment()
 }
 
+// Close releases the sidecar reference if one was acquired.
+//
+// Close never blocks on an in-flight startup attempt: if one is running,
+// it observes the closed flag when it finishes and releases the
+// reference itself (see getClient).
 func (a *XPU) Close() {
 	a.mu.Lock()
 	if a.closed {
@@ -96,26 +130,87 @@ func (a *XPU) Close() {
 		return
 	}
 	a.closed = true
-	initialized := a.initialized && a.initErr == nil
+	state := a.initState
 	ref := a.resourceRef
+	err := a.initErr
 	a.mu.Unlock()
 
-	if initialized {
+	if state == xpuInitDone && err == nil {
 		a.resourceManager.Release(ref)
 	}
 }
 
-func (a *XPU) getClient() (spb.SystemMonitorServiceClient, error) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+// getClient returns the sidecar client, starting the sidecar on first use.
+//
+// The manager's Acquire call runs without holding a.mu so that Probe,
+// Sample, and Close never stall behind a slow startup. If an attempt is
+// cut short by ctx (e.g. the run is shutting down or the sampling
+// deadline expired), a later call may retry it, up to maxXPUInitAttempts
+// times; any other failure is cached for the lifetime of the resource.
+func (a *XPU) getClient(ctx context.Context) (spb.SystemMonitorServiceClient, error) {
+	for {
+		a.mu.Lock()
 
-	if a.closed {
-		return nil, errors.New("monitor: xpu resource is closed")
-	}
-	if !a.initialized {
-		a.initialized = true
-		a.client, a.resourceRef, a.initErr = a.resourceManager.Acquire()
-	}
+		switch {
+		case a.closed:
+			a.mu.Unlock()
+			return nil, errXPUClosed
 
-	return a.client, a.initErr
+		case a.initState == xpuInitDone:
+			client, err := a.client, a.initErr
+			a.mu.Unlock()
+			return client, err
+
+		case a.initState == xpuInitInFlight:
+			done := a.initDone
+			a.mu.Unlock()
+
+			select {
+			case <-done:
+				// Re-check the state: the attempt may have failed in a
+				// retryable way, in which case this call starts its own.
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+
+		default: // xpuInitNotStarted
+			a.initState = xpuInitInFlight
+			a.initAttempts++
+			done := make(chan struct{})
+			a.initDone = done
+			a.mu.Unlock()
+
+			client, ref, err := a.resourceManager.Acquire(ctx)
+
+			a.mu.Lock()
+			switch {
+			case a.closed:
+				a.initState = xpuInitDone
+				a.initErr = errXPUClosed
+				a.mu.Unlock()
+				close(done)
+
+				// Closed while acquiring: hand the reference back.
+				if err == nil {
+					a.resourceManager.Release(ref)
+				}
+				return nil, errXPUClosed
+
+			case err != nil && ctx.Err() != nil && a.initAttempts < maxXPUInitAttempts:
+				// The attempt was interrupted rather than failing
+				// outright; let a later call retry it.
+				a.initState = xpuInitNotStarted
+				a.mu.Unlock()
+				close(done)
+				return nil, err
+
+			default:
+				a.initState = xpuInitDone
+				a.client, a.resourceRef, a.initErr = client, ref, err
+				a.mu.Unlock()
+				close(done)
+				return client, err
+			}
+		}
+	}
 }

--- a/core/internal/monitor/xpu.go
+++ b/core/internal/monitor/xpu.go
@@ -2,15 +2,28 @@ package monitor
 
 import (
 	"context"
+	"errors"
+	"sync"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
+// XPUManager manages access to the shared wandb-xpu sidecar.
+type XPUManager interface {
+	Acquire() (spb.SystemMonitorServiceClient, XPUResourceManagerRef, error)
+	Release(XPUResourceManagerRef)
+}
+
 // XPU monitors GPUs (Nvidia, AMD, Apple) and Google TPUs via the
 // wandb-xpu sidecar binary.
 type XPU struct {
-	resourceManager *XPUResourceManager
+	mu              sync.Mutex
+	resourceManager XPUManager
 	resourceRef     XPUResourceManagerRef
+	initialized     bool
+	closed          bool
+	initErr         error
+	initErrReported bool
 
 	pid          int32
 	gpuDeviceIds []int32
@@ -18,28 +31,38 @@ type XPU struct {
 }
 
 func NewXPU(
-	resourceManager *XPUResourceManager,
+	resourceManager XPUManager,
 	pid int32,
 	gpuDeviceIds []int32,
 ) (*XPU, error) {
-	client, ref, err := resourceManager.Acquire()
-	if err != nil {
-		return nil, err
+	if resourceManager == nil {
+		return nil, errors.New("monitor: xpu resource manager is nil")
 	}
+
 	return &XPU{
 		resourceManager: resourceManager,
-		resourceRef:     ref,
 		pid:             pid,
 		gpuDeviceIds:    gpuDeviceIds,
-		client:          client,
 	}, nil
 }
 
 func (a *XPU) Sample() (*spb.StatsRecord, error) {
+	client, err := a.getClient()
+	if err != nil {
+		a.mu.Lock()
+		shouldReport := !a.initErrReported
+		a.initErrReported = true
+		a.mu.Unlock()
+		if shouldReport {
+			return nil, err
+		}
+		return nil, nil
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultSamplingInterval)
 	defer cancel()
 
-	stats, err := a.client.GetStats(
+	stats, err := client.GetStats(
 		ctx,
 		&spb.GetStatsRequest{Pid: a.pid, GpuDeviceIds: a.gpuDeviceIds},
 	)
@@ -54,7 +77,12 @@ func (a *XPU) Sample() (*spb.StatsRecord, error) {
 }
 
 func (a *XPU) Probe(ctx context.Context) *spb.EnvironmentRecord {
-	e, err := a.client.GetMetadata(ctx, &spb.GetMetadataRequest{})
+	client, err := a.getClient()
+	if err != nil {
+		return nil
+	}
+
+	e, err := client.GetMetadata(ctx, &spb.GetMetadataRequest{})
 	if err != nil {
 		return nil
 	}
@@ -62,5 +90,32 @@ func (a *XPU) Probe(ctx context.Context) *spb.EnvironmentRecord {
 }
 
 func (a *XPU) Close() {
-	a.resourceManager.Release(a.resourceRef)
+	a.mu.Lock()
+	if a.closed {
+		a.mu.Unlock()
+		return
+	}
+	a.closed = true
+	initialized := a.initialized && a.initErr == nil
+	ref := a.resourceRef
+	a.mu.Unlock()
+
+	if initialized {
+		a.resourceManager.Release(ref)
+	}
+}
+
+func (a *XPU) getClient() (spb.SystemMonitorServiceClient, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return nil, errors.New("monitor: xpu resource is closed")
+	}
+	if !a.initialized {
+		a.initialized = true
+		a.client, a.resourceRef, a.initErr = a.resourceManager.Acquire()
+	}
+
+	return a.client, a.initErr
 }

--- a/core/internal/monitor/xpuresourcemanager.go
+++ b/core/internal/monitor/xpuresourcemanager.go
@@ -19,6 +19,10 @@ import (
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
+// collectorStartupTimeout bounds how long Acquire waits for the sidecar
+// process to write its portfile.
+const collectorStartupTimeout = 5 * time.Second
+
 type XPUResourceManagerRef int
 
 // XPUResourceManager manages the sidecar process that collects
@@ -43,7 +47,7 @@ func NewXPUResourceManager(enableDCGMProfiling bool) *XPUResourceManager {
 	}
 }
 
-func (m *XPUResourceManager) Acquire() (
+func (m *XPUResourceManager) Acquire(ctx context.Context) (
 	spb.SystemMonitorServiceClient,
 	XPUResourceManagerRef,
 	error,
@@ -52,7 +56,7 @@ func (m *XPUResourceManager) Acquire() (
 	defer m.mu.Unlock()
 
 	if m.collectorConn == nil {
-		if err := m.startCollector(); err != nil {
+		if err := m.startCollector(ctx); err != nil {
 			return nil, 0, err
 		}
 	}
@@ -86,7 +90,7 @@ func (m *XPUResourceManager) Release(ref XPUResourceManagerRef) {
 	}()
 }
 
-func (m *XPUResourceManager) startCollector() error {
+func (m *XPUResourceManager) startCollector(ctx context.Context) error {
 	pf := NewPortfile()
 	if pf == nil {
 		return errors.New("monitor: could not create portfile")
@@ -114,7 +118,7 @@ func (m *XPUResourceManager) startCollector() error {
 		return fmt.Errorf("monitor: could not start wandb-xpu binary: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, collectorStartupTimeout)
 	defer cancel()
 	targetURI, err := pf.Read(ctx)
 	if err != nil {


### PR DESCRIPTION
Description
-----------

Acquire the shared wandb-xpu sidecar when sampling or metadata probing first uses it, instead of while constructing the system monitor. A failed launch is reported once.
