### PR TITLE
fix(sdk): defer temporary directories until first use

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,4 +16,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Fixed
 
+- Importing `wandb` no longer creates artifact and media temporary directories until they are first needed (#7148).
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)

--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import functools
+import json
+import os
 import queue
 import shutil
+import subprocess
+import sys
+import textwrap
 import unittest.mock as mock
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -91,6 +96,69 @@ def test_capped_cache():
         art._state = "COMMITTED"
         artifact_instance_cache[art.id] = art
     assert len(artifact_instance_cache) == 100
+
+
+def test_import_defers_temp_directory_creation(tmp_path: Path) -> None:
+    script = textwrap.dedent(
+        """
+        import json
+        import os
+        from pathlib import Path
+
+        temp_dir = Path(os.environ["TMPDIR"])
+        before_import = {path.name for path in temp_dir.iterdir()}
+
+        import wandb
+
+        after_import = {path.name for path in temp_dir.iterdir()}
+        media = wandb.Html("<p>media</p>")
+        artifact = wandb.Artifact("artifact", type="dataset")
+        artifact.add(wandb.Table(data=[[1]], columns=["value"]), "media/tables/table")
+
+        from wandb.sdk.artifacts.artifact import Artifact
+        from wandb.sdk.data_types._private import MEDIA_TMP
+
+        print(
+            "RESULT="
+            + json.dumps(
+                {
+                    "new_temp_entries": sorted(after_import - before_import),
+                    "artifact_temp_dir": Artifact._TMP_DIR.name,
+                    "media_temp_dir": MEDIA_TMP.name,
+                    "media_path": media._path,
+                }
+            )
+        )
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=True,
+        cwd=Path(__file__).parents[3],
+        env={
+            **os.environ,
+            "TMPDIR": str(tmp_path),
+            "TMP": str(tmp_path),
+            "TEMP": str(tmp_path),
+        },
+        text=True,
+    )
+    output_line = next(
+        line for line in result.stdout.splitlines() if line.startswith("RESULT=")
+    )
+    result_data = json.loads(output_line.removeprefix("RESULT="))
+
+    assert result_data["new_temp_entries"] == []
+
+    artifact_temp_dir = Path(result_data["artifact_temp_dir"])
+    media_temp_dir = Path(result_data["media_temp_dir"])
+    assert artifact_temp_dir.parent == tmp_path
+    assert media_temp_dir.parent == tmp_path
+    assert Path(result_data["media_path"]).parent == media_temp_dir
+    assert not artifact_temp_dir.exists()
+    assert not media_temp_dir.exists()
 
 
 class TestStoreFile:

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import stat
 import tempfile
+import threading
 import time
 from collections import deque
 from collections.abc import Generator, Sequence
@@ -166,8 +167,16 @@ class Artifact:
         An `Artifact` object.
     """
 
-    _TMP_DIR = tempfile.TemporaryDirectory("wandb-artifacts")
-    atexit.register(_TMP_DIR.cleanup)
+    _TMP_DIR: tempfile.TemporaryDirectory | None = None
+    _TMP_DIR_LOCK = threading.Lock()
+
+    @staticmethod
+    def _get_tmp_dir() -> tempfile.TemporaryDirectory:
+        with Artifact._TMP_DIR_LOCK:
+            if Artifact._TMP_DIR is None:
+                Artifact._TMP_DIR = tempfile.TemporaryDirectory("wandb-artifacts")
+                atexit.register(Artifact._TMP_DIR.cleanup)
+            return Artifact._TMP_DIR
 
     def __init__(
         self,
@@ -1811,7 +1820,7 @@ class Artifact:
             return entry
 
         if is_tmp_name:
-            file_path = os.path.join(self._TMP_DIR.name, str(id(self)), name)
+            file_path = os.path.join(self._get_tmp_dir().name, str(id(self)), name)
             folder_path, _ = os.path.split(file_path)
             os.makedirs(folder_path, exist_ok=True)
             with open(file_path, "w", encoding="utf-8") as tmp_f:

--- a/wandb/sdk/data_types/_private.py
+++ b/wandb/sdk/data_types/_private.py
@@ -1,9 +1,30 @@
 import atexit
 import tempfile
+import threading
+
+
+class _LazyTemporaryDirectory:
+    def __init__(self, suffix: str) -> None:
+        self._suffix = suffix
+        self._directory: tempfile.TemporaryDirectory | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        with self._lock:
+            if self._directory is None:
+                self._directory = tempfile.TemporaryDirectory(self._suffix)
+            return self._directory.name
+
+    def cleanup(self) -> None:
+        with self._lock:
+            if self._directory is not None:
+                self._directory.cleanup()
+
 
 # Staging directory, so we can encode raw data into files, then hash them before
 # we put them into the Run directory to be uploaded.
-MEDIA_TMP = tempfile.TemporaryDirectory("wandb-media")
+MEDIA_TMP = _LazyTemporaryDirectory("wandb-media")
 
 
 def _cleanup_media_tmp_dir() -> None:


### PR DESCRIPTION
Description
-----------

- Fixes #7148
- Replace the eager Artifact and Media staging directories with thread-safe lazy initialization.
- Preserve the existing `.name` and cleanup behavior, while creating each directory only when an Artifact table or Media object first needs it.
- Add a fresh-process regression that isolates all platform temp environment variables, verifies `import wandb` creates no entries, exercises both first-use paths, and confirms process-exit cleanup.
- [x] I updated CHANGELOG.unreleased.md.

Testing
-------

The regression was first run with the original production code and failed because `import wandb` created both `wandb-media` and `wandb-artifacts` directories.

- `pytest tests/unit_tests/test_artifacts/test_wandb_artifacts.py`: 74 passed
- focused fresh-process regression: passed
- Ruff check and format hooks: passed
- `ty 0.0.73` on both changed SDK modules: passed
- remaining changed-file pre-push hooks, including `go-mod-tidy`: passed
- `git diff --check`: passed

The broader optional Media/DataTypes test modules were also attempted, but local collection requires optional Bokeh, pandas, RDKit, and Torch dependencies that are not installed in this isolated environment. The added regression directly exercises `wandb.Html` and `wandb.Table`; the repository CI remains the full matrix.

AI assistance
-------------

This contribution was developed with AI assistance. The issue scope, import chain, baseline failure, lazy lifecycle and cleanup behavior, cross-platform temp variables, affected call sites, tests, static checks, and final diff were independently reviewed and rerun before submission.