### PR TITLE
fix: infer the unit of Apple frequency tables from their values

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,3 +36,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 - Fixed the memory size of Apple Silicon Macs with 256 GB or more of RAM being reported as 0 GB (@dmitryduev in https://github.com/wandb/wandb/pull/12677)
 - Fixed CPU and GPU temperature metrics on Apple Silicon Macs being skewed by invalid sensor readings (@dmitryduev in https://github.com/wandb/wandb/pull/12678)
 - Fixed the `ecpu_cores` count of Apple M5 Pro and M5 Max Macs being reported as 0 (@dmitryduev in https://github.com/wandb/wandb/pull/12680)
+- Fixed CPU frequency metrics on the MacBook Neo being reported about 1000 times too high (@dmitryduev in https://github.com/wandb/wandb/pull/12681)

--- a/xpu/src/gpu_apple_sources.rs
+++ b/xpu/src/gpu_apple_sources.rs
@@ -508,7 +508,14 @@ fn cfnum_get_i64(dict: CFDictionaryRef, key: &str) -> Option<i64> {
     unsafe { CFNumberGetValue(obj, kCFNumberSInt64Type, ptr) }.then_some(val)
 }
 
-fn to_mhz(vals: Vec<u32>, scale: u32) -> Vec<u32> {
+/// Converts a DVFS frequency table to MHz. Chips before M4 and the A series store
+/// frequencies in Hz, M4 and later in kHz.
+fn to_mhz(vals: Vec<u32>) -> Vec<u32> {
+    let scale = match vals.iter().max() {
+        Some(&max) if max >= 100_000_000 => 1_000_000,
+        Some(&max) if max >= 100_000 => 1_000,
+        _ => 1,
+    };
     vals.iter().map(|x| *x / scale).collect()
 }
 
@@ -538,13 +545,6 @@ pub fn get_soc_info() -> WithError<SocInfo> {
         unsafe { CFRelease(item as _) }
     }
 
-    // Determine scaling based on chip type
-    let before_m4 = info.chip_name.contains("M1")
-        || info.chip_name.contains("M2")
-        || info.chip_name.contains("M3");
-    let cpu_scale: u32 = if before_m4 { 1000 * 1000 } else { 1000 }; // MHz before M4, KHz after
-    let gpu_scale: u32 = 1000 * 1000; // MHz
-
     // CPU frequencies
     for (entry, name) in IOServiceIterator::new("AppleARMIODevice")? {
         if name == "pmgr" {
@@ -552,9 +552,9 @@ pub fn get_soc_info() -> WithError<SocInfo> {
             // 1) `strings /usr/bin/powermetrics | grep voltage-states` uses non-sram keys
             //    but their values are zero, so sram used here; it looks valid.
             // 2) sudo powermetrics --samplers cpu_power -i 1000 -n 1 | grep "active residency" | grep "Cluster"
-            info.ecpu_freqs = to_mhz(get_dvfs_mhz(item, "voltage-states1-sram").1, cpu_scale);
-            info.pcpu_freqs = to_mhz(get_dvfs_mhz(item, "voltage-states5-sram").1, cpu_scale);
-            info.gpu_freqs = to_mhz(get_dvfs_mhz(item, "voltage-states9").1, gpu_scale);
+            info.ecpu_freqs = to_mhz(get_dvfs_mhz(item, "voltage-states1-sram").1);
+            info.pcpu_freqs = to_mhz(get_dvfs_mhz(item, "voltage-states5-sram").1);
+            info.gpu_freqs = to_mhz(get_dvfs_mhz(item, "voltage-states9").1);
             unsafe { CFRelease(item as _) }
         }
     }


### PR DESCRIPTION
Description
-----------

Apple stores the CPU and GPU frequency tables in Hz on chips before M4 and on A-series chips, and in kHz from M4 on. The sampler picked the divisor from a list of chip names, so the A18 Pro in the MacBook Neo fell through to the kHz case and reported CPU frequencies about 1000 times too high (vladkens/macmon#57).

The divisor is now chosen from the largest value in the table, which works for every chip without a per-chip list.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
