### PR TITLE
chore: ignore the uv.lock written by the ty prek hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ build/
 # Conventional location for Python virtual environments.
 .venv/*
 
+# Written by uv when the ty prek hook runs.
+uv.lock
+
 # Configuration files.
 .python-version
 .idea/


### PR DESCRIPTION
Description
-----------
Since the bump to ty 0.0.78 in #12693, every run of the ty prek hook leaves a uv.lock in the working tree. ty no longer passes `--frozen` when it asks uv for workspace metadata (https://github.com/astral-sh/ruff/pull/28224), and `uv check --isolated` does not forward its isolation to that subprocess, so uv resolves the project and writes the lockfile. The repository does not use a lockfile, so ignore it until uv forwards the policy.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
