### PR TITLE
fix: poll for wandb-xpu readiness every 20 ms instead of 100 ms

### DIFF
--- a/core/internal/monitor/portfile.go
+++ b/core/internal/monitor/portfile.go
@@ -25,19 +25,19 @@ func NewPortfile() *portfile {
 	return &portfile{Path: file.Name()}
 }
 
-// Read reads the target URI from the portfile.
+// Read reads the target URI from the portfile, polling until it appears
+// or ctx is canceled.
 func (p *portfile) Read(ctx context.Context) (string, error) {
 	for {
+		target, err := p.ReadFile()
+		if err == nil {
+			return target, nil
+		}
+
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("timeout reading portfile %s", p.Path)
-		default:
-			target, err := p.ReadFile()
-			if err != nil {
-				time.Sleep(100 * time.Millisecond)
-				continue
-			}
-			return target, nil
+			return "", fmt.Errorf("reading portfile %s: %w", p.Path, ctx.Err())
+		case <-time.After(20 * time.Millisecond):
 		}
 	}
 }


### PR DESCRIPTION
Description
-----------

wandb-core waits for the wandb-xpu sidecar to write its portfile before it can request hardware metrics. The poll checked the file once and then slept 100 ms between attempts, so a sidecar that was ready after 10 ms still cost about 100 ms. The poll now runs every 20 ms and returns as soon as the caller's context is canceled.

Until the next PR in this stack moves the sidecar start off the run startup path, this trims about 80 ms from every run's startup; after that it trims the same from the wait for the first hardware metrics sample.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

go test ./internal/monitor/. The sidecar writes its portfile about 10 ms after spawn on an M-series Mac, measured with a small Go harness.
