### PR TITLE
chore: delete remaining upload logic in wandb_storage_policy.py

### DIFF
--- a/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
+++ b/tests/unit_tests/test_artifacts/test_wandb_artifacts.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import queue
-import shutil
 import unittest.mock as mock
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -12,7 +11,7 @@ import requests
 import responses
 from hypothesis import given
 from hypothesis.strategies import from_regex, text
-from pytest import CaptureFixture, MonkeyPatch, fail, mark, raises
+from pytest import fail, mark, raises
 from wandb.sdk.artifacts._generated.enums import ArtifactDigestAlgorithm
 from wandb.sdk.artifacts._validators import NAME_MAXLEN
 from wandb.sdk.artifacts.artifact import Artifact
@@ -26,7 +25,6 @@ from wandb.sdk.artifacts.storage_policies._multipart import (
     multipart_download,
     should_multipart_download,
 )
-from wandb.sdk.artifacts.storage_policies.wandb_storage_policy import WandbStoragePolicy
 from wandb.sdk.lib.hashutil import _md5, _xxh128, md5_string, xxh128_string
 
 
@@ -128,29 +126,6 @@ def test_unlogged_artifact_other_method_errors():
 
     with raises(ArtifactNotLoggedError, match="Artifact.get"):
         art["obj_name"]
-
-
-def test_cache_write_failure_is_ignored(
-    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
-):
-    def bad_write(*args, **kwargs):
-        raise FileNotFoundError("unable to copy from source file")
-
-    monkeypatch.setattr(shutil, "copyfileobj", bad_write)
-    policy = WandbStoragePolicy()
-    path = Path("foo.txt")
-    path.write_text("hello")
-
-    entry = ArtifactManifestEntry(
-        path=path,
-        digest="NWQ0MTQwMmFiYzRiMmE3NmI5NzE5ZDkxMTAxN2M1OTI=",
-        local_path=path,
-    )
-
-    policy._write_cache(entry)
-
-    captured = capsys.readouterr()
-    assert "Failed to cache" in captured.err
 
 
 def test_artifact_manifest_length():

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -4,35 +4,26 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
-import os
-import shutil
-from collections import deque
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import requests
 from typing_extensions import assert_never
 
-from wandb.errors.term import termwarn
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.artifacts._models.storage import StoragePolicyConfig
 from wandb.sdk.artifacts.artifact_file_cache import (
     ArtifactFileCache,
     get_artifact_file_cache,
 )
-from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.artifacts.storage_handlers.multi_handler import MultiHandler
 from wandb.sdk.artifacts.storage_handlers.tracking_handler import TrackingHandler
 from wandb.sdk.artifacts.storage_layout import StorageLayout
-from wandb.sdk.artifacts.storage_policies._multipart import (
-    KiB,
-    multipart_download,
-    scan_chunks,
-)
+from wandb.sdk.artifacts.storage_policies._multipart import KiB, multipart_download
 from wandb.sdk.artifacts.storage_policies.register import WANDB_STORAGE_POLICY
 from wandb.sdk.artifacts.storage_policy import StoragePolicy
 from wandb.sdk.internal.internal_api import Api as InternalApi
-from wandb.sdk.lib.hashutil import b64_to_hex_id, hex_to_b64_id
+from wandb.sdk.lib.hashutil import b64_to_hex_id
 from wandb.sdk.lib.paths import FilePathStr, URIStr
 
 from ._factories import make_http_session, make_storage_handlers
@@ -40,7 +31,6 @@ from ._factories import make_http_session, make_storage_handlers
 if TYPE_CHECKING:
     from wandb.sdk.artifacts.artifact import Artifact
     from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
-    from wandb.sdk.internal import progress
 
 logger = logging.getLogger(__name__)
 
@@ -243,65 +233,3 @@ class WandbStoragePolicy(StoragePolicy):
             return f"{base_url}/artifactsV2/{region}/{quote(entity)}/{quote(project)}/{quote(collection)}/{quote(birth_artifact_id)}/{hexhash}/{entry.path.name}"
 
         assert_never(layout)
-
-    def s3_multipart_file_upload(
-        self,
-        file_path: str,
-        chunk_size: int,
-        hex_digests: dict[int, str],
-        multipart_urls: dict[int, str],
-        extra_headers: dict[str, str],
-    ) -> list[dict[str, Any]]:
-        etags: deque[dict[str, Any]] = deque()
-        file_chunks = scan_chunks(file_path, chunk_size)
-        for num, data in enumerate(file_chunks, start=1):
-            rsp = self._api.upload_multipart_file_chunk_retry(
-                multipart_urls[num],
-                data,
-                extra_headers={
-                    "content-md5": hex_to_b64_id(hex_digests[num]),
-                    "content-length": str(len(data)),
-                    "content-type": extra_headers.get("Content-Type") or "",
-                },
-            )
-            assert rsp is not None
-            etags.append({"partNumber": num, "hexMD5": rsp.headers["ETag"]})
-        return list(etags)
-
-    def default_file_upload(
-        self,
-        upload_url: str,
-        file_path: str,
-        extra_headers: dict[str, Any],
-        progress_callback: progress.ProgressFn | None = None,
-    ) -> None:
-        """Upload a file to the artifact store and write to cache."""
-        with open(file_path, "rb") as file:
-            # This fails if we don't send the first byte before the signed URL expires.
-            self._api.upload_file_retry(
-                upload_url, file, progress_callback, extra_headers=extra_headers
-            )
-
-    def _write_cache(self, entry: ArtifactManifestEntry) -> None:
-        if entry.local_path is None:
-            return
-
-        # Cache upon successful upload.
-        _, hit, cache_open = self._cache.check_digest_obj_path(
-            entry.digest,
-            size=entry.size or 0,
-            algorithm=entry.digest_algorithm(),
-        )
-
-        staging_dir = get_staging_dir()
-        try:
-            if not (entry.skip_cache or hit):
-                with cache_open("wb") as f, open(entry.local_path, "rb") as src:
-                    shutil.copyfileobj(src, f)
-            if entry.local_path.startswith(staging_dir):
-                # Delete staged files here instead of waiting till
-                # all the files are uploaded
-                os.chmod(entry.local_path, 0o600)
-                os.remove(entry.local_path)
-        except OSError as e:
-            termwarn(f"Failed to cache {entry.local_path}, ignoring {e}")


### PR DESCRIPTION
Deletes more dead code from `wandb_storage_policy.py` that I didn't delete in #12696. Based on regex searches (which are more reliable than LSP because legacy code has bad type annotations), everything else seems to be used as part of artifact downloads, which can still happen through Python.