### PR TITLE
fix: add server probe for python telemetry side

### DIFF
--- a/tests/unit_tests/test_lib/test_telemetry.py
+++ b/tests/unit_tests/test_lib/test_telemetry.py
@@ -4,6 +4,7 @@ import threading
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from wandb import env
 from wandb.analytics.opentelemetry import opentelemetry_proxy
 from wandb.analytics.opentelemetry.opentelemetry_proxy import (
@@ -55,6 +56,50 @@ def test_disabled_telemetry_does_not_publish(monkeypatch):
 
     recorder.increment_counter_and_log_event("test")
     recorder.exception(Exception("test"))
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_none"),
+    [
+        (requests.codes.not_found, True),
+        (requests.codes.method_not_allowed, True),
+        (requests.codes.unauthorized, False),
+    ],
+)
+def test_server_supports_open_telemetry_proxy(
+    monkeypatch,
+    status_code: int,
+    expected_none: bool,
+):
+    post = MagicMock(return_value=MagicMock(status_code=status_code))
+    monkeypatch.setattr(opentelemetry_proxy.requests, "post", post)
+    monkeypatch.setattr(
+        OpenTelemetryProxy,
+        "_build_meter_provider",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        OpenTelemetryProxy,
+        "_build_logger_provider",
+        MagicMock(),
+    )
+
+    settings = Settings(base_url="http://localhost:8765")
+    proxy = OpenTelemetryProxy.from_settings(settings)
+
+    assert (proxy is None) is expected_none
+
+
+def test_server_supports_open_telemetry_proxy_timeout(monkeypatch):
+    monkeypatch.setattr(
+        opentelemetry_proxy.requests,
+        "post",
+        MagicMock(side_effect=requests.Timeout),
+    )
+
+    proxy = OpenTelemetryProxy.from_settings(Settings(base_url="http://localhost:8765"))
+
+    assert proxy is None
 
 
 def test_telemetry_without_proxy_does_not_publish():

--- a/wandb/analytics/opentelemetry/opentelemetry_proxy.py
+++ b/wandb/analytics/opentelemetry/opentelemetry_proxy.py
@@ -37,6 +37,11 @@ _DEFAULT_EXPORT_TIMEOUT_MILLIS = 5_000
 # httpClientTimeout mirror: per-request timeout for HTTP calls to the backend.
 _HTTP_CLIENT_TIMEOUT_SECONDS = 10
 
+# probeTimeout is the timeout for the server capability probe. The probe runs
+# during SDK initialization, so it must be shorter than the initialization
+# timeout rather than consuming the whole request budget.
+_PROBE_TIMEOUT_SECONDS = 2
+
 # Backend OpenTelemetry proxy ingestion paths, appended to the base URL.
 _METRICS_PATH = "/sdk/otel/v1/metrics"
 _LOGS_PATH = "/sdk/otel/v1/logs"
@@ -46,6 +51,26 @@ _DEFAULT_SERVICE_NAME = "sdk-wandb"
 # _disabled gates OpenTelemetryProxy for the whole process. Once set, no new
 # proxy is created and telemetry becomes a no-op.
 _disabled = threading.Event()
+
+
+def _check_server_supports_open_telemetry_proxy(settings: Settings) -> bool:
+    """Return whether the server exposes the OpenTelemetry proxy endpoint."""
+    try:
+        response = requests.post(
+            settings.base_url.rstrip("/") + _METRICS_PATH,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException:
+        return False
+    status_code = response.status_code
+    response.close()
+
+    # Depending on the server configuration, an unsupported endpoint may
+    # respond with either 404 Not Found or 405 Method Not Allowed.
+    return status_code not in (
+        requests.codes.not_found,
+        requests.codes.method_not_allowed,
+    )
 
 
 def disable() -> None:
@@ -382,7 +407,11 @@ class OpenTelemetryProxy:
         pid: int | None = None,
     ) -> OpenTelemetryProxy | None:
         """Create a proxy from settings, or None if telemetry is disabled."""
-        if _disabled.is_set() or settings._offline:
+        if (
+            _disabled.is_set()
+            or settings._offline
+            or not _check_server_supports_open_telemetry_proxy(settings)
+        ):
             return None
         return cls(settings=settings, pid=pid)
 


### PR DESCRIPTION
Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

What does the PR do? Include a concise description of the PR contents.

wandb-core has a server probe check for SDK telemetry, that is used to disable recording telemetry if the W&B server does not support receiving telemetry.
This PR adds the same check on the python side.


<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
