### PR TITLE
chore: keep proto tooling out of sidecar builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,6 +521,11 @@ jobs:
             sudo apt-get install -y -qq python3-pip >/dev/null
             cd xpu
             cargo test --verbose
+      - run:
+          name: Check wandb-xpu proto tooling compiles
+          command: |
+            cd xpu
+            cargo check --features build-proto --bin build_proto
       - save-cargo-cache
 
 workflows:

--- a/xpu/Cargo.lock
+++ b/xpu/Cargo.lock
@@ -1440,20 +1440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-reflection"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
-dependencies = [
- "prost",
- "prost-types",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,7 +1556,6 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
- "tonic-reflection",
  "which",
  "zip",
 ]

--- a/xpu/Cargo.toml
+++ b/xpu/Cargo.toml
@@ -7,6 +7,10 @@ rust-version = "1.88"
 [[bin]]
 name = "build_proto"
 path = "tools/build_proto.rs"
+required-features = ["build-proto"]
+
+[features]
+build-proto = ["dep:tempfile", "dep:tonic-prost-build"]
 
 [dependencies]
 log = "0.4.33"
@@ -19,13 +23,12 @@ prost = "0.14.4"
 prost-types = "0.14.4"
 tonic = "0.14.6"
 tonic-prost = "0.14.6"
-tonic-reflection = "0.14.6"
 tokio = { version = "1.53.1", features = ["full"] }
 tokio-stream = "0.1.19"
 chrono = "0.4.45"
 
-tonic-prost-build = "0.14.6"
-tempfile = "3.27.0"
+tonic-prost-build = { version = "0.14.6", optional = true }
+tempfile = { version = "3.27.0", optional = true }
 
 libloading = "0.9"
 async-trait = "0.1.91"

--- a/xpu/tools/generate-proto.sh
+++ b/xpu/tools/generate-proto.sh
@@ -9,4 +9,4 @@ cd "$SCRIPT_DIR/.."
 
 # Run the Rust proto generation.
 echo "[INFO] generate-proto.sh: Generating Rust protobuf files"
-cargo run --bin build_proto
+cargo run --features build-proto --bin build_proto


### PR DESCRIPTION
Description
-----------

Gate proto-generation dependencies behind a build-proto feature and remove the
unused tonic-reflection dependency. Normal sidecar builds no longer compile
these tools.

Stacked on #12625.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

`cargo test --all-features`