### PR TITLE
chore: stop gating media logging on the server's max CLI version

### DIFF
--- a/tests/system_tests/test_artifacts/test_data_types.py
+++ b/tests/system_tests/test_artifacts/test_data_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TypeAlias
 
 import matplotlib
 import numpy as np
@@ -12,9 +12,6 @@ from wandb import Api
 from wandb.data_types import Table, WBValue
 from wandb.sdk.data_types._dtypes import TypedDictType
 from wandb.sdk.internal import incremental_table_util
-
-if TYPE_CHECKING:
-    from tests.fixtures.wandb_backend_spy import WandbBackendSpy
 
 matplotlib.use("Agg")
 
@@ -135,28 +132,7 @@ def test_table_logged_from_run_with_special_characters_in_name(
         run.log({"my-table": table}, step=1)
 
 
-@mark.parametrize("max_cli_version", ["0.10.33", "0.11.0"])
-def test_reference_table_logging(
-    user: str,
-    test_settings: SettingsFactory,
-    wandb_backend_spy: WandbBackendSpy,
-    max_cli_version: str,
-):
-    gql = wandb_backend_spy.gql
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="ServerInfo"),
-        gql.once(
-            content={
-                "data": {
-                    "serverInfo": {
-                        "cliVersionInfo": {"max_cli_version": max_cli_version}
-                    }
-                }
-            },
-            status=200,
-        ),
-    )
-
+def test_reference_table_logging(user: str, test_settings: SettingsFactory):
     with wandb.init(settings=test_settings()) as run:
         t = wandb.Table(
             columns=["a"],
@@ -166,24 +142,7 @@ def test_reference_table_logging(
         run.log({"logged_table": t})
 
 
-def test_reference_table_artifacts(
-    user: str,
-    test_settings: SettingsFactory,
-    wandb_backend_spy: WandbBackendSpy,
-):
-    gql = wandb_backend_spy.gql
-    wandb_backend_spy.stub_gql(
-        gql.Matcher(operation="ServerInfo"),
-        gql.once(
-            content={
-                "data": {
-                    "serverInfo": {"cliVersionInfo": {"max_cli_version": "0.11.0"}}
-                }
-            },
-            status=200,
-        ),
-    )
-
+def test_reference_table_artifacts(user: str, test_settings: SettingsFactory):
     with wandb.init(settings=test_settings()) as run:
         t = wandb.Table(
             columns=["a"],

--- a/tests/system_tests/test_core/test_data_types_full.py
+++ b/tests/system_tests/test_core/test_data_types_full.py
@@ -155,42 +155,6 @@ def test_log_with_back_slash_windows(user):
             run.log({r"train\image": wb_image})
 
 
-def test_image_array_old_wandb(
-    wandb_backend_spy,
-    monkeypatch,
-    mock_wandb_log,
-):
-    monkeypatch.setattr(wandb.util, "_get_max_cli_version", lambda: "0.10.33")
-
-    with wandb.init() as run:
-        wb_image = [wandb.Image(np.zeros((28, 28))) for i in range(5)]
-        run.log({"logged_images": wb_image})
-
-    mock_wandb_log.assert_warned("Unable to log image array filenames.")
-
-    with wandb_backend_spy.freeze() as snapshot:
-        summary = snapshot.summary(run_id=run.id)
-        assert "filenames" not in summary["logged_images"]
-
-
-def test_image_array_old_wandb_mp_warning(
-    user,
-    monkeypatch,
-    mock_wandb_log,
-):
-    monkeypatch.setattr(wandb.util, "_get_max_cli_version", lambda: "0.10.33")
-
-    with wandb.init() as run:
-        wb_image = [wandb.Image(np.zeros((28, 28))) for _ in range(5)]
-        run._init_pid += 1
-        run.log({"logged_images": wb_image})
-
-    mock_wandb_log.assert_warned(
-        "Attempting to log a sequence of Image objects from multiple processes"
-        " might result in data loss. Please upgrade your wandb server"
-    )
-
-
 @pytest.mark.parametrize(
     (
         "create_media",

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -22,19 +22,6 @@ settings.load_profile("ci")
 
 
 @pytest.fixture
-def patch_max_cli_version(monkeypatch: pytest.MonkeyPatch):
-    """Make util._get_max_cli_version() always return None.
-
-    By default, this fails in unit tests (usually times out).
-
-    Tests that invoke `_get_max_cli_version()` but don't care about the version
-    should use this fixture. It is not autouse because that can conflict with
-    other patches or with tests for the function itself.
-    """
-    monkeypatch.setattr("wandb.util._get_max_cli_version", lambda: None)
-
-
-@pytest.fixture
 def api() -> wandb.Api:
     """A fake wandb.Api instance.
 

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -165,7 +165,6 @@ def test_captions(
     assert wandb.Image.all_captions([wbone, wbtwo]) == ["Cool", "Nice"]
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_bind_image(
     mock_run,
     image,
@@ -181,7 +180,6 @@ def test_image_accepts_other_images():
     assert image_a == image_b
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_bounding_boxes(
     mock_run,
     image,
@@ -202,7 +200,6 @@ def test_image_accepts_bounding_boxes(
     assert os.path.exists(os.path.join(run.dir, path))
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_bounding_boxes_optional_args(
     mock_run,
     image,
@@ -228,7 +225,6 @@ def test_image_accepts_bounding_boxes_optional_args(
     assert os.path.exists(os.path.join(run.dir, path))
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_masks(
     mock_run,
     image,
@@ -247,7 +243,6 @@ def test_image_accepts_masks(
     assert os.path.exists(os.path.join(run.dir, path))
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_accepts_masks_without_class_labels(
     mock_run,
     image,
@@ -336,7 +331,6 @@ def test_image_mask_type_schema_carries_per_mask_class_maps(image):
     }
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_image_seq_to_json(
     mock_run,
     image,
@@ -348,7 +342,6 @@ def test_image_seq_to_json(
     assert os.path.exists(os.path.join(run.dir, "media", "images", "test_0_0.png"))
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_max_images(mock_run):
     run = mock_run()
     large_image = np.random.randint(255, size=(10, 10))
@@ -463,7 +456,6 @@ def test_image_from_matplotlib_with_image():
 @pytest.mark.skipif(
     platform.system() != "Windows", reason="Failure case is only happening on Windows"
 )
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_fail_to_make_file(
     mock_run,
     image,

--- a/tests/unit_tests/test_media/test_media_logging.py
+++ b/tests/unit_tests/test_media/test_media_logging.py
@@ -96,7 +96,6 @@ def plotly_media() -> wandb.Plotly:
         "plotly_media",
     ],
 )
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_saves_to_run_directory(mock_run, request, media_object):
     run = mock_run(use_magic_mock=True)
     media_object = request.getfixturevalue(media_object)
@@ -119,7 +118,6 @@ def test_log_media_saves_to_run_directory(mock_run, request, media_object):
     ],
 )
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_with_invalid_character_on_windows(
     mock_run, image_media, invalid_character
 ):
@@ -128,7 +126,6 @@ def test_log_media_with_invalid_character_on_windows(
         image_media.bind_to_run(run, f"image{invalid_character}test", 0)
 
 
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_with_path_traversal(mock_run, image_media):
     run = mock_run()
     image_media.bind_to_run(run, "../../../image", 0)
@@ -146,7 +143,6 @@ def test_log_media_with_path_traversal(mock_run, image_media):
         "my///image",
     ],
 )
-@pytest.mark.usefixtures("patch_max_cli_version")
 def test_log_media_prefixed_with_multiple_slashes(mock_run, media_key, image_media):
     run = mock_run()
     image_media.bind_to_run(run, media_key, 0)

--- a/wandb/sdk/data_types/base_types/wb_value.py
+++ b/wandb/sdk/data_types/base_types/wb_value.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from wandb import util
 from wandb.sdk import wandb_setup
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -38,20 +37,12 @@ def _is_maybe_offline() -> bool:
     return singleton.settings._offline
 
 
-def _server_accepts_client_ids() -> bool:
-    from packaging.version import parse
+def _client_ids_allowed() -> bool:
+    """Whether media may reference artifact entries by client ID.
 
-    # There are versions of W&B Server that cannot accept client IDs. Those versions of
-    # the backend have a max_cli_version of less than "0.11.0." If the backend cannot
-    # accept client IDs, manifests and artifact data would never be resolvable and lead
-    # to failed uploads. Our position in 2021/06/29 was to never lose data - and instead take the
-    # tradeoff in the UI. The results in tables not displaying media correctly, but
-    # the table can still be accessed via the .artifact op.
-    #
-    # The latest SDK version that is < "0.11.0" was released on 2021/06/29.
-    # AS OF NOW, 2024/11/06, we assume that all customer's server deployments accept
-    # client IDs.
-
+    Offline runs only resolve such references when `allow_offline_artifacts`
+    is set.
+    """
     if _is_maybe_offline():
         singleton = wandb_setup.singleton()
 
@@ -60,13 +51,7 @@ def _server_accepts_client_ids() -> bool:
         else:
             return singleton.settings.allow_offline_artifacts
 
-    # If the script is online, request the max_cli_version and ensure the server
-    # is of a high enough version.
-    max_cli_version = util._get_max_cli_version()
-    if max_cli_version is None:
-        return False
-    accepts_client_ids: bool = parse(max_cli_version) >= parse("0.11.0")
-    return accepts_client_ids
+    return True
 
 
 class _WBValueArtifactSource:
@@ -239,27 +224,11 @@ class WBValue:
             and target.name
             and (client_id := target.artifact._client_id) is not None
             and target.artifact._final
-            and _server_accepts_client_ids()
+            and _client_ids_allowed()
         ):
             return (
                 f"wandb-client-artifact://{client_id}/{self.with_suffix(target.name)}"
             )
-
-        # Else if we do not support client IDs, but online, then block on upload
-        # Note: this is old behavior just to stay backwards compatible
-        # with older server versions. This code path should be removed
-        # once those versions are no longer supported. This path uses a .wait
-        # which blocks the user process on artifact upload.
-        if (
-            (target := self._artifact_target)
-            and target.name
-            and target.artifact._is_draft_save_started()
-            and not _is_maybe_offline()
-            and not _server_accepts_client_ids()
-        ):
-            target.artifact.wait()
-            ref_entry = target.artifact.get_entry(self.with_suffix(target.name))
-            return ref_entry.ref_url()
 
         return None
 
@@ -269,23 +238,8 @@ class WBValue:
             and target.name
             and (sequence_client_id := target.artifact._sequence_client_id) is not None
             and target.artifact._final
-            and _server_accepts_client_ids()
+            and _client_ids_allowed()
         ):
             return f"wandb-client-artifact://{sequence_client_id}:latest/{self.with_suffix(target.name)}"
 
-        # Else if we do not support client IDs, then block on upload
-        # Note: this is old behavior just to stay backwards compatible
-        # with older server versions. This code path should be removed
-        # once those versions are no longer supported. This path uses a .wait
-        # which blocks the user process on artifact upload.
-        if (
-            (target := self._artifact_target)
-            and target.name
-            and target.artifact._is_draft_save_started()
-            and not _is_maybe_offline()
-            and not _server_accepts_client_ids()
-        ):
-            target.artifact.wait()
-            ref_entry = target.artifact.get_entry(self.with_suffix(target.name))
-            return ref_entry.ref_url()
         return None

--- a/wandb/sdk/data_types/image.py
+++ b/wandb/sdk/data_types/image.py
@@ -9,8 +9,6 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 from urllib import parse
 
-from packaging.version import parse as parse_version
-
 import wandb
 from wandb import util
 from wandb.sdk.lib import hashutil, runid
@@ -44,33 +42,6 @@ def _convert_to_uint8(data: np.ndarray) -> np.ndarray:
         required="wandb.Image requires numpy if not supplying PIL Images: pip install numpy",
     )
     return data.astype(np.uint8)
-
-
-def _server_accepts_image_filenames(run: wandb.Run) -> bool:
-    if run.offline:
-        return True
-
-    # Newer versions of wandb accept large image filenames arrays
-    # but older versions would have issues with this.
-    max_cli_version = util._get_max_cli_version()
-    if max_cli_version is None:
-        return False
-
-    accepts_image_filenames: bool = parse_version(max_cli_version) >= parse_version(
-        "0.12.10"
-    )
-    return accepts_image_filenames
-
-
-def _server_accepts_artifact_path(run: wandb.Run) -> bool:
-    if run.offline:
-        return False
-
-    max_cli_version = util._get_max_cli_version()
-    if max_cli_version is None:
-        return False
-
-    return parse_version(max_cli_version) >= parse_version("0.12.14")
 
 
 class Image(BatchableMedia):
@@ -455,10 +426,7 @@ class Image(BatchableMedia):
         # Windows filenames fail fast instead of blocking on a version lookup.
         util.make_file_path_upload_safe(str(key))
 
-        if (
-            not _server_accepts_artifact_path(run)
-            or self._get_artifact_entry_ref_url() is None
-        ):
+        if run.offline or self._get_artifact_entry_ref_url() is None:
             super().bind_to_run(run, key, step, id_, ignore_copy_err=ignore_copy_err)
         if self._boxes is not None:
             for i, k in enumerate(self._boxes):
@@ -613,16 +581,7 @@ class Image(BatchableMedia):
             "format": format,
             "count": num_images_to_log,
         }
-        if _server_accepts_image_filenames(run):
-            meta["filenames"] = [
-                obj.get("path", obj.get("artifact_path")) for obj in jsons
-            ]
-        else:
-            wandb.termwarn(
-                "Unable to log image array filenames. In some cases, this can prevent images from being "
-                "viewed in the UI. Please upgrade your wandb server",
-                repeat=False,
-            )
+        meta["filenames"] = [obj.get("path", obj.get("artifact_path")) for obj in jsons]
 
         captions = Image.all_captions(seq)
 

--- a/wandb/sdk/data_types/utils.py
+++ b/wandb/sdk/data_types/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import os
 from collections.abc import Sequence
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
@@ -13,7 +12,6 @@ from wandb import util
 from ..internal import incremental_table_util
 from .base_types.media import BatchableMedia, Media
 from .base_types.wb_value import WBValue
-from .image import _server_accepts_image_filenames
 from .plotly import Plotly
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -106,28 +104,13 @@ def val_to_json(
 
             items = _prune_max_seq(val)
 
-            if _server_accepts_image_filenames(run):
-                for item in items:
-                    item.bind_to_run(
-                        run=run,
-                        key=key,
-                        step=namespace,
-                        ignore_copy_err=ignore_copy_err,
-                    )
-            else:
-                for i, item in enumerate(items):
-                    item.bind_to_run(
-                        run=run,
-                        key=key,
-                        step=namespace,
-                        id_=i,
-                        ignore_copy_err=ignore_copy_err,
-                    )
-                if run._attach_id and run._init_pid != os.getpid():
-                    wandb.termwarn(
-                        f"Attempting to log a sequence of {items[0].__class__.__name__} objects from multiple processes might result in data loss. Please upgrade your wandb server",
-                        repeat=False,
-                    )
+            for item in items:
+                item.bind_to_run(
+                    run=run,
+                    key=key,
+                    step=namespace,
+                    ignore_copy_err=ignore_copy_err,
+                )
 
             return items[0].seq_to_json(items, run, key, namespace)
         else:

--- a/wandb/util.py
+++ b/wandb/util.py
@@ -1525,11 +1525,6 @@ def parse_artifact_string(v: str) -> tuple[str, str | None, bool]:
     return f"{entity}/{project}/{name_and_alias_or_version}", base_uri, False
 
 
-def _get_max_cli_version() -> str | None:
-    max_cli_version = wandb.api.max_cli_version()
-    return str(max_cli_version) if max_cli_version is not None else None
-
-
 def make_artifact_name_safe(name: str) -> str:
     """Make an artifact name safe for use in artifacts."""
     # artifact names may only contain alphanumeric characters, dashes, underscores, and dots.


### PR DESCRIPTION
Description
-----------

Logging media queried `serverInfo.cliVersionInfo.max_cli_version` to decide whether the server accepts client IDs (2021), image filename arrays (January 2022) and artifact paths (April 2022), and otherwise fell back to blocking on the artifact upload or logging without filenames. Servers that old have been out of support for years, so the checks and the fallbacks are gone, together with the GraphQL request they cost on the first media log of a process.

`wandb.util._get_max_cli_version` was the last user of the module-level `wandb.api` object, which the next PR in this stack removes.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Removed the unit and system tests that exercised the old-server fallbacks.
