### PR TITLE
refactor: reorganize runsyncstate, replace Noop by InMemory

### DIFF
--- a/core/internal/runsyncstate/filestore.go
+++ b/core/internal/runsyncstate/filestore.go
@@ -1,0 +1,53 @@
+package runsyncstate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+// syncState is the content of the run's sync state file.
+type syncState struct {
+	// StartingStep is the initial step number for the run.
+	//
+	// For new runs this is zero.
+	// For forked runs this is specified by the user when they create the run.
+	// For resumed runs, this is determined during the first upload.
+	StartingStep *int64 `json:"starting_step,omitempty"`
+}
+
+// fileStore implements Store with a file and file-level locks.
+type fileStore struct {
+	// path is the path to the sync state file.
+	path string
+}
+
+// GetOrInitStartingStep implements Store.GetOrInitStartingStep.
+func (s *fileStore) GetOrInitStartingStep(
+	startingStep int64,
+) (int64, error) {
+	var state syncState
+
+	err := lockedfile.Transform(s.path, func(data []byte) ([]byte, error) {
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &state); err != nil {
+				return nil, fmt.Errorf("runsync: failed to parse sync state file: %v", err)
+			}
+			if state.StartingStep != nil {
+				return data, nil
+			}
+		}
+
+		state.StartingStep = &startingStep
+		updated, err := json.Marshal(state)
+		if err != nil {
+			return nil, fmt.Errorf("runsync: failed to encode sync state file: %v", err)
+		}
+		return updated, nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("runsync: failed to update sync state file: %v", err)
+	}
+	return *state.StartingStep, nil
+}

--- a/core/internal/runsyncstate/filestore_test.go
+++ b/core/internal/runsyncstate/filestore_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wandb/wandb/core/internal/runsyncstate"
 )
 
-func TestSyncStateStore_GetOrInitStartingStep_PersistsFirstValue(t *testing.T) {
+func TestFileStore_GetOrInitStartingStep_PersistsFirstValue(t *testing.T) {
 	wandbFile := filepath.Join(t.TempDir(), "run-xyz.wandb")
 	store := runsyncstate.File(wandbFile)
 
@@ -26,7 +26,7 @@ func TestSyncStateStore_GetOrInitStartingStep_PersistsFirstValue(t *testing.T) {
 	assert.EqualValues(t, 5, step)
 }
 
-func TestSyncStateStore_GetOrInitStartingStep_PersistsAcrossStores(t *testing.T) {
+func TestFileStore_GetOrInitStartingStep_PersistsAcrossStores(t *testing.T) {
 	wandbFile := filepath.Join(t.TempDir(), "run-xyz.wandb")
 
 	_, err := runsyncstate.File(wandbFile).GetOrInitStartingStep(7)
@@ -38,7 +38,7 @@ func TestSyncStateStore_GetOrInitStartingStep_PersistsAcrossStores(t *testing.T)
 	assert.EqualValues(t, 7, step)
 }
 
-func TestSyncStateStore_GetOrInitStartingStep_HandlesMissingStartingStep(t *testing.T) {
+func TestFileStore_GetOrInitStartingStep_HandlesMissingStartingStep(t *testing.T) {
 	wandbFile := filepath.Join(t.TempDir(), "run-xyz.wandb")
 
 	// Simulate a pre-existing sync state file that's valid JSON but

--- a/core/internal/runsyncstate/memorystore.go
+++ b/core/internal/runsyncstate/memorystore.go
@@ -1,0 +1,18 @@
+package runsyncstate
+
+type memoryStore struct {
+	startingStep            int64
+	startingStepInitialized bool
+}
+
+// GetOrInitStartingStep implements Store.GetOrInitStartingStep.
+func (s *memoryStore) GetOrInitStartingStep(
+	startingStep int64,
+) (int64, error) {
+	if !s.startingStepInitialized {
+		s.startingStep = startingStep
+		s.startingStepInitialized = true
+	}
+
+	return s.startingStep, nil
+}

--- a/core/internal/runsyncstate/memorystore_test.go
+++ b/core/internal/runsyncstate/memorystore_test.go
@@ -1,0 +1,22 @@
+package runsyncstate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/internal/runsyncstate"
+)
+
+func TestMemoryStore_GetOrInitStartingStep_PersistsValue(t *testing.T) {
+	store := runsyncstate.InMemory()
+
+	value1, err := store.GetOrInitStartingStep(1)
+	require.NoError(t, err)
+	value2, err := store.GetOrInitStartingStep(2)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, value1)
+	assert.EqualValues(t, 1, value2)
+}

--- a/core/internal/runsyncstate/syncstate.go
+++ b/core/internal/runsyncstate/syncstate.go
@@ -1,88 +1,32 @@
 package runsyncstate
 
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/rogpeppe/go-internal/lockedfile"
-)
-
 // syncStateSuffix is appended to a .wandb file's path to get the path of
 // its sync state file.
 const syncStateSuffix = ".syncstate"
 
-// syncState is a run's saved upload state.
+// Store reads and updates the run's upload state.
 //
-// It is stored in a file alongside the `.wandb` file, and may be updated
-// when run data is uploaded to the server, either during `wandb sync` or
-// during an online run's automatic upload.
-type syncState struct {
-	// StartingStep is the initial step number for the run.
-	//
-	// For new runs this is zero.
-	// For forked runs this is specified by the user when they create the run.
-	// For resumed runs, this is determined during the first upload.
-	StartingStep *int64 `json:"starting_step,omitempty"`
-}
-
-// GetOrInitStartingStep returns the starting step previously initialized, if any.
-//
-// Otherwise, it persists startingStep so that future calls (including from
-// other processes) return the same value.
-//
-// The read-check-write is performed under an exclusive file lock so that
-// concurrent syncs of the same file can't race.
+// The sync state is usually stored in a file alongside the `.wandb` file
+// and may be updated when run data is uploaded to the server, either during
+// `wandb sync` or an online run. It ensures that syncing a run is idempotent,
+// in particular for resumed runs.
 type Store interface {
+	// GetOrInitStartingStep returns the run's starting step.
+	//
+	// If the step hasn't been initialized yet, this initializes it to
+	// the given value.
 	GetOrInitStartingStep(startingStep int64) (int64, error)
 }
 
-// SyncStateStore reads and updates the sync state file for a
-// single run.
-type fileStore struct {
-	// path is the path to the sync state file.
-	path string
-}
-
-type noopStore struct{}
-
-func Noop() Store {
-	return &noopStore{}
-}
-
-func (s *noopStore) GetOrInitStartingStep(startingStep int64) (int64, error) {
-	return startingStep, nil
-}
-
-// File returns a store for a run's sync state file.
+// File returns a Store backed by a `.wandb.syncstate` file.
+//
+// This uses file-level locking to read and update the file and is meant to work
+// when accessed by multiple wandb-core processes at once.
 func File(transactionLogPath string) Store {
 	return &fileStore{path: transactionLogPath + syncStateSuffix}
 }
 
-// GetOrInitStartingStep implements Store.GetOrInitStartingStep.
-func (s *fileStore) GetOrInitStartingStep(
-	startingStep int64,
-) (int64, error) {
-	var state syncState
-
-	err := lockedfile.Transform(s.path, func(data []byte) ([]byte, error) {
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &state); err != nil {
-				return nil, fmt.Errorf("runsync: failed to parse sync state file: %v", err)
-			}
-			if state.StartingStep != nil {
-				return data, nil
-			}
-		}
-
-		state.StartingStep = &startingStep
-		updated, err := json.Marshal(state)
-		if err != nil {
-			return nil, fmt.Errorf("runsync: failed to encode sync state file: %v", err)
-		}
-		return updated, nil
-	})
-	if err != nil {
-		return 0, fmt.Errorf("runsync: failed to update sync state file: %v", err)
-	}
-	return *state.StartingStep, nil
+// InMemory returns an in-memory Store.
+func InMemory() Store {
+	return &memoryStore{}
 }

--- a/core/internal/runupsertertest/runupsertertest.go
+++ b/core/internal/runupsertertest/runupsertertest.go
@@ -53,7 +53,7 @@ func NewTestUpserter(
 		params.FeatureProvider = featurechecker.NewPreloaded(nil)
 	}
 	if params.SyncStateStore == nil {
-		params.SyncStateStore = runsyncstate.Noop()
+		params.SyncStateStore = runsyncstate.InMemory()
 	}
 
 	record := &spb.Record{RecordType: &spb.Record_Run{

--- a/core/internal/stream/stream.go
+++ b/core/internal/stream/stream.go
@@ -122,7 +122,7 @@ func NewStream(
 		runWork,
 		/*fileReadDelay=*/ 5*time.Second,
 	)
-	syncStateStore := runsyncstate.Noop()
+	syncStateStore := runsyncstate.InMemory()
 	if !s.IsSkipTransactionLog() {
 		syncStateStore = runsyncstate.File(s.GetTransactionLogPath())
 	}


### PR DESCRIPTION
Replaces the `Noop` store by an `InMemory` store because calling `GetOrInit` twice in a row on a no-op store returns the parameter both times, which doesn't match the implied semantics. This would be a bug if another caller were added.

Separates the file-based and in-memory implementations and the public interface into separate files. The public interface will grow and keeping it separate makes it easier to tell what this component does.