### PR TITLE
feat: store runtime in the syncstate file

### DIFF
--- a/core/internal/runbranch/processresponse.go
+++ b/core/internal/runbranch/processresponse.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/wandb/simplejsonext"
 
@@ -126,12 +127,12 @@ func processHistory(history *string) (map[string]any, error) {
 	return historyTail, nil
 }
 
-func extractRuntime(runtime any) float64 {
+func extractRuntime(runtime any) time.Duration {
 	switch x := runtime.(type) {
 	case int64:
-		return float64(x)
+		return time.Duration(x) * time.Second
 	case float64:
-		return x
+		return time.Duration(int64(x*1000)) * time.Millisecond
 	}
 	return 0
 }

--- a/core/internal/runbranch/resume.go
+++ b/core/internal/runbranch/resume.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"math"
 
 	"github.com/Khan/genqlient/graphql"
 
@@ -185,11 +184,10 @@ func processResponse(
 		return err
 	} else if events != nil {
 		if runtime, ok := events["_runtime"]; ok {
-			params.Runtime = int32(
-				math.Max(
-					extractRuntime(runtime),
-					float64(params.Runtime),
-				))
+			params.Runtime = max(
+				extractRuntime(runtime),
+				params.Runtime,
+			)
 		}
 	}
 
@@ -216,19 +214,17 @@ func processResponse(
 		switch x := params.Summary["_wandb"].(type) {
 		case map[string]any:
 			if runtime, ok := x["runtime"]; ok {
-				params.Runtime = int32(
-					math.Max(
-						extractRuntime(runtime),
-						float64(params.Runtime),
-					))
+				params.Runtime = max(
+					extractRuntime(runtime),
+					params.Runtime,
+				)
 			}
 		default:
 			if runtime, ok := params.Summary["_runtime"]; ok {
-				params.Runtime = int32(
-					math.Max(
-						extractRuntime(runtime),
-						float64(params.Runtime),
-					))
+				params.Runtime = max(
+					extractRuntime(runtime),
+					params.Runtime,
+				)
 			}
 		}
 	}
@@ -247,11 +243,10 @@ func processResponse(
 		}
 
 		if runtime, ok := history["_runtime"]; ok {
-			params.Runtime = int32(
-				math.Max(
-					extractRuntime(runtime),
-					float64(params.Runtime),
-				))
+			params.Runtime = max(
+				extractRuntime(runtime),
+				params.Runtime,
+			)
 		}
 	}
 

--- a/core/internal/runbranch/resume_test.go
+++ b/core/internal/runbranch/resume_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -280,7 +281,7 @@ func TestMustResumeValidHistory(t *testing.T) {
 	params := &runbranch.RunParams{}
 	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Equal(t, int64(2), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(50), params.Runtime, "GetUpdates should return correct runtime")
+	assert.Equal(t, 50*time.Second, params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
@@ -324,7 +325,7 @@ func TestMustResumeZeroHisotry(t *testing.T) {
 	params := &runbranch.RunParams{}
 	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
+	assert.EqualValues(t, 0, params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
@@ -369,7 +370,7 @@ func TestMustResumeHistoryTailStepZero(t *testing.T) {
 	params := &runbranch.RunParams{}
 	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Equal(t, int64(1), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
+	assert.EqualValues(t, 0, params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 	assert.Nil(t, err, "GetUpdates should not return an error")
 }
@@ -413,9 +414,9 @@ func TestMustResumeValidSummary(t *testing.T) {
 
 	params := &runbranch.RunParams{}
 	err = resumeState.UpdateForResume(params, runconfig.New())
-	assert.Equal(t, int64(2), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(40), params.Runtime, "GetUpdates should return correct runtime")
-	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
+	assert.Equal(t, int64(2), params.StartingStep)
+	assert.EqualValues(t, 40.2, params.Runtime.Seconds())
+	assert.True(t, params.Resumed)
 
 	// check the value of the summary are correct
 	assert.Len(t, params.Summary, 4, "GetUpdates should return correct summary")
@@ -479,7 +480,7 @@ func TestMustResumeValidConfig(t *testing.T) {
 	err = resumeState.UpdateForResume(params, config)
 	assert.Nil(t, err, "GetUpdates should not return an error")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
+	assert.EqualValues(t, 0, params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 	assert.Len(t, config.CloneTree(), 1, "GetUpdates should return correct config")
 	assert.Equal(t, 0.001, config.CloneTree()["lr"], "GetUpdates should return correct config")
@@ -527,7 +528,7 @@ func TestMustResumeValidTags(t *testing.T) {
 	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
+	assert.EqualValues(t, 0, params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 	assert.Len(t, params.Tags, 2, "GetUpdates should return correct tags")
 	assert.Contains(t, params.Tags, "tag1", "GetUpdates should return correct tags")
@@ -576,7 +577,7 @@ func TestMustResumeValidStorageId(t *testing.T) {
 	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(0), params.Runtime, "GetUpdates should return correct runtime")
+	assert.EqualValues(t, 0, params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 	assert.Equal(t, "storage_id", params.StorageID, "GetUpdates should return correct storage id")
 }
@@ -624,7 +625,7 @@ func TestMustResumeValidEvents(t *testing.T) {
 	err = resumeState.UpdateForResume(params, runconfig.New())
 	assert.Nil(t, err, "GetUpdates should not return an error")
 	assert.Equal(t, int64(0), params.StartingStep, "GetUpdates should return correct starting step")
-	assert.Equal(t, int32(50), params.Runtime, "GetUpdates should return correct runtime")
+	assert.Equal(t, 50*time.Second, params.Runtime, "GetUpdates should return correct runtime")
 	assert.True(t, params.Resumed, "GetUpdates should return correct resumed state")
 
 	assert.Len(t, params.Summary, 1, "GetUpdates should return correct summary")
@@ -1155,7 +1156,7 @@ func TestExtractRunState(t *testing.T) {
 	assert.Equal(t, int64(5), params.StartingStep, "Incorrect starting step")
 
 	// Test Runtime
-	assert.Equal(t, int32(130), params.Runtime, "Incorrect runtime")
+	assert.Equal(t, 130*time.Second, params.Runtime, "Incorrect runtime")
 
 	// Test Resumed flag
 	assert.True(t, params.Resumed, "Resumed flag should be true")
@@ -1397,7 +1398,7 @@ func TestExtractRunStateAdjustsStartTime(t *testing.T) {
 	assert.Nil(t, err, "GetUpdates should not return an error")
 
 	// Verify other fields are set correctly
-	assert.Equal(t, int32(130), params.Runtime, "Runtime should be set to the maximum value")
+	assert.Equal(t, 130*time.Second, params.Runtime, "Runtime should be set to the maximum value")
 	assert.True(t, params.Resumed, "Resumed flag should be set to true")
 }
 

--- a/core/internal/runbranch/state.go
+++ b/core/internal/runbranch/state.go
@@ -73,7 +73,7 @@ type RunParams struct {
 
 	// run state fields based on response from the server
 	StartingStep int64
-	Runtime      int32
+	Runtime      time.Duration
 
 	Tags []string
 
@@ -149,7 +149,7 @@ func (r *RunParams) SetOnProto(record *spb.RunRecord) {
 	record.SweepId = r.SweepID
 
 	record.StartingStep = r.StartingStep
-	record.Runtime = r.Runtime
+	record.Runtime = int32(r.Runtime.Seconds())
 
 	record.Tags = slices.Clone(r.Tags)
 
@@ -230,7 +230,7 @@ func (r *RunParams) Update(
 		r.StartingStep = record.StartingStep
 	}
 	if record.Runtime != 0 {
-		r.Runtime = record.Runtime
+		r.Runtime = time.Duration(record.Runtime) * time.Second
 	}
 
 	if len(record.Tags) > 0 {

--- a/core/internal/runsyncstate/filestore.go
+++ b/core/internal/runsyncstate/filestore.go
@@ -3,18 +3,18 @@ package runsyncstate
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
 // syncState is the content of the run's sync state file.
 type syncState struct {
-	// StartingStep is the initial step number for the run.
-	//
-	// For new runs this is zero.
-	// For forked runs this is specified by the user when they create the run.
-	// For resumed runs, this is determined during the first upload.
+	// StartingStep is the encoded StartState.StartStep.
 	StartingStep *int64 `json:"starting_step,omitempty"`
+
+	// StartingRuntimeMs is the StartState.StartRuntime in milliseconds.
+	StartingRuntimeMs *int64 `json:"starting_runtime,omitempty"`
 }
 
 // fileStore implements Store with a file and file-level locks.
@@ -23,31 +23,48 @@ type fileStore struct {
 	path string
 }
 
-// GetOrInitStartingStep implements Store.GetOrInitStartingStep.
-func (s *fileStore) GetOrInitStartingStep(
-	startingStep int64,
-) (int64, error) {
-	var state syncState
+// GetOrInitStartState implements Store.GetOrInitStartState.
+func (s *fileStore) GetOrInitStartState(
+	initialState StartState,
+) (result StartState, err error) {
+	err = lockedfile.Transform(s.path, func(data []byte) ([]byte, error) {
+		var fileContent syncState
 
-	err := lockedfile.Transform(s.path, func(data []byte) ([]byte, error) {
 		if len(data) > 0 {
-			if err := json.Unmarshal(data, &state); err != nil {
-				return nil, fmt.Errorf("runsync: failed to parse sync state file: %v", err)
-			}
-			if state.StartingStep != nil {
-				return data, nil
+			if err := json.Unmarshal(data, &fileContent); err != nil {
+				return nil, fmt.Errorf(
+					"runsync: failed to parse sync state file: %v",
+					err,
+				)
 			}
 		}
 
-		state.StartingStep = &startingStep
-		updated, err := json.Marshal(state)
-		if err != nil {
-			return nil, fmt.Errorf("runsync: failed to encode sync state file: %v", err)
+		if fileContent.StartingStep != nil {
+			result.StartStep = *fileContent.StartingStep
+		} else {
+			result.StartStep = initialState.StartStep
+			fileContent.StartingStep = &initialState.StartStep
 		}
+
+		if fileContent.StartingRuntimeMs != nil {
+			result.StartRuntime = time.Millisecond *
+				time.Duration(*fileContent.StartingRuntimeMs)
+		} else {
+			result.StartRuntime = initialState.StartRuntime
+			millis := initialState.StartRuntime.Milliseconds()
+			fileContent.StartingRuntimeMs = &millis
+		}
+
+		updated, err := json.Marshal(fileContent)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"runsync: failed to encode sync state file: %v",
+				err,
+			)
+		}
+
 		return updated, nil
 	})
-	if err != nil {
-		return 0, fmt.Errorf("runsync: failed to update sync state file: %v", err)
-	}
-	return *state.StartingStep, nil
+
+	return
 }

--- a/core/internal/runsyncstate/filestore_test.go
+++ b/core/internal/runsyncstate/filestore_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,48 +12,65 @@ import (
 	"github.com/wandb/wandb/core/internal/runsyncstate"
 )
 
-func TestFileStore_GetOrInitStartingStep_PersistsFirstValue(t *testing.T) {
+func TestFileStore_GetOrInitStartState_PersistsFirstValue(t *testing.T) {
 	wandbFile := filepath.Join(t.TempDir(), "run-xyz.wandb")
 	store := runsyncstate.File(wandbFile)
 
-	step, err := store.GetOrInitStartingStep(5)
+	state, err := store.GetOrInitStartState(runsyncstate.StartState{
+		StartStep:    5,
+		StartRuntime: 7 * time.Millisecond,
+	})
 	require.NoError(t, err)
-	assert.EqualValues(t, 5, step)
+	assert.EqualValues(t, 5, state.StartStep)
+	assert.EqualValues(t, 7, state.StartRuntime.Milliseconds())
 
 	// A second call should reuse the initialized value, regardless of the
 	// passed-in value.
-	step, err = store.GetOrInitStartingStep(999)
+	state, err = store.GetOrInitStartState(runsyncstate.StartState{})
 	require.NoError(t, err)
-	assert.EqualValues(t, 5, step)
+	assert.EqualValues(t, 5, state.StartStep)
+	assert.EqualValues(t, 7*time.Millisecond, state.StartRuntime)
 }
 
-func TestFileStore_GetOrInitStartingStep_PersistsAcrossStores(t *testing.T) {
+func TestFileStore_GetOrInitStartState_PersistsAcrossStores(t *testing.T) {
 	wandbFile := filepath.Join(t.TempDir(), "run-xyz.wandb")
 
-	_, err := runsyncstate.File(wandbFile).GetOrInitStartingStep(7)
+	_, err := runsyncstate.File(wandbFile).GetOrInitStartState(
+		runsyncstate.StartState{
+			StartStep:    7,
+			StartRuntime: time.Minute,
+		})
 	require.NoError(t, err)
 
 	// A fresh store instance should read the previously initialized value.
-	step, err := runsyncstate.File(wandbFile).GetOrInitStartingStep(42)
+	state, err := runsyncstate.File(wandbFile).
+		GetOrInitStartState(runsyncstate.StartState{})
 	require.NoError(t, err)
-	assert.EqualValues(t, 7, step)
+	assert.EqualValues(t, 7, state.StartStep)
+	assert.EqualValues(t, time.Minute, state.StartRuntime)
 }
 
-func TestFileStore_GetOrInitStartingStep_HandlesMissingStartingStep(t *testing.T) {
-	wandbFile := filepath.Join(t.TempDir(), "run-xyz.wandb")
-
+func TestFileStore_GetOrInitStartState_HandlesMissingStartState(t *testing.T) {
 	// Simulate a pre-existing sync state file that's valid JSON but
-	// doesn't set starting_step. This should behave like an uninitialized
+	// doesn't set the start state. This should behave like an uninitialized
 	// file.
+	wandbFile := filepath.Join(t.TempDir(), "run-xyz.wandb")
 	require.NoError(t,
 		os.WriteFile(wandbFile+".syncstate", []byte("{}"), 0o666))
 
-	step, err := runsyncstate.File(wandbFile).GetOrInitStartingStep(5)
+	state, err := runsyncstate.File(wandbFile).GetOrInitStartState(
+		runsyncstate.StartState{
+			StartStep:    5,
+			StartRuntime: 4 * time.Hour,
+		})
 	require.NoError(t, err)
-	assert.EqualValues(t, 5, step)
+	assert.EqualValues(t, 5, state.StartStep)
+	assert.EqualValues(t, 4*time.Hour, state.StartRuntime)
 
 	// The value should now be persisted for subsequent calls.
-	step, err = runsyncstate.File(wandbFile).GetOrInitStartingStep(999)
+	state, err = runsyncstate.File(wandbFile).
+		GetOrInitStartState(runsyncstate.StartState{})
 	require.NoError(t, err)
-	assert.EqualValues(t, 5, step)
+	assert.EqualValues(t, 5, state.StartStep)
+	assert.EqualValues(t, 4*time.Hour, state.StartRuntime)
 }

--- a/core/internal/runsyncstate/memorystore.go
+++ b/core/internal/runsyncstate/memorystore.go
@@ -1,18 +1,18 @@
 package runsyncstate
 
 type memoryStore struct {
-	startingStep            int64
-	startingStepInitialized bool
+	startState            StartState
+	startStateInitialized bool
 }
 
-// GetOrInitStartingStep implements Store.GetOrInitStartingStep.
-func (s *memoryStore) GetOrInitStartingStep(
-	startingStep int64,
-) (int64, error) {
-	if !s.startingStepInitialized {
-		s.startingStep = startingStep
-		s.startingStepInitialized = true
+// GetOrInitStartState implements Store.GetOrInitStartState.
+func (s *memoryStore) GetOrInitStartState(
+	initialState StartState,
+) (StartState, error) {
+	if !s.startStateInitialized {
+		s.startState = initialState
+		s.startStateInitialized = true
 	}
 
-	return s.startingStep, nil
+	return s.startState, nil
 }

--- a/core/internal/runsyncstate/memorystore_test.go
+++ b/core/internal/runsyncstate/memorystore_test.go
@@ -2,6 +2,7 @@ package runsyncstate_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,11 +13,23 @@ import (
 func TestMemoryStore_GetOrInitStartingStep_PersistsValue(t *testing.T) {
 	store := runsyncstate.InMemory()
 
-	value1, err := store.GetOrInitStartingStep(1)
+	value1, err := store.GetOrInitStartState(runsyncstate.StartState{
+		StartStep:    1,
+		StartRuntime: time.Millisecond,
+	})
 	require.NoError(t, err)
-	value2, err := store.GetOrInitStartingStep(2)
+	value2, err := store.GetOrInitStartState(runsyncstate.StartState{
+		StartStep:    2,
+		StartRuntime: 2 * time.Millisecond,
+	})
 	require.NoError(t, err)
 
-	assert.EqualValues(t, 1, value1)
-	assert.EqualValues(t, 1, value2)
+	assert.EqualValues(t, runsyncstate.StartState{
+		StartStep:    1,
+		StartRuntime: time.Millisecond,
+	}, value1)
+	assert.EqualValues(t, runsyncstate.StartState{
+		StartStep:    1,
+		StartRuntime: time.Millisecond,
+	}, value2)
 }

--- a/core/internal/runsyncstate/syncstate.go
+++ b/core/internal/runsyncstate/syncstate.go
@@ -1,8 +1,27 @@
 package runsyncstate
 
+import "time"
+
 // syncStateSuffix is appended to a .wandb file's path to get the path of
 // its sync state file.
 const syncStateSuffix = ".syncstate"
+
+// StartState contains starting parameters that are necessary to sync the run
+// but that are determined by the server.
+type StartState struct {
+	// StartStep is the run's initial `_step` value.
+	//
+	// For new runs, this is zero.
+	// For forked runs, this is specified by the user.
+	// For resumed runs, this is one more than the previous run's last `_step`.
+	StartStep int64
+
+	// StartRuntime is the run's initial `_runtime` value.
+	//
+	// This is non-zero only for resumed runs, where it is the previous run's
+	// last `_runtime`.
+	StartRuntime time.Duration
+}
 
 // Store reads and updates the run's upload state.
 //
@@ -11,11 +30,11 @@ const syncStateSuffix = ".syncstate"
 // `wandb sync` or an online run. It ensures that syncing a run is idempotent,
 // in particular for resumed runs.
 type Store interface {
-	// GetOrInitStartingStep returns the run's starting step.
+	// GetOrInitStartState returns the run's starting state.
 	//
-	// If the step hasn't been initialized yet, this initializes it to
+	// If the start state hasn't been initialized yet, this initializes it to
 	// the given value.
-	GetOrInitStartingStep(startingStep int64) (int64, error)
+	GetOrInitStartState(initialState StartState) (StartState, error)
 }
 
 // File returns a Store backed by a `.wandb.syncstate` file.

--- a/core/internal/runupserter/runupserter.go
+++ b/core/internal/runupserter/runupserter.go
@@ -226,13 +226,16 @@ func InitRun(
 		}
 	}
 
-	startingStep, err := upserter.syncStateStore.GetOrInitStartingStep(
-		upserter.params.StartingStep,
-	)
+	startState, err := upserter.syncStateStore.GetOrInitStartState(
+		runsyncstate.StartState{
+			StartStep:    upserter.params.StartingStep,
+			StartRuntime: upserter.params.Runtime,
+		})
 	if err != nil {
 		return nil, ToRunUpdateError(err)
 	}
-	upserter.params.StartingStep = startingStep
+	upserter.params.StartingStep = startState.StartStep
+	upserter.params.Runtime = startState.StartRuntime
 
 	upserter.startRuntime = time.Duration(upserter.params.Runtime) * time.Second
 

--- a/core/internal/runupserter/runupserter_test.go
+++ b/core/internal/runupserter/runupserter_test.go
@@ -242,6 +242,61 @@ func TestInitRun_Offline(t *testing.T) {
 	assert.NotNil(t, upserter)
 }
 
+func TestInitRun_InitializesSyncStartState(t *testing.T) {
+	mockClient := gqlmock.NewMockClient()
+	runupsertertest.StubRunResumeStatusWithStepAndRuntime(t, mockClient, 5, 3.5)
+	runupsertertest.StubUpsertBucket(t, mockClient)
+
+	params := testParams(t)
+	params.GraphqlClientOrNil = mockClient
+	params.Settings = settings.From(&spb.Settings{
+		Resume: wrapperspb.String("allow")})
+
+	upserter, err := runupserter.InitRun(
+		runRecord(&spb.RunRecord{RunId: "run"}),
+		params,
+	)
+	require.NoError(t, err)
+	defer upserter.Finish()
+
+	startState, err := params.SyncStateStore.
+		GetOrInitStartState(runsyncstate.StartState{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, runsyncstate.StartState{
+		StartStep:    5,
+		StartRuntime: 3500 * time.Millisecond,
+	}, startState)
+}
+
+func TestInitRun_ReusesSyncStartState(t *testing.T) {
+	mockClient := gqlmock.NewMockClient()
+	runupsertertest.StubRunResumeStatusWithStepAndRuntime(t, mockClient, 9, 1.5)
+	runupsertertest.StubUpsertBucket(t, mockClient)
+
+	params := testParams(t)
+	_, err := params.SyncStateStore.GetOrInitStartState(runsyncstate.StartState{
+		StartStep:    6,
+		StartRuntime: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	params.GraphqlClientOrNil = mockClient
+	params.Settings = settings.From(&spb.Settings{
+		Resume: wrapperspb.String("allow")})
+
+	upserter, err := runupserter.InitRun(
+		runRecord(&spb.RunRecord{RunId: "run"}),
+		params,
+	)
+	require.NoError(t, err)
+	defer upserter.Finish()
+
+	run := &spb.RunRecord{}
+	upserter.FillRunRecord(run)
+	// The values in the syncstate file take precedence over the loaded values.
+	assert.EqualValues(t, 6, run.StartingStep)
+	assert.EqualValues(t, 5, run.Runtime)
+}
+
 func TestResume(t *testing.T) {
 	mockClient := gqlmock.NewMockClient()
 	mockClient.StubMatchOnce(gqlmock.WithOpName("RunResumeStatus"), `{}`)
@@ -267,51 +322,6 @@ func TestResume_Offline_Succeeds(t *testing.T) {
 	defer upserter.Finish()
 
 	assert.NoError(t, err)
-}
-
-func TestResume_InitializesSyncStateStartingStep(t *testing.T) {
-	mockClient := gqlmock.NewMockClient()
-	runupsertertest.StubRunResumeStatusWithStep(t, mockClient, 5)
-	runupsertertest.StubUpsertBucket(t, mockClient)
-
-	params := testParams(t)
-	params.GraphqlClientOrNil = mockClient
-	params.Settings = settings.From(&spb.Settings{Resume: wrapperspb.String("allow")})
-
-	upserter, err := runupserter.InitRun(runRecord(&spb.RunRecord{RunId: "run"}), params)
-	require.NoError(t, err)
-	defer upserter.Finish()
-
-	run := &spb.RunRecord{}
-	upserter.FillRunRecord(run)
-	assert.EqualValues(t, 5, run.StartingStep)
-	startingStep, err := params.SyncStateStore.GetOrInitStartingStep(0)
-	require.NoError(t, err)
-	assert.EqualValues(t, 5, startingStep)
-}
-
-func TestResume_ReusesSyncStateStartingStep(t *testing.T) {
-	mockClient := gqlmock.NewMockClient()
-	runupsertertest.StubRunResumeStatusWithStep(t, mockClient, 99)
-	runupsertertest.StubUpsertBucket(t, mockClient)
-
-	startingStep := int64(6)
-	params := testParams(t)
-	_, err := params.SyncStateStore.GetOrInitStartingStep(startingStep)
-	require.NoError(t, err)
-	params.GraphqlClientOrNil = mockClient
-	params.Settings = settings.From(&spb.Settings{Resume: wrapperspb.String("allow")})
-
-	upserter, err := runupserter.InitRun(runRecord(&spb.RunRecord{RunId: "run"}), params)
-	require.NoError(t, err)
-	defer upserter.Finish()
-
-	run := &spb.RunRecord{}
-	upserter.FillRunRecord(run)
-	// Even though the live query resolves _step=99, as if a previous sync
-	// already uploaded more history, the pre-initialized value wins so that
-	// re-syncing doesn't shift steps forward.
-	assert.EqualValues(t, 6, run.StartingStep)
 }
 
 func TestResume_KeepsEventsAndOutputFileStreamOffsets(t *testing.T) {
@@ -363,74 +373,6 @@ func TestResume_KeepsEventsAndOutputFileStreamOffsets(t *testing.T) {
 			filestream.OutputChunk:  15,
 		},
 		upserter.FileStreamOffsets())
-}
-
-func TestNewRun_InitializesSyncStateStartingStep(t *testing.T) {
-	params := testParams(t)
-
-	upserter, err := runupserter.InitRun(runRecord(&spb.RunRecord{RunId: "run"}), params)
-	require.NoError(t, err)
-	defer upserter.Finish()
-
-	run := &spb.RunRecord{}
-	upserter.FillRunRecord(run)
-	assert.EqualValues(t, 0, run.StartingStep)
-	startingStep, err := params.SyncStateStore.GetOrInitStartingStep(1)
-	require.NoError(t, err)
-	assert.EqualValues(t, 0, startingStep)
-}
-
-func TestRewind_InitializesSyncStateStartingStep(t *testing.T) {
-	// NOTE: Rewinding works offline.
-	runInitRecord := runRecord(
-		&spb.RunRecord{
-			RunId: "run to rewind",
-			BranchPoint: &spb.BranchPoint{
-				Run:    "run to rewind",
-				Metric: "_step",
-				Value:  123,
-			},
-		})
-
-	params := testParams(t)
-
-	upserter, err := runupserter.InitRun(runInitRecord, params)
-	defer upserter.Finish()
-
-	assert.NoError(t, err)
-	run := &spb.RunRecord{}
-	upserter.FillRunRecord(run)
-	assert.EqualValues(t, run.StartingStep, 124)
-	startingStep, err := params.SyncStateStore.GetOrInitStartingStep(0)
-	require.NoError(t, err)
-	assert.EqualValues(t, 124, startingStep)
-}
-
-func TestFork_InitializesSyncStateStartingStep(t *testing.T) {
-	// NOTE: Forking works offline.
-	runInitRecord := runRecord(
-		&spb.RunRecord{
-			RunId: "run",
-			BranchPoint: &spb.BranchPoint{
-				Run:    "other run",
-				Metric: "_step",
-				Value:  10,
-			},
-		},
-	)
-
-	params := testParams(t)
-
-	upserter, err := runupserter.InitRun(runInitRecord, params)
-	defer upserter.Finish()
-
-	assert.NoError(t, err)
-	run := &spb.RunRecord{}
-	upserter.FillRunRecord(run)
-	assert.EqualValues(t, run.StartingStep, 11)
-	startingStep, err := params.SyncStateStore.GetOrInitStartingStep(0)
-	require.NoError(t, err)
-	assert.EqualValues(t, 11, startingStep)
 }
 
 type variablesForUpdateTest struct {

--- a/core/internal/runupsertertest/runupsertertest.go
+++ b/core/internal/runupsertertest/runupsertertest.go
@@ -89,7 +89,12 @@ func StubUpsertBucket(t *testing.T, mockGQL *gqlmock.MockClient) {
 	}`)
 }
 
-func StubRunResumeStatusWithStep(t *testing.T, mock *gqlmock.MockClient, step int64) {
+func StubRunResumeStatusWithStepAndRuntime(
+	t *testing.T,
+	mock *gqlmock.MockClient,
+	step int64,
+	runtime float64,
+) {
 	mock.StubMatchOnce(gqlmock.WithOpName("RunResumeStatus"), fmt.Sprintf(`{
 		"model": {
 			"bucket": {
@@ -99,13 +104,13 @@ func StubRunResumeStatusWithStep(t *testing.T, mock *gqlmock.MockClient, step in
 				"eventsLineCount": 0,
 				"logLineCount": 0,
 				"historyTail": "[]",
-				"summaryMetrics": "{\"_step\": %d}",
+				"summaryMetrics": "{\"_step\": %d, \"_runtime\": %f}",
 				"config": "{}",
 				"eventsTail": "[]",
 				"wandbConfig": "{\"t\": 1}"
 			}
 		}
-	}`, step))
+	}`, step, runtime))
 }
 
 // Telemetry is the telemetry uploaded through an UpsertBucket request.


### PR DESCRIPTION
Updates `runsyncstate` to also track the run's starting `_runtime`.

I fixed up logic that was rounding the `_runtime` down to a whole number of seconds, which would be wrong for offline resume.

I simplified `runupserter_test.go` - there were way too many tests testing the same thing. Only one test is needed for one `GetOrInitStartState()` call. Checking this for forking and rewind is redundant with existing tests for those features.

`resume_test.go` is quite horrible, and I didn't bother simplifying it for that updates that I had to make.