### PR TITLE
fix: collect system metrics as soon as a run starts or resumes

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,3 +21,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
+- System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)

--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -52,6 +52,13 @@ type Resource interface {
 	Probe(ctx context.Context) *spb.EnvironmentRecord
 }
 
+// monitoredResource is a Resource whose mutex is held while it is being
+// sampled, so that a slow sample is skipped rather than overlapped.
+type monitoredResource struct {
+	Resource
+	sync.Mutex
+}
+
 // SystemMonitor is responsible for monitoring system metrics across various resources.
 type SystemMonitor struct {
 	// The context for the system monitor.
@@ -64,8 +71,12 @@ type SystemMonitor struct {
 	// The state of the system monitor: stopped, running, or paused.
 	state atomic.Int32
 
+	// wakeCh is a buffered channel used to force sampling of the monitored resources
+	// at startup and upon monitoring resumption.
+	wakeCh chan struct{}
+
 	// The list of resources to monitor.
-	resources []Resource
+	resources []*monitoredResource
 
 	// extraWork accepts outgoing messages for the run.
 	extraWork runwork.ExtraWork
@@ -125,6 +136,7 @@ func (f *SystemMonitorFactory) New(extraWork runwork.ExtraWork) *SystemMonitor {
 		ctx:              ctx,
 		cancel:           cancel,
 		wg:               sync.WaitGroup{},
+		wakeCh:           make(chan struct{}, 1),
 		runHandle:        f.RunHandle,
 		settings:         f.Settings,
 		logger:           f.Logger,
@@ -157,6 +169,11 @@ func (f *SystemMonitorFactory) New(extraWork runwork.ExtraWork) *SystemMonitor {
 	return sm
 }
 
+// addResource registers a resource to monitor.
+func (sm *SystemMonitor) addResource(r Resource) {
+	sm.resources = append(sm.resources, &monitoredResource{Resource: r})
+}
+
 // initializeResources sets up the resources to be monitored based on the provided settings.
 func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceManager) {
 	pid := sm.settings.GetStatsPid()
@@ -172,11 +189,11 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 			DiskPaths:                   sm.settings.GetStatsDiskPaths(),
 		},
 	); system != nil {
-		sm.resources = append(sm.resources, system)
+		sm.addResource(system)
 	}
 
 	if xpu, err := NewXPU(xpuResourceManager, pid, gpuDeviceIds); xpu != nil {
-		sm.resources = append(sm.resources, xpu)
+		sm.addResource(xpu)
 	} else if err != nil {
 		sm.logger.CaptureError(
 			"monitor",
@@ -190,7 +207,7 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 		samplingInterval,
 		neuronMonitorConfigPath,
 	); trainium != nil {
-		sm.resources = append(sm.resources, trainium)
+		sm.addResource(trainium)
 	}
 
 	// CoreWeave compute environment metadata.
@@ -202,7 +219,7 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 			Settings:      sm.settings,
 		},
 	); cwm != nil {
-		sm.resources = append(sm.resources, cwm)
+		sm.addResource(cwm)
 	} else if err != nil {
 		sm.logger.CaptureError(
 			"monitor",
@@ -221,7 +238,7 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 			Logger:  sm.logger,
 		}
 		if de := NewDCGMExporter(params); de != nil {
-			sm.resources = append(sm.resources, de)
+			sm.addResource(de)
 		}
 	}
 
@@ -231,7 +248,7 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 			filters := sm.settings.GetStatsOpenMetricsFilters()
 			headers := sm.settings.GetStatsOpenMetricsHeaders()
 			if om := NewOpenMetrics(sm.logger, name, url, filters, headers, nil); om != nil {
-				sm.resources = append(sm.resources, om)
+				sm.addResource(om)
 			}
 		}
 	}
@@ -359,14 +376,22 @@ func (sm *SystemMonitor) Start(git *spb.GitRepoRecord) {
 
 	sm.git = git
 
-	// Start collecting metrics.
-	if !sm.settings.IsDisableStats() && !sm.settings.IsDisableMachineInfo() {
-		sm.logger.Debug("monitor: starting")
-		for _, resource := range sm.resources {
-			sm.wg.Go(func() {
-				sm.monitorResource(resource)
-			})
-		}
+	if sm.settings.IsDisableStats() || sm.settings.IsDisableMachineInfo() {
+		return
+	}
+
+	sm.logger.Debug("monitor: starting")
+	sm.wg.Go(func() {
+		sm.loop()
+	})
+	sm.wake()
+}
+
+// wake forces the system monitor to sample resources immediately.
+func (sm *SystemMonitor) wake() {
+	select {
+	case sm.wakeCh <- struct{}{}:
+	default: // a wake is already pending; coalesce
 	}
 }
 
@@ -413,31 +438,12 @@ func (sm *SystemMonitor) Pause() {
 func (sm *SystemMonitor) Resume() {
 	if sm.state.CompareAndSwap(StatePaused, StateRunning) {
 		sm.logger.Debug("monitor: resuming")
+		sm.wake()
 	}
 }
 
-// monitorResource handles the monitoring loop for a single resource.
-//
-// It handles sampling, aggregation, and reporting of metrics
-// and is meant to run in its own goroutine.
-func (sm *SystemMonitor) monitorResource(resource Resource) {
-	if resource == nil {
-		return
-	}
-
-	// recover from panic and log the error
-	defer func() {
-		if err := recover(); err != nil {
-			if resource != nil {
-				sm.logger.CaptureError(
-					"monitor",
-					fmt.Errorf("monitor: panic: %v", err),
-				)
-			}
-		}
-	}()
-
-	// Create a ticker that fires every `samplingInterval` seconds
+// loop handles the resource monitoring loop.
+func (sm *SystemMonitor) loop() {
 	ticker := time.NewTicker(sm.samplingInterval)
 	defer ticker.Stop()
 
@@ -445,12 +451,36 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 		select {
 		case <-sm.ctx.Done():
 			return
+		case <-sm.wakeCh:
+			ticker.Reset(sm.samplingInterval) // realign cadence to "now"
 		case <-ticker.C:
-			if sm.state.Load() != StateRunning {
-				continue // Skip work when not running
-			}
+		}
 
-			metrics, err := resource.Sample()
+		if sm.state.Load() != StateRunning {
+			continue
+		}
+
+		sm.sample()
+	}
+}
+
+// sample collects and publishes stats for all monitored resources.
+//
+// A resource whose previous sample has not returned yet is skipped.
+func (sm *SystemMonitor) sample() {
+	for _, r := range sm.resources {
+		if !r.TryLock() {
+			continue
+		}
+		sm.wg.Go(func() {
+			defer r.Unlock()
+			defer func() {
+				if err := recover(); err != nil {
+					sm.logger.CaptureError("monitor",
+						fmt.Errorf("monitor: panic sampling: %v", err))
+				}
+			}()
+			metrics, err := r.Sample()
 			if err != nil {
 				if ShouldCaptureSamplingError(err) {
 					sm.logger.CaptureError(
@@ -463,10 +493,10 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 			}
 
 			if metrics == nil || len(metrics.Item) == 0 {
-				continue // nothing to do
+				return // nothing to do
 			}
 
-			// Push metrics to the buffer when in-memory buffering is enabled.
+			// Push metrics to the in-memory buffer when enabled.
 			if sm.buffer != nil {
 				sm.buffer.Push(metrics)
 			}
@@ -478,7 +508,7 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 				}
 			}
 
-			// publish metrics
+			// Publish metrics.
 			record := &spb.Record{
 				RecordType: &spb.Record_Stats{
 					Stats: metrics,
@@ -489,9 +519,8 @@ func (sm *SystemMonitor) monitorResource(resource Resource) {
 				sm.ctx.Done(),
 				runwork.NoRequest(runwork.WorkFromRecord(record)),
 			)
-		}
+		})
 	}
-
 }
 
 // ShouldCaptureSamplingError checks if a resource sampling error should be sent to Sentry.
@@ -564,7 +593,7 @@ func (sm *SystemMonitor) Finish() {
 	sm.wg.Wait()
 	// close the resources, if they require any cleanup
 	for _, resource := range sm.resources {
-		if closer, ok := resource.(interface{ Close() }); ok {
+		if closer, ok := resource.Resource.(interface{ Close() }); ok {
 			closer.Close()
 		}
 	}

--- a/core/internal/monitor/monitor_test.go
+++ b/core/internal/monitor/monitor_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/wandb/wandb/core/internal/monitor"
 	"github.com/wandb/wandb/core/internal/observabilitytest"
@@ -19,7 +20,7 @@ func newTestSystemMonitor(t *testing.T) *monitor.SystemMonitor {
 	t.Helper()
 	factory := &monitor.SystemMonitorFactory{
 		Logger:             observabilitytest.NewTestLogger(t),
-		Settings:           settings.From(&spb.Settings{}),
+		Settings:           settings.From(&spb.Settings{XDisableStats: wrapperspb.Bool(true)}),
 		XPUResourceManager: monitor.NewXPUResourceManager(false),
 	}
 	return factory.New(runworktest.New())


### PR DESCRIPTION
Description
-----------

The system monitor took its first sample one full sampling interval (15 seconds by default) after a run started, so runs shorter than that recorded no system metrics and every run's system charts began with a gap. It now samples as soon as monitoring starts and again when it resumes after a notebook cell pause, then continues at the configured interval.

The per-resource sampling goroutines are replaced by one loop that fans out to all resources on each tick. A resource whose previous sample has not returned yet is skipped for that tick, so a slow resource still has at most one sample in flight, as before.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
