### PR TITLE
fix(sdk): serialize symbolic torch graph dimensions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,4 +16,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Fixed
 
+- `wandb.watch(..., log_graph=True)` now supports PyTorch models with jagged nested tensor outputs.
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)

--- a/tests/unit_tests/test_torch.py
+++ b/tests/unit_tests/test_torch.py
@@ -1,6 +1,9 @@
+import json
+
 import pytest
 import torch
 import torch.nn as nn
+import wandb
 from wandb.integration.torch import wandb_torch
 
 
@@ -24,6 +27,38 @@ def test_nested_shape():
     t3.append(t2)
     shape = wandb_torch.nested_shape([t1, t2, t3])
     assert shape == [[2, 3], [4, 5], [[2, 3], [4, 5], 0, [4, 5]]]
+
+
+def test_nested_shape_with_jagged_tensor_is_json_serializable():
+    jagged_tensor = torch.nested.nested_tensor(
+        [torch.randn(4, 10), torch.randn(5, 10)], layout=torch.jagged
+    )
+
+    output_shape = wandb_torch.nested_shape((jagged_tensor,))
+
+    assert json.loads(wandb.util.json_dumps_safer(output_shape)) == [
+        [2, str(jagged_tensor.shape[1]), 10]
+    ]
+
+
+def test_watch_graph_with_jagged_tensor(mock_run):
+    class JaggedModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer = nn.Linear(10, 10)
+
+        def forward(self, tensor):
+            return self.layer(tensor).sum()
+
+    run = mock_run()
+    model = JaggedModel()
+    run.watch(model, log=None, log_graph=True)
+
+    jagged_tensor = torch.nested.nested_tensor(
+        [torch.randn(4, 10), torch.randn(5, 10)], layout=torch.jagged
+    )
+
+    assert model(jagged_tensor).shape == torch.Size([])
 
 
 @pytest.mark.parametrize(

--- a/wandb/integration/torch/wandb_torch.py
+++ b/wandb/integration/torch/wandb_torch.py
@@ -30,7 +30,10 @@ def nested_shape(array_or_tuple, seen=None):
         seen = set()
     if hasattr(array_or_tuple, "size"):
         # pytorch tensors use V.size() to get size of tensor
-        return list(array_or_tuple.size())
+        return [
+            size if isinstance(size, int) else str(size)
+            for size in array_or_tuple.size()
+        ]
     elif hasattr(array_or_tuple, "get_shape"):
         # tensorflow uses V.get_shape() to get size of tensor
         return array_or_tuple.get_shape().as_list()


### PR DESCRIPTION
Description
-----------

- Fixes #10026

`TorchGraph` stores layer output shapes in graph metadata. Jagged nested tensors
can include `torch.SymInt` dimensions, which are not JSON serializable and cause
`wandb.watch(..., log_graph=True)` to fail while publishing the graph summary.

This converts only non-Python-integer tensor dimensions to their stable string
representation at the existing `nested_shape()` boundary. Ordinary tensor
dimensions remain integers. The regression coverage exercises both direct graph
shape serialization and the Python `watch -> forward hook -> graph summary`
path with a CPU jagged nested tensor.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

- Baseline A/B: with the production change removed, both new regressions fail
  with `TypeError: Object of type SymInt is not JSON serializable`.
- `.venv/bin/python -m pytest -q tests/unit_tests/test_torch.py` (22 passed)
- `uv tool run ruff check wandb/integration/torch/wandb_torch.py tests/unit_tests/test_torch.py`
- `uv tool run ruff format --check wandb/integration/torch/wandb_torch.py tests/unit_tests/test_torch.py`
- `uv tool run ty@0.0.73 check wandb/integration/torch/wandb_torch.py tests/unit_tests/test_torch.py`
- Applicable changed-file pre-push hooks and `git diff --check`

A real `wandb.init(mode="offline")` service-process run was also attempted, but
this clean source checkout has no built `wandb-core` binary. The mocked-run test
uses the repository's standard fixture and reaches `Graph.bind_to_run()` and
`json_dump_safer()`; the baseline failure confirms that serialization path.

AI disclosure: this change was developed with AI assistance. The final diff was
reviewed and the A/B regression, affected test suite, lint, formatting, type
checks, and repository hooks were rerun before submission.
