### PR TITLE
fix(sdk): stop retrying payment required errors

### DIFF
--- a/core/internal/clients/retry_policy.go
+++ b/core/internal/clients/retry_policy.go
@@ -63,6 +63,8 @@ func RetryMostFailures(
 		return false, nil
 	case http.StatusUnauthorized: // don't retry on 401 unauthorized
 		return false, nil
+	case http.StatusPaymentRequired: // don't retry on 402 payment required
+		return false, nil
 	case http.StatusForbidden: // don't retry on 403 forbidden
 		return false, nil
 	case http.StatusNotFound: // don't retry on 404 not found

--- a/core/internal/clients/retry_policy_test.go
+++ b/core/internal/clients/retry_policy_test.go
@@ -39,6 +39,12 @@ func TestDefaultRetryPolicy(t *testing.T) {
 			"the API key you provided is either invalid or missing. (Error 401: Unauthorized)",
 		},
 		{
+			"PaymentRequired",
+			http.StatusPaymentRequired,
+			false,
+			"the server responded with an error. (Error 402: Payment Required)",
+		},
+		{
 			"Forbidden",
 			http.StatusForbidden,
 			false,


### PR DESCRIPTION
## Summary
- treat HTTP 402 Payment Required responses as permanent in the shared SDK retry policy
- prevent plan and quota rejections, including artifact usage limits, from being retried
- preserve retry behavior for other unrecognized 4xx responses

## Testing
- `go test ./internal/clients` from `core/`