### PR TITLE
fix: measure Apple system metrics over the whole sampling interval

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,3 +27,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
 - `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)
+- Fixed noisy CPU utilization and frequency metrics and overstated power metrics on Apple Silicon Macs. They now cover the whole sampling interval instead of a snapshot of about 10 milliseconds (@dmitryduev in https://github.com/wandb/wandb/pull/12676)

--- a/xpu/src/gpu_apple.rs
+++ b/xpu/src/gpu_apple.rs
@@ -290,79 +290,55 @@ impl Sampler {
         Ok(val)
     }
 
-    pub fn get_metrics(&mut self, duration: u32) -> WithError<Metrics> {
-        let measures: usize = 4;
-        let mut results: Vec<Metrics> = Vec::with_capacity(measures);
+    pub fn get_metrics(&mut self) -> WithError<Metrics> {
+        let (sample, dt) = self.ior.sample_since_last();
+        let mut ecpu_usages = Vec::new();
+        let mut pcpu_usages = Vec::new();
+        let mut rs = Metrics::default();
 
-        // do several samples to smooth metrics
-        // see: https://github.com/vladkens/macmon/issues/10
-        for (sample, dt) in self.ior.get_samples(duration as u64, measures) {
-            let mut ecpu_usages = Vec::new();
-            let mut pcpu_usages = Vec::new();
-            let mut rs = Metrics::default();
-
-            for x in sample {
-                if x.group == "CPU Stats" && x.subgroup == CPU_FREQ_CORE_SUBG {
-                    if x.channel.contains("ECPU") {
-                        ecpu_usages.push(calc_freq(x.item, &self.soc.ecpu_freqs));
-                        continue;
-                    }
-
-                    if x.channel.contains("PCPU") {
-                        pcpu_usages.push(calc_freq(x.item, &self.soc.pcpu_freqs));
-                        continue;
-                    }
+        for x in sample {
+            if x.group == "CPU Stats" && x.subgroup == CPU_FREQ_CORE_SUBG {
+                if x.channel.contains("ECPU") {
+                    ecpu_usages.push(calc_freq(x.item, &self.soc.ecpu_freqs));
+                    continue;
                 }
 
-                if x.group == "GPU Stats" && x.subgroup == GPU_FREQ_DICE_SUBG {
-                    match x.channel.as_str() {
-                        // Guard the `[1..]` slice: indexing an empty table panics.
-                        "GPUPH" if !self.soc.gpu_freqs.is_empty() => {
-                            rs.gpu_usage = calc_freq(x.item, &self.soc.gpu_freqs[1..])
-                        }
-                        _ => {}
-                    }
-                }
-
-                if x.group == "Energy Model" {
-                    match x.channel.as_str() {
-                        "GPU Energy" => rs.gpu_power += cfio_watts(x.item, &x.unit, dt)?,
-                        // "CPU Energy" for Basic / Max, "DIE_{}_CPU Energy" for Ultra
-                        c if c.ends_with("CPU Energy") => {
-                            rs.cpu_power += cfio_watts(x.item, &x.unit, dt)?
-                        }
-                        // same pattern next keys: "ANE" for Basic, "ANE0" for Max, "ANE0_{}" for Ultra
-                        c if c.starts_with("ANE") => {
-                            rs.ane_power += cfio_watts(x.item, &x.unit, dt)?
-                        }
-                        c if c.starts_with("DRAM") => {
-                            rs.ram_power += cfio_watts(x.item, &x.unit, dt)?
-                        }
-                        c if c.starts_with("GPU SRAM") => {
-                            rs.gpu_ram_power += cfio_watts(x.item, &x.unit, dt)?
-                        }
-                        _ => {}
-                    }
+                if x.channel.contains("PCPU") {
+                    pcpu_usages.push(calc_freq(x.item, &self.soc.pcpu_freqs));
+                    continue;
                 }
             }
 
-            rs.ecpu_usage = calc_freq_final(&ecpu_usages, &self.soc.ecpu_freqs);
-            rs.pcpu_usage = calc_freq_final(&pcpu_usages, &self.soc.pcpu_freqs);
-            results.push(rs);
+            if x.group == "GPU Stats" && x.subgroup == GPU_FREQ_DICE_SUBG {
+                match x.channel.as_str() {
+                    // Guard the `[1..]` slice: indexing an empty table panics.
+                    "GPUPH" if !self.soc.gpu_freqs.is_empty() => {
+                        rs.gpu_usage = calc_freq(x.item, &self.soc.gpu_freqs[1..])
+                    }
+                    _ => {}
+                }
+            }
+
+            if x.group == "Energy Model" {
+                match x.channel.as_str() {
+                    "GPU Energy" => rs.gpu_power += cfio_watts(x.item, &x.unit, dt)?,
+                    // "CPU Energy" for Basic / Max, "DIE_{}_CPU Energy" for Ultra
+                    c if c.ends_with("CPU Energy") => {
+                        rs.cpu_power += cfio_watts(x.item, &x.unit, dt)?
+                    }
+                    // same pattern next keys: "ANE" for Basic, "ANE0" for Max, "ANE0_{}" for Ultra
+                    c if c.starts_with("ANE") => rs.ane_power += cfio_watts(x.item, &x.unit, dt)?,
+                    c if c.starts_with("DRAM") => rs.ram_power += cfio_watts(x.item, &x.unit, dt)?,
+                    c if c.starts_with("GPU SRAM") => {
+                        rs.gpu_ram_power += cfio_watts(x.item, &x.unit, dt)?
+                    }
+                    _ => {}
+                }
+            }
         }
 
-        let mut rs = Metrics::default();
-        rs.ecpu_usage.0 = zero_div(results.iter().map(|x| x.ecpu_usage.0).sum(), measures as _);
-        rs.ecpu_usage.1 = zero_div(results.iter().map(|x| x.ecpu_usage.1).sum(), measures as _);
-        rs.pcpu_usage.0 = zero_div(results.iter().map(|x| x.pcpu_usage.0).sum(), measures as _);
-        rs.pcpu_usage.1 = zero_div(results.iter().map(|x| x.pcpu_usage.1).sum(), measures as _);
-        rs.gpu_usage.0 = zero_div(results.iter().map(|x| x.gpu_usage.0).sum(), measures as _);
-        rs.gpu_usage.1 = zero_div(results.iter().map(|x| x.gpu_usage.1).sum(), measures as _);
-        rs.cpu_power = zero_div(results.iter().map(|x| x.cpu_power).sum(), measures as _);
-        rs.gpu_power = zero_div(results.iter().map(|x| x.gpu_power).sum(), measures as _);
-        rs.ane_power = zero_div(results.iter().map(|x| x.ane_power).sum(), measures as _);
-        rs.ram_power = zero_div(results.iter().map(|x| x.ram_power).sum(), measures as _);
-        rs.gpu_ram_power = zero_div(results.iter().map(|x| x.gpu_ram_power).sum(), measures as _);
+        rs.ecpu_usage = calc_freq_final(&ecpu_usages, &self.soc.ecpu_freqs);
+        rs.pcpu_usage = calc_freq_final(&pcpu_usages, &self.soc.pcpu_freqs);
         rs.all_power = rs.cpu_power + rs.gpu_power + rs.ane_power;
 
         rs.memory = self.get_mem()?;
@@ -695,7 +671,7 @@ fn sampler_thread(receiver: Receiver<SamplerCommand>) {
                 // Catch panics from a single sample so one bad reading can't
                 // permanently kill the sampler thread (and with it all metrics).
                 let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    sampler.get_metrics(1)
+                    sampler.get_metrics()
                 })) {
                     Ok(result) => result.map_err(|e| SamplerError(e.to_string())),
                     Err(_) => Err(SamplerError("panic while sampling Apple metrics".into())),

--- a/xpu/src/gpu_apple_sources.rs
+++ b/xpu/src/gpu_apple_sources.rs
@@ -32,6 +32,7 @@ use std::{
     mem::{MaybeUninit, size_of},
     os::raw::c_void,
     ptr::null,
+    time::{Duration, Instant},
 };
 
 use core_foundation::{
@@ -209,13 +210,13 @@ pub fn cfio_get_residencies(item: CFDictionaryRef) -> Vec<(String, i64)> {
     res
 }
 
-pub fn cfio_watts(item: CFDictionaryRef, unit: &String, duration: u64) -> WithError<f32> {
-    let val = unsafe { IOReportSimpleGetIntegerValue(item, 0) } as f32;
-    let val = val / (duration as f32 / 1000.0);
-    match unit.as_str() {
-        "mJ" => Ok(val / 1e3f32),
-        "uJ" => Ok(val / 1e6f32),
-        "nJ" => Ok(val / 1e9f32),
+pub fn cfio_watts(item: CFDictionaryRef, unit: &str, duration: Duration) -> WithError<f32> {
+    let val = unsafe { IOReportSimpleGetIntegerValue(item, 0) } as f64;
+    let val = val / duration.as_secs_f64();
+    match unit {
+        "mJ" => Ok((val / 1e3) as f32),
+        "uJ" => Ok((val / 1e6) as f32),
+        "nJ" => Ok((val / 1e9) as f32),
         _ => Err(format!("Invalid energy unit: {}", unit).into()),
     }
 }
@@ -635,65 +636,31 @@ fn cfio_get_subs(chan: CFMutableDictionaryRef) -> WithError<IOReportSubscription
 pub struct IOReport {
     subs: IOReportSubscriptionRef,
     chan: CFMutableDictionaryRef,
-    prev: Option<(CFDictionaryRef, std::time::Instant)>,
+    prev: (CFDictionaryRef, Instant),
 }
 
 impl IOReport {
     pub fn new(channels: Vec<(&str, Option<&str>)>) -> WithError<Self> {
         let chan = cfio_get_chan(channels)?;
         let subs = cfio_get_subs(chan)?;
-        Ok(Self {
-            subs,
-            chan,
-            prev: None,
-        })
+        let prev = unsafe { (IOReportCreateSamples(subs, chan, null()), Instant::now()) };
+        Ok(Self { subs, chan, prev })
     }
 
-    pub fn get_sample(&self, duration: u64) -> IOReportIterator {
-        unsafe {
-            let sample1 = IOReportCreateSamples(self.subs, self.chan, null());
-            std::thread::sleep(std::time::Duration::from_millis(duration));
-            let sample2 = IOReportCreateSamples(self.subs, self.chan, null());
-
-            let sample3 = IOReportCreateSamplesDelta(sample1, sample2, null());
-            CFRelease(sample1 as _);
-            CFRelease(sample2 as _);
-            IOReportIterator::new(sample3)
-        }
-    }
-
-    fn raw_sample(&self) -> (CFDictionaryRef, std::time::Instant) {
-        (
-            unsafe { IOReportCreateSamples(self.subs, self.chan, null()) },
-            std::time::Instant::now(),
-        )
-    }
-
-    pub fn get_samples(&mut self, duration: u64, count: usize) -> Vec<(IOReportIterator, u64)> {
-        let count = count.clamp(1, 32);
-        let mut samples: Vec<(IOReportIterator, u64)> = Vec::with_capacity(count);
-        let step_msec = duration / count as u64;
-
-        let mut prev = match self.prev {
-            Some(x) => x,
-            None => self.raw_sample(),
+    /// Returns the counter deltas since the previous call (or since construction)
+    /// together with the elapsed wall time.
+    pub fn sample_since_last(&mut self) -> (IOReportIterator, Duration) {
+        let next = unsafe {
+            (
+                IOReportCreateSamples(self.subs, self.chan, null()),
+                Instant::now(),
+            )
         };
-
-        for _ in 0..count {
-            std::thread::sleep(std::time::Duration::from_millis(step_msec));
-
-            let next = self.raw_sample();
-            let diff = unsafe { IOReportCreateSamplesDelta(prev.0, next.0, null()) };
-            unsafe { CFRelease(prev.0 as _) };
-
-            let elapsed = next.1.duration_since(prev.1).as_millis() as u64;
-            prev = next;
-
-            samples.push((IOReportIterator::new(diff), elapsed.max(1)));
-        }
-
-        self.prev = Some(prev);
-        samples
+        let diff = unsafe { IOReportCreateSamplesDelta(self.prev.0, next.0, null()) };
+        unsafe { CFRelease(self.prev.0 as _) };
+        let elapsed = next.1.duration_since(self.prev.1);
+        self.prev = next;
+        (IOReportIterator::new(diff), elapsed)
     }
 }
 
@@ -702,9 +669,7 @@ impl Drop for IOReport {
         unsafe {
             CFRelease(self.chan as _);
             CFRelease(self.subs as _);
-            if self.prev.is_some() {
-                CFRelease(self.prev.unwrap().0 as _);
-            }
+            CFRelease(self.prev.0 as _);
         }
     }
 }


### PR DESCRIPTION
Description
-----------

The Apple sampler split every request into four IOReport sub-samples and averaged them. The first sub-sample covered the time since the previous request, but the other three each lasted about 3 ms because the request asked for a 1 ms window. CPU utilization and frequency were therefore weighted three to one toward a 10 ms snapshot, and power came out about 25% too high because a 3.9 ms sub-sample was truncated to 3 ms before dividing.

The sampler now takes one IOReport delta between consecutive requests and converts energy counters with the exact elapsed time. The baseline is taken when the sampler starts, so the first request already covers a real interval.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Under a steady load on an M4 Max the old average reported 25 to 27 W of CPU power against 21 W for a single delta over a full 2 s interval.
