### PR TITLE
fix: report the memory size of Apple Silicon Macs with 256 GB or more

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -28,3 +28,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)
 - `wandb.init()` no longer waits for the GPU and TPU metrics collector to start (@dmitryduev in https://github.com/wandb/wandb/pull/12651)
 - Fixed noisy CPU utilization and frequency metrics and overstated power metrics on Apple Silicon Macs. They now cover the whole sampling interval instead of a snapshot of about 10 milliseconds (@dmitryduev in https://github.com/wandb/wandb/pull/12676)
+- Fixed the memory size of Apple Silicon Macs with 256 GB or more of RAM being reported as 0 GB (@dmitryduev in https://github.com/wandb/wandb/pull/12677)

--- a/xpu/src/gpu_apple_sources.rs
+++ b/xpu/src/gpu_apple_sources.rs
@@ -426,7 +426,7 @@ pub fn libc_swap() -> WithError<(u64, u64)> {
 pub struct SocInfo {
     pub mac_model: String,
     pub chip_name: String,
-    pub memory_gb: u8,
+    pub memory_gb: u16,
     pub ecpu_cores: u8,
     pub pcpu_cores: u8,
     pub ecpu_freqs: Vec<u32>,
@@ -541,7 +541,7 @@ pub fn get_soc_info() -> WithError<SocInfo> {
     // Assign parsed values to info
     info.chip_name = chip_name;
     info.mac_model = mac_model;
-    info.memory_gb = mem_gb as u8;
+    info.memory_gb = mem_gb as u16;
     info.gpu_cores = gpu_cores as u8;
     info.ecpu_cores = ecpu_cores as u8;
     info.pcpu_cores = pcpu_cores as u8;


### PR DESCRIPTION
Description
-----------

The Apple hardware description stored the memory size in an 8-bit integer, so Macs with 256 GB or more of unified memory reported 0 GB. The field is now 16 bits wide.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
