### PR TITLE
chore: keep the CircleCI Go install out of the default GOPATH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ commands:
 
             rm $file_name
 
-            echo 'export PATH="$HOME/sdk/go/bin:$PATH"' >> "$BASH_ENV"
+            echo 'export PATH="$HOME/sdk/go/bin:$HOME/go/bin:$PATH"' >> "$BASH_ENV"
 
             $HOME/sdk/go/bin/go version
             $HOME/sdk/go/bin/go env -w GOCACHE=$HOME/.cache/go-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,21 +249,22 @@ commands:
             esac
 
             curl -L -o $file_name https://go.dev/dl/$file_name
+            mkdir -p $HOME/sdk
             case $suffix in
               zip)
-                unzip -q $file_name -d $HOME
+                unzip -q $file_name -d $HOME/sdk
                 ;;
               tar.gz)
-                tar -C $HOME -xzf $file_name
+                tar -C $HOME/sdk -xzf $file_name
                 ;;
             esac
 
             rm $file_name
 
-            echo 'export PATH="$HOME/go/bin:$PATH"' >> "$BASH_ENV"
+            echo 'export PATH="$HOME/sdk/go/bin:$PATH"' >> "$BASH_ENV"
 
-            $HOME/go/bin/go version
-            $HOME/go/bin/go env -w GOCACHE=$HOME/.cache/go-build
+            $HOME/sdk/go/bin/go version
+            $HOME/sdk/go/bin/go env -w GOCACHE=$HOME/.cache/go-build
           no_output_timeout: 1m
 
   install_rust:


### PR DESCRIPTION
Description
-----------
The `install_go` CircleCI command extracted the Go tarball into `$HOME`, which put GOROOT at `$HOME/go`, the default GOPATH. Every `go` invocation then printed `warning: both GOPATH and GOROOT are the same directory`. The tarball now lands in `$HOME/sdk`, the directory the golang.org/dl wrappers use, and `$HOME/sdk/go/bin` goes on PATH.
