### PR TITLE
chore: improve resume failure debug logs

### DIFF
--- a/core/internal/runbranch/resume.go
+++ b/core/internal/runbranch/resume.go
@@ -3,7 +3,6 @@ package runbranch
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -80,7 +79,10 @@ func (rb *ResumeBranch) UpdateForResume(
 				" If you are trying to start a new run, please omit the `resume` argument or use `resume='allow'`.",
 				params.RunID),
 		}
-		err = errors.New("no data but must resume")
+		err = fmt.Errorf(
+			"resume setting is 'must' but run %s does not exist",
+			params.RunID,
+		)
 		return &BranchError{Err: err, Response: info}
 	}
 
@@ -94,7 +96,10 @@ func (rb *ResumeBranch) UpdateForResume(
 				"  Please check your inputs and try again with a valid value for the `resume` argument.",
 				params.RunID),
 		}
-		err = errors.New("data but cannot resume")
+		err = fmt.Errorf(
+			"resume setting is 'never' but run %s exists",
+			params.RunID,
+		)
 		return &BranchError{Err: err, Response: info}
 	}
 


### PR DESCRIPTION
Updates the messages written to `debug-internal.log` when a run fails to initialize due to its `resume` setting. I left the actual printed messages as is; they're too verbose but otherwise fine.

Fixes WB-38847.