### PR TITLE
fix: start the wandb-xpu sidecar in the background instead of during run setup

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -22,3 +22,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
+- `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)

--- a/core/internal/leet/symonsampler.go
+++ b/core/internal/leet/symonsampler.go
@@ -1,6 +1,7 @@
 package leet
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"os"
@@ -63,15 +64,9 @@ func NewSymonSampler(params SymonSamplerParams) *SymonSampler {
 			Pid:              0,
 			TrackProcessTree: false,
 			DiskPaths:        defaultSymonDiskPaths(),
-		}))
-
-	xm := monitor.NewXPUResourceManager(false)
-	xpu, err := monitor.NewXPU(xm, 0, nil)
-	if err != nil {
-		logger.Debug(fmt.Sprintf("symon: xpu monitor unavailable: %v", err))
-	} else if xpu != nil {
-		sampler.resources = append(sampler.resources, xpu)
-	}
+		}),
+		monitor.NewXPU(context.Background(), monitor.NewXPUResourceManager(false), 0, nil),
+	)
 
 	return sampler
 }

--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -192,14 +192,7 @@ func (sm *SystemMonitor) initializeResources(xpuResourceManager *XPUResourceMana
 		sm.addResource(system)
 	}
 
-	if xpu, err := NewXPU(xpuResourceManager, pid, gpuDeviceIds); xpu != nil {
-		sm.addResource(xpu)
-	} else if err != nil {
-		sm.logger.CaptureError(
-			"monitor",
-			fmt.Errorf("monitor: failed to initialize xpu resource: %v", err),
-		)
-	}
+	sm.addResource(NewXPU(sm.ctx, xpuResourceManager, pid, gpuDeviceIds))
 
 	if trainium := NewTrainium(
 		sm.logger,
@@ -527,8 +520,15 @@ func (sm *SystemMonitor) sample() {
 //
 // Use to filter out expected/transient failures. Keep this intentionally small and specific.
 func ShouldCaptureSamplingError(err error) bool {
-	// Transient gRPC connectivity to the wandb-xpu sidecar.
-	if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
+	// The caller went away, e.g. the run finished mid-sample.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	// Transient gRPC connectivity to the wandb-xpu sidecar, or a request
+	// canceled by the caller.
+	if s, ok := status.FromError(err); ok &&
+		(s.Code() == codes.Unavailable || s.Code() == codes.Canceled) {
 		return false
 	}
 

--- a/core/internal/monitor/xpu.go
+++ b/core/internal/monitor/xpu.go
@@ -2,44 +2,68 @@ package monitor
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
+var errXPUClosed = errors.New("monitor: xpu resource is closed")
+
 // XPU monitors GPUs (Nvidia, AMD, Apple) and Google TPUs via the
 // wandb-xpu sidecar binary.
+//
+// The sidecar is started by the first Sample or Probe call, not by NewXPU.
 type XPU struct {
+	ctx             context.Context
 	resourceManager *XPUResourceManager
-	resourceRef     XPUResourceManagerRef
 
 	pid          int32
 	gpuDeviceIds []int32
-	client       spb.SystemMonitorServiceClient
+
+	startOnce        sync.Once
+	startErrReported atomic.Bool
+
+	mu          sync.Mutex
+	closed      bool
+	client      spb.SystemMonitorServiceClient
+	resourceRef XPUResourceManagerRef
+	startErr    error
 }
 
+// NewXPU returns an XPU resource whose sidecar start and requests are
+// canceled together with ctx.
 func NewXPU(
+	ctx context.Context,
 	resourceManager *XPUResourceManager,
 	pid int32,
 	gpuDeviceIds []int32,
-) (*XPU, error) {
-	client, ref, err := resourceManager.Acquire()
-	if err != nil {
-		return nil, err
-	}
+) *XPU {
 	return &XPU{
+		ctx:             ctx,
 		resourceManager: resourceManager,
-		resourceRef:     ref,
 		pid:             pid,
 		gpuDeviceIds:    gpuDeviceIds,
-		client:          client,
-	}, nil
+	}
 }
 
+// Sample collects hardware metrics.
+//
+// A sidecar start failure is returned once; later samples return nothing.
 func (a *XPU) Sample() (*spb.StatsRecord, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultSamplingInterval)
+	ctx, cancel := context.WithTimeout(a.ctx, defaultSamplingInterval)
 	defer cancel()
 
-	stats, err := a.client.GetStats(
+	client, err := a.getClient(ctx)
+	if err != nil {
+		if errors.Is(err, errXPUClosed) || a.startErrReported.Swap(true) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	stats, err := client.GetStats(
 		ctx,
 		&spb.GetStatsRequest{Pid: a.pid, GpuDeviceIds: a.gpuDeviceIds},
 	)
@@ -54,13 +78,61 @@ func (a *XPU) Sample() (*spb.StatsRecord, error) {
 }
 
 func (a *XPU) Probe(ctx context.Context) *spb.EnvironmentRecord {
-	e, err := a.client.GetMetadata(ctx, &spb.GetMetadataRequest{})
+	client, err := a.getClient(ctx)
+	if err != nil {
+		return nil
+	}
+
+	e, err := client.GetMetadata(ctx, &spb.GetMetadataRequest{})
 	if err != nil {
 		return nil
 	}
 	return e.GetRecord().GetEnvironment()
 }
 
+// Close releases the sidecar reference if one was acquired.
+//
+// Close does not wait for a start that is still in progress; getClient
+// hands the reference back when that start completes.
 func (a *XPU) Close() {
-	a.resourceManager.Release(a.resourceRef)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return
+	}
+	a.closed = true
+
+	if a.client != nil {
+		a.resourceManager.Release(a.resourceRef)
+	}
+}
+
+// getClient returns the sidecar client, starting the sidecar on first use.
+//
+// The outcome of the first start, success or failure, is kept for the
+// lifetime of the resource.
+func (a *XPU) getClient(ctx context.Context) (spb.SystemMonitorServiceClient, error) {
+	a.startOnce.Do(func() {
+		client, ref, err := a.resourceManager.Acquire(ctx)
+
+		a.mu.Lock()
+		defer a.mu.Unlock()
+
+		if a.closed {
+			if err == nil {
+				a.resourceManager.Release(ref)
+			}
+			return
+		}
+		a.client, a.resourceRef, a.startErr = client, ref, err
+	})
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return nil, errXPUClosed
+	}
+	return a.client, a.startErr
 }

--- a/core/internal/monitor/xpuresourcemanager.go
+++ b/core/internal/monitor/xpuresourcemanager.go
@@ -19,6 +19,16 @@ import (
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
+const (
+	// collectorStartupTimeout bounds how long Acquire waits for the
+	// sidecar process to write its portfile.
+	collectorStartupTimeout = 5 * time.Second
+
+	// collectorShutdownTimeout bounds how long Release waits for the
+	// sidecar process to exit after asking it to tear down.
+	collectorShutdownTimeout = 5 * time.Second
+)
+
 type XPUResourceManagerRef int
 
 // XPUResourceManager manages the sidecar process that collects
@@ -43,7 +53,9 @@ func NewXPUResourceManager(enableDCGMProfiling bool) *XPUResourceManager {
 	}
 }
 
-func (m *XPUResourceManager) Acquire() (
+// Acquire starts the sidecar if it is not running and registers a
+// reference to it. ctx bounds the start.
+func (m *XPUResourceManager) Acquire(ctx context.Context) (
 	spb.SystemMonitorServiceClient,
 	XPUResourceManagerRef,
 	error,
@@ -52,7 +64,7 @@ func (m *XPUResourceManager) Acquire() (
 	defer m.mu.Unlock()
 
 	if m.collectorConn == nil {
-		if err := m.startCollector(); err != nil {
+		if err := m.startCollector(ctx); err != nil {
 			return nil, 0, err
 		}
 	}
@@ -80,13 +92,25 @@ func (m *XPUResourceManager) Release(ref XPUResourceManagerRef) {
 	m.collectorClient = nil
 
 	go func() {
-		_, _ = client.TearDown(context.Background(), &spb.TearDownRequest{})
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			collectorShutdownTimeout,
+		)
+		defer cancel()
+
+		_, _ = client.TearDown(ctx, &spb.TearDownRequest{})
 		_ = conn.Close()
+
+		context.AfterFunc(ctx, func() { _ = proc.Process.Kill() })
 		_ = proc.Wait()
 	}()
 }
 
-func (m *XPUResourceManager) startCollector() error {
+func (m *XPUResourceManager) startCollector(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	pf := NewPortfile()
 	if pf == nil {
 		return errors.New("monitor: could not create portfile")
@@ -114,12 +138,13 @@ func (m *XPUResourceManager) startCollector() error {
 		return fmt.Errorf("monitor: could not start wandb-xpu binary: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, collectorStartupTimeout)
 	defer cancel()
 	targetURI, err := pf.Read(ctx)
 	if err != nil {
 		_ = cmd.Process.Kill()
-		return fmt.Errorf("monitor: wandb-xpu binary failed to start: %v", err)
+		_ = cmd.Wait()
+		return fmt.Errorf("monitor: wandb-xpu binary failed to start: %w", err)
 	}
 
 	conn, err := grpc.NewClient(
@@ -128,6 +153,7 @@ func (m *XPUResourceManager) startCollector() error {
 	)
 	if err != nil {
 		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
 		return fmt.Errorf("monitor: could not connect to wandb-xpu binary: %v", err)
 	}
 


### PR DESCRIPTION
Description
-----------

Creating a run's system monitor started the wandb-xpu sidecar synchronously and waited up to 5 seconds for it, so every `wandb.init()` paid for the sidecar launch, and a sidecar that failed to start held the run up for the full timeout. The sidecar is now started by the first metrics sample or metadata probe, which run in the background after the run has started.

The start is tied to the monitor's lifetime: finishing the run cancels a start or request that is still in flight instead of waiting for it, and requests canceled that way are logged at debug level rather than reported. A sidecar that fails to start is reported once and the resource stays quiet afterwards. Shutdown is bounded as well: a sidecar that has not exited 5 seconds after its teardown request is killed, and a sidecar that fails to start is reaped instead of being left as a zombie.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
