### PR TITLE
fix(artifacts): bound HTTP GET requests

### DIFF
--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -84,6 +84,43 @@ def mock_preparer(**kwargs):
     return Mock(**kwargs)
 
 
+@mark.parametrize(
+    ("file_transfer_timeout", "request_timeout", "expected_timeout"),
+    [
+        (None, None, 7),
+        (4.5, None, 4.5),
+        (0, None, None),
+        (None, 3, 3),
+    ],
+)
+def test_artifact_http_session_timeout(
+    monkeypatch: MonkeyPatch,
+    file_transfer_timeout: float | None,
+    request_timeout: float | None,
+    expected_timeout: float | None,
+) -> None:
+    settings = Mock(
+        x_extra_http_headers=None,
+        x_file_transfer_timeout_seconds=file_transfer_timeout,
+    )
+    monkeypatch.setattr(
+        "wandb.sdk.wandb_setup.singleton",
+        Mock(return_value=Mock(settings=settings)),
+    )
+    monkeypatch.setenv("WANDB_HTTP_TIMEOUT", "7")
+    request = Mock()
+    monkeypatch.setattr(requests.Session, "request", request)
+
+    with make_http_session() as session:
+        kwargs = {} if request_timeout is None else {"timeout": request_timeout}
+        session.get("https://example.invalid/manifest.json", **kwargs)
+
+    if expected_timeout is None:
+        assert "timeout" not in request.call_args.kwargs
+    else:
+        assert request.call_args.kwargs["timeout"] == expected_timeout
+
+
 def test_capped_cache():
     for i in range(101):
         art = Artifact(f"foo-{i}", type="test")

--- a/wandb/sdk/artifacts/storage_policies/_factories.py
+++ b/wandb/sdk/artifacts/storage_policies/_factories.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from typing import TYPE_CHECKING, Final
 
 from ..storage_handler import StorageHandler
@@ -30,6 +31,7 @@ def make_http_session() -> Session:
     from requests.adapters import HTTPAdapter
     from urllib3.util.retry import Retry
 
+    from wandb import env
     from wandb.sdk import wandb_setup
 
     # Sleep length: 0, 2, 4, 8, 16, 32, 64, 120, 120, 120, 120, 120, 120, 120, 120, 120
@@ -48,6 +50,12 @@ def make_http_session() -> Session:
     settings = wandb_setup.singleton().settings
     headers = settings.x_extra_http_headers or {}
     session.headers.update(headers)
+
+    timeout = settings.x_file_transfer_timeout_seconds
+    if timeout is None:
+        timeout = env.get_http_timeout()
+    if timeout > 0:
+        session.get = functools.partial(session.get, timeout=timeout)  # type: ignore[method-assign]
 
     # Explicitly configure the retry strategy for http/https adapters.
     adapter = HTTPAdapter(


### PR DESCRIPTION
Description
-----------

- Fixes #8572

Artifact downloads now apply a request timeout at the shared HTTP-session factory instead of allowing GET requests to wait indefinitely. The artifact-specific `x_file_transfer_timeout_seconds` setting takes precedence; otherwise the existing `WANDB_HTTP_TIMEOUT` value (20 seconds by default) is used. A timeout at or below zero preserves the prior opt-out behavior, and a caller's explicit timeout still overrides the default.

This shared path covers manifest, serial/fallback, multipart, and HTTP reference GETs without bypassing the existing retry and status hooks.

- [x] Updating `CHANGELOG.unreleased.md` is not applicable because this restores the documented timeout behavior.

Testing
-------

- Before the fix, a focused diagnostic observed no `timeout` on the manifest GET and exited with the expected failure sentinel.
- After the fix, the same diagnostic observed `timeout=7` and exited successfully.
- `tests/unit_tests/test_artifacts/test_wandb_artifacts.py`: 77 passed.
- Related artifact tests, excluding three modules whose optional dependencies (`boto3`, `cloudpickle`, and `pyfakefs`) are unavailable locally: 201 passed.
- Ruff 0.16.4 check and format check passed on both changed files.
- `ty` 0.0.73 passed on the changed production file. The exact isolated type hook could not complete locally because the editable build requires a configured Rust toolchain; its only targeted test-file diagnostic also reproduces on unmodified `main`.
- All other applicable changed-file pre-push hooks passed, including Ruff, merge-conflict, large-file, debug-statement, generated-stub, and `go-mod-tidy` checks.

AI assistance
-------------

This PR was implemented with AI assistance and independently reviewed and tested against the reported failure path.
