### PR TITLE
feat(sandbox): deprecate wandb.sandbox

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -17,3 +17,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
+
+### Deprecated
+
+- `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,10 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
-### Fixed
-
-- File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
-
 ### Deprecated
 
 - `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead.
+
+### Fixed
+
+- File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from typing import Any
 
 import cwsandbox
@@ -23,6 +25,18 @@ _SUPPORTED_NETWORK_VALUES = (
     {"deny_egress": False},
     {"deny_egress": True},
 )
+
+
+def test_import_warns_that_wandb_sandbox_is_deprecated() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import wandb.sandbox"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "`wandb.sandbox` is deprecated" in result.stderr
+    assert "Use the `cwsandbox` package directly instead." in result.stderr
 
 
 def test_sandbox_wrapper_reexports_cwsandbox_public_api() -> None:

--- a/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
+++ b/tests/unit_tests/test_sandbox/test_sandbox_wrapper.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 from typing import Any
 
 import cwsandbox
@@ -25,18 +23,6 @@ _SUPPORTED_NETWORK_VALUES = (
     {"deny_egress": False},
     {"deny_egress": True},
 )
-
-
-def test_import_warns_that_wandb_sandbox_is_deprecated() -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", "import wandb.sandbox"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-    assert "`wandb.sandbox` is deprecated" in result.stderr
-    assert "Use the `cwsandbox` package directly instead." in result.stderr
 
 
 def test_sandbox_wrapper_reexports_cwsandbox_public_api() -> None:

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from wandb.errors.term import termwarn
+
 try:
     import cwsandbox
 except ImportError as exc:
@@ -14,6 +16,12 @@ from cwsandbox import __all__ as cwsandbox_all
 from ._auth import _set_wandb_auth_mode
 from ._sandbox import Sandbox, Session
 from ._secret import Secret
+
+termwarn(
+    "`wandb.sandbox` is deprecated and will be removed in a future release. "
+    "Use the `cwsandbox` package directly instead.",
+    repeat=False,
+)
 
 _set_wandb_auth_mode()
 

--- a/wandb/sandbox/__init__.py
+++ b/wandb/sandbox/__init__.py
@@ -1,13 +1,19 @@
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from wandb.errors.term import termwarn
 
+termwarn(
+    "`wandb.sandbox` is deprecated and will be removed in a future release. "
+    "Use the `cwsandbox` package directly instead.",
+    repeat=False,
+)
+
 try:
     import cwsandbox
 except ImportError as exc:
-    raise ImportError(
-        "cwsandbox is not installed. Please install it with: pip install wandb[sandbox]"
-    ) from exc
+    raise ImportError("cwsandbox is not installed") from exc
 
 from cwsandbox import *  # noqa: F403
 from cwsandbox import __all__ as cwsandbox_all
@@ -16,12 +22,6 @@ from cwsandbox import __all__ as cwsandbox_all
 from ._auth import _set_wandb_auth_mode
 from ._sandbox import Sandbox, Session
 from ._secret import Secret
-
-termwarn(
-    "`wandb.sandbox` is deprecated and will be removed in a future release. "
-    "Use the `cwsandbox` package directly instead.",
-    repeat=False,
-)
 
 _set_wandb_auth_mode()
 


### PR DESCRIPTION
Description
-----------

Deprecates `wandb.sandbox` in favor of using the `cwsandbox` package directly.

- Emits a user-visible warning when `wandb.sandbox` is imported.
- Directs users to the native `cwsandbox` package.
- Adds an import-boundary regression test and an unreleased changelog entry.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

- `pytest -q tests/unit_tests/test_sandbox` against the SDK's pinned `cwsandbox==1.6.0`: 80 passed.
- Ruff check and format validation passed.
- Ran a real remote sandbox through `wandb.sandbox` with `WANDB_API_KEY` unset so credentials were loaded from the local `.netrc`. Exec and file read/write operations succeeded, and the sandbox reached `completed` during cleanup.

Live warning output:

```text
wandb: WARNING `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead.
```
