### PR TITLE
fix: skip reading every SMC key value when the Apple sampler starts

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -21,6 +21,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Changed
 
 - LEET is faster on long runs: a 50k-step run loads in about half the time, frames render about 30 percent faster, and live chart updates no longer re-render every point (@dmitryduev in https://github.com/wandb/wandb/pull/12535, https://github.com/wandb/wandb/pull/12536, https://github.com/wandb/wandb/pull/12537, https://github.com/wandb/wandb/pull/12538, https://github.com/wandb/wandb/pull/12539)
+- System metrics from Apple Silicon Macs become available about 1.5 seconds sooner after monitoring starts (@dmitryduev in https://github.com/wandb/wandb/pull/12679)
 
 ### Deprecated
 

--- a/xpu/src/gpu_apple.rs
+++ b/xpu/src/gpu_apple.rs
@@ -142,36 +142,31 @@ fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>)> {
     let mut cpu_sensors = Vec::new();
     let mut gpu_sensors = Vec::new();
 
-    let names = smc.read_all_keys().unwrap_or(vec![]);
-    for name in &names {
-        let key = match smc.read_key_info(name) {
-            Ok(key) => key,
-            Err(_) => continue,
-        };
-
-        if key.data_size != 4 || key.data_type != FLOAT_TYPE {
+    // Unfortunately, it is not known which keys are responsible for what.
+    // Basically in the code that can be found publicly "Tp" is used for CPU and "Tg" for GPU.
+    // "Tp" – performance cores, "Te" – efficiency cores
+    for name in smc.read_all_keys().unwrap_or_default() {
+        let is_cpu = name.starts_with("Tp") || name.starts_with("Te");
+        let is_gpu = name.starts_with("Tg");
+        if !is_cpu && !is_gpu {
             continue;
         }
 
-        let _ = match smc.read_val(name) {
-            Ok(val) => val,
+        let key = match smc.read_key_info(&name) {
+            Ok(key) => key,
             Err(_) => continue,
         };
+        if key.data_size != 4 || key.data_type != FLOAT_TYPE || smc.read_val(&name).is_err() {
+            continue;
+        }
 
-        // Unfortunately, it is not known which keys are responsible for what.
-        // Basically in the code that can be found publicly "Tp" is used for CPU and "Tg" for GPU.
-
-        match name {
-            // "Tp" – performance cores, "Te" – efficiency cores
-            name if name.starts_with("Tp") || name.starts_with("Te") => {
-                cpu_sensors.push(name.clone())
-            }
-            name if name.starts_with("Tg") => gpu_sensors.push(name.clone()),
-            _ => (),
+        if is_cpu {
+            cpu_sensors.push(name);
+        } else {
+            gpu_sensors.push(name);
         }
     }
 
-    // println!("{} {}", cpu_sensors.len(), gpu_sensors.len());
     Ok((smc, cpu_sensors, gpu_sensors))
 }
 

--- a/xpu/src/gpu_apple_sources.rs
+++ b/xpu/src/gpu_apple_sources.rs
@@ -974,21 +974,8 @@ impl SMC {
 
     pub fn read_all_keys(&mut self) -> WithError<Vec<String>> {
         let val = self.read_val("#KEY")?;
-        let val = u32::from_be_bytes(val.data[0..4].try_into().unwrap());
-
-        let mut keys = Vec::new();
-        for i in 0..val {
-            let key = self.key_by_index(i)?;
-            let val = self.read_val(&key);
-            if val.is_err() {
-                continue;
-            }
-
-            let val = val.unwrap();
-            keys.push(val.name);
-        }
-
-        Ok(keys)
+        let count = u32::from_be_bytes(val.data[0..4].try_into().unwrap());
+        (0..count).map(|i| self.key_by_index(i)).collect()
     }
 }
 


### PR DESCRIPTION
Description
-----------

Starting the Apple sampler took about 2.5 seconds on an M4 Max. 1.8 seconds of that went into reading the value of each of the 3386 SMC keys, twice, to find the roughly 150 temperature sensors among them.

Enumeration now only fetches key names, and the type and value are read for the keys with a temperature prefix. Sampler startup drops to about 1.1 seconds.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
