### PR TITLE
fix: publish wandb-xpu readiness before initializing hardware monitors

### DIFF
--- a/xpu/src/main.rs
+++ b/xpu/src/main.rs
@@ -467,6 +467,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
     let shutdown_sender = Arc::new(tokio::sync::Mutex::new(Some(shutdown_sender)));
 
+    // Bind the socket and publish the portfile before initializing hardware
+    // monitors, so wandb-core does not wait on driver initialization.
+    let listener = create_listener(&args).await?;
+
     let system_monitor_service = SystemMonitorServiceImpl::new(
         args.parent_pid,
         args.enable_dcgm_profiling,
@@ -480,8 +484,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         shutdown_receiver.await.ok();
         debug!("Server is shutting down...");
     };
-
-    let listener = create_listener(&args).await?;
 
     match listener {
         ListenerType::Tcp(stream) => {


### PR DESCRIPTION
Description
-----------

wandb-xpu initialized every hardware monitor (NVML, DCGM, rocm-smi, libtpu, Apple IOReport) before binding its socket and writing the portfile that tells wandb-core it is ready. Driver initialization therefore counted against wandb-core's 5-second startup timeout, and a slow or hung driver made the whole sidecar look like it failed to start.

The listener is now created and the portfile written first. Hardware monitors initialize while wandb-core connects, and the first request is served once they are ready.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
