### PR TITLE
chore: run ty in ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       # ty's coverage and rule config live in [tool.ty] in pyproject.toml.
       - id: ty
         args: ["--isolated", "--no-install-project"] # --isolated stops `uv check` from writing a uv.lock.
-        stages: [pre-commit]
+        stages: [pre-commit, pre-push]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v22.1.8
     hooks:


### PR DESCRIPTION
Description
-----------
The ty hook only ran locally, at commit time. The pre-commit workflow on GitHub Actions runs the pre-push stage, so no pull request was type-checked with ty; mypy in CircleCI was the only gate, with a different rule set. Adding the pre-push stage to the hook runs ty in that workflow on every pull request and makes mypy redundant.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
