### PR TITLE
feat(sandbox): deprecate W&B sandbox CLI

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 - `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead.
 - `wandb.api` and `wandb.ensure_configured()` are deprecated and will be removed in a future release. `wandb.api` now only provides `api_key`, `default_entity` and `viewer()`; use `wandb.Api()` instead of the last two (@dmitryduev in https://github.com/wandb/wandb/pull/12715)
+- `wandb beta sandbox` is deprecated and will be removed in a future release. Sandbox functionality is now maintained in the `cwsandbox` package.
 
 ### Fixed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,9 +34,9 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Deprecated
 
-- `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead.
+- `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead. (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12647)
 - `wandb.api` and `wandb.ensure_configured()` are deprecated and will be removed in a future release. `wandb.api` now only provides `api_key`, `default_entity` and `viewer()`; use `wandb.Api()` instead of the last two (@dmitryduev in https://github.com/wandb/wandb/pull/12715)
-- `wandb beta sandbox` is deprecated and will be removed in a future release. Sandbox functionality is now maintained in the `cwsandbox` package.
+- `wandb beta sandbox` is deprecated and will be removed in a future release. Sandbox functionality is now maintained in the `cwsandbox` package. (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12689)
 
 ### Fixed
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -34,9 +34,9 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Deprecated
 
-- `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead. (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12647)
+- `wandb.sandbox` is deprecated and will be removed in a future release. Use the `cwsandbox` package directly instead (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12647)
 - `wandb.api` and `wandb.ensure_configured()` are deprecated and will be removed in a future release. `wandb.api` now only provides `api_key`, `default_entity` and `viewer()`; use `wandb.Api()` instead of the last two (@dmitryduev in https://github.com/wandb/wandb/pull/12715)
-- `wandb beta sandbox` is deprecated and will be removed in a future release. Sandbox functionality is now maintained in the `cwsandbox` package. (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12689)
+- `wandb beta sandbox` is deprecated and will be removed in a future release. Sandbox functionality is now maintained in the `cwsandbox` package (@nicholaspun-wandb in https://github.com/wandb/wandb/pull/12689)
 
 ### Fixed
 

--- a/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
+++ b/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
@@ -62,7 +62,12 @@ def test_sandbox_help_text(
 
     assert result.exit_code == 0, result.output
     assert "wandb beta sandbox" in result.output
-    assert "cwsandbox" not in result.output
+    normalized_output = " ".join(result.output.split())
+    assert "deprecated" in normalized_output.lower()
+    assert (
+        "It will be removed in a future release. Sandbox functionality is now "
+        "maintained in the `cwsandbox` package." in normalized_output
+    )
     for expected in expected_strings:
         assert expected in result.output
 

--- a/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
+++ b/tests/unit_tests/test_sandbox/test_cli_beta_sandbox.py
@@ -1,75 +1,9 @@
 from __future__ import annotations
 
 import cwsandbox.cli.list as cwsandbox_list
-import pytest
 from click.testing import CliRunner
 from wandb.cli import cli
 from wandb.sandbox import CWSandboxError
-
-
-@pytest.mark.parametrize(
-    ("argv", "expected_strings"),
-    [
-        (
-            ["sandbox", "--help"],
-            ["ls", "sh", "exec", "logs", "--entity", "wandb beta sandbox ls"],
-        ),
-        (
-            ["sandbox", "ls", "--help"],
-            [
-                "--entity",
-                "--status",
-                "--all",
-                "--tag",
-                "--output",
-                "wandb beta sandbox ls",
-            ],
-        ),
-        (
-            ["sandbox", "sh", "--help"],
-            ["--entity", "SANDBOX_ID", "--cmd", "wandb beta sandbox sh"],
-        ),
-        (
-            ["sandbox", "exec", "--help"],
-            [
-                "--entity",
-                "SANDBOX_ID",
-                "COMMAND_ARGS...",
-                "--cwd",
-                "--timeout",
-                "wandb beta sandbox exec",
-            ],
-        ),
-        (
-            ["sandbox", "logs", "--help"],
-            [
-                "--entity",
-                "SANDBOX_ID",
-                "--follow",
-                "--tail",
-                "--since",
-                "--timestamps",
-                "wandb beta sandbox logs",
-            ],
-        ),
-    ],
-)
-def test_sandbox_help_text(
-    argv: list[str],
-    expected_strings: list[str],
-) -> None:
-    result = CliRunner().invoke(cli.beta, argv)
-
-    assert result.exit_code == 0, result.output
-    assert "wandb beta sandbox" in result.output
-    normalized_output = " ".join(result.output.split())
-    assert "deprecated" in normalized_output.lower()
-    assert (
-        "It will be removed in a future release. Sandbox functionality is now "
-        "maintained in the `cwsandbox` package." in normalized_output
-    )
-    for expected in expected_strings:
-        assert expected in result.output
 
 
 def test_sandbox_command_converts_cwsandbox_error(monkeypatch) -> None:

--- a/wandb/cli/beta_sandbox.py
+++ b/wandb/cli/beta_sandbox.py
@@ -8,6 +8,10 @@ from cwsandbox import CWSandboxError, SandboxStatus
 from cwsandbox.cli.shell import _validate_cmd as _cwsandbox_validate_cmd
 
 _STATUS_CHOICES = [s.value for s in SandboxStatus if s != SandboxStatus.UNSPECIFIED]
+_DEPRECATION_MESSAGE = (
+    "It will be removed in a future release. "
+    "Sandbox functionality is now maintained in the `cwsandbox` package."
+)
 
 
 class SandboxCommand(click.Command):
@@ -42,7 +46,7 @@ class SandboxGroup(click.Group):
     command_class = SandboxCommand
 
 
-@click.group(cls=SandboxGroup)
+@click.group(cls=SandboxGroup, deprecated=_DEPRECATION_MESSAGE)
 def sandbox() -> None:
     """Manage W&B sandboxes.
 


### PR DESCRIPTION
Description
-----------

Deprecates the `wandb beta sandbox` CLI group ahead of its eventual removal.

- Marks the Click command group as deprecated so the notice appears in help and when invoked.
- Keeps the existing CLI behavior intact.
- Notes that Sandbox functionality is maintained in the `cwsandbox` package without prescribing the replacement auth-selection UX yet.
- Adds an unreleased changelog entry.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

- Repository pre-push hooks passed, including Ruff check/format and ty.
- Tests were not run for this warning-only change.