### PR TITLE
fix: initialize AMD GPU monitoring without running rocm-smi first

### DIFF
--- a/xpu/src/gpu_amd.rs
+++ b/xpu/src/gpu_amd.rs
@@ -250,12 +250,8 @@ impl GpuAmd {
         is_driver_installed() // Check if AMD GPU driver is installed
             .then(|| find_rocm_smi().ok()) // Find rocm-smi binary
             .flatten()
-            .and_then(|path| {
-                let gpu = Self {
-                    rocm_smi_path: path,
-                };
-                // Check if we can read stats using the found rocm-smi
-                (!gpu.get_rocm_smi_stats().unwrap_or_default().is_empty()).then_some(gpu)
+            .map(|path| Self {
+                rocm_smi_path: path,
             })
     }
 
@@ -323,10 +319,15 @@ impl GpuAmd {
             })
             .collect();
 
+        let gpu_type = gpu_amd
+            .first()
+            .map(|gpu| gpu.series.clone())
+            .unwrap_or_default();
+
         Ok(EnvironmentRecord {
             gpu_count: raw_stats.len() as u32,
-            gpu_type: gpu_amd[0].series.clone(),
-            gpu_amd: gpu_amd,
+            gpu_type,
+            gpu_amd,
             ..Default::default()
         })
     }


### PR DESCRIPTION
Description
-----------

The AMD monitor constructor ran `rocm-smi -a --json` to check that the tool works before registering itself. rocm-smi is a Python script that takes 1 to 3 seconds, so every wandb-xpu start on an AMD host paid for it up front. The constructor now only checks that the amdgpu driver is loaded and rocm-smi exists; the first metrics or metadata request does the real query.

Metadata collection no longer indexes into an empty list when rocm-smi reports no GPUs, which panicked.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
