### PR TITLE
chore: stop building wandb inside the ty prek hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       # Type-check with ty on every commit.
       # ty's coverage and rule config live in [tool.ty] in pyproject.toml.
       - id: ty
-        args: ["--isolated"] # --isolated stops `uv check` from writing a uv.lock.
+        args: ["--isolated", "--no-install-project"] # --isolated stops `uv check` from writing a uv.lock.
         stages: [pre-commit]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v22.1.8


### PR DESCRIPTION
Description
-----------
The ty prek hook runs `uv check`, which syncs the project into an environment before type checking. By default that includes installing wandb itself, and installing wandb from source compiles wandb-core and wandb-xpu. A cold run of the hook in a fresh worktree takes about 85 seconds of wall time and more than 10 CPU-minutes, and the build reruns whenever pyproject.toml changes.

ty reads first-party code from the working tree and only needs the dependencies installed to resolve third-party imports. Passing `--no-install-project` skips the wandb build. A cold run now takes about 8 seconds and a warm run under half a second.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Timed `prek run ty --hook-stage pre-commit --all-files` in a fresh worktree with and without the flag.
