### PR TITLE
chore: scope hardware dependencies by platform

### DIFF
--- a/xpu/Cargo.toml
+++ b/xpu/Cargo.toml
@@ -15,7 +15,6 @@ build-proto = ["dep:tempfile", "dep:tonic-prost-build"]
 [dependencies]
 log = "0.4.33"
 env_logger = { version = "0.11.11", features = ["auto-color"] }
-nvml-wrapper = "0.12.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 clap = { version = "4.6.5", features = ["derive"] }
@@ -30,17 +29,25 @@ chrono = "0.4.45"
 tonic-prost-build = { version = "0.14.6", optional = true }
 tempfile = { version = "3.27.0", optional = true }
 
-libloading = "0.9"
 async-trait = "0.1.91"
-glob = "0.3.4"
 
 [dev-dependencies]
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
-[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
+nvml-wrapper = "0.12.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+glob = "0.3.4"
+libloading = "0.9"
 which = "8.0.5"
+
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
+core-foundation = "0.10.1"
+libc = "0.2.189"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31.3", features = ["process"] }
-core-foundation = "0.10.1"
-libc = "0.2.189"
+
+[profile.release]
+strip = "symbols"

--- a/xpu/Cargo.toml
+++ b/xpu/Cargo.toml
@@ -50,4 +50,6 @@ libc = "0.2.189"
 nix = { version = "0.31.3", features = ["process"] }
 
 [profile.release]
-strip = "symbols"
+# Drop debug info but keep symbol names so panic backtraces from user
+# machines remain readable (there is no crash reporting in the sidecar).
+strip = "debuginfo"


### PR DESCRIPTION
Description
-----------

Compile hardware dependencies only on the platforms that use them and strip
symbols from release binaries. This reduces sidecar build work and package
size.

Stacked on #12626.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------

`cargo test`; Linux target check; release startup benchmark