### PR TITLE
chore: move the `useArtifact` and `createArtifact` mutations off `InternalApi`

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Fixed
 
+- Passing `aliases` or `tags` to `Run.log_artifact()` in the public API no longer fails with a server error (@dmitryduev in https://github.com/wandb/wandb/pull/12719)
 - `wandb.Image` masks are no longer silently corrupted when `mask_data` is a float array with values outside 0-255. The range check previously only ran for integer dtypes, so out-of-range class ids were written to the saved mask wrapped modulo 256; they now raise `TypeError` like their integer equivalents already did (@Kayvan-Zahiri in https://github.com/wandb/wandb/pull/12685)
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)

--- a/tests/unit_tests/test_artifacts/test_gqlutils.py
+++ b/tests/unit_tests/test_artifacts/test_gqlutils.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock
+
+import pytest
+from wandb.sdk.artifacts._gqlutils import record_artifact_use
+
+
+@pytest.mark.parametrize("server_takes_artifact_location", [True, False])
+@pytest.mark.parametrize("use_as", ["test-use-as", None])
+def test_record_artifact_use_query(server_takes_artifact_location, use_as):
+    service_api = Mock()
+    service_api.feature_enabled.return_value = server_takes_artifact_location
+    service_api.execute_graphql.return_value = {
+        "useArtifact": {"artifact": {"id": "test-artifact-id"}}
+    }
+
+    result = record_artifact_use(
+        service_api,
+        artifact_id="test-artifact-id",
+        entity_name="test-entity",
+        project_name="test-project",
+        run_name="test-run",
+        artifact_entity_name="test-artifact-entity",
+        artifact_project_name="test-artifact-project",
+        use_as=use_as,
+    )
+
+    assert result == {"id": "test-artifact-id"}
+    query, variables = service_api.execute_graphql.call_args.args
+    assert variables["entityName"] == "test-entity"
+    assert variables["runName"] == "test-run"
+    assert ("usedAs: $usedAs" in query) == (use_as is not None)
+    assert ("artifactEntityName" in query) == server_takes_artifact_location
+    assert ("artifactEntityName" in variables) == server_takes_artifact_location

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -5,7 +5,6 @@ import hashlib
 import os
 import pathlib
 import tempfile
-from itertools import chain
 from unittest.mock import Mock, patch
 
 import pytest
@@ -268,126 +267,6 @@ def test_server_feature_checks(
     else:
         result = api._server_supports(feature)
         assert result == expected_result
-
-
-def test_construct_use_artifact_query_with_every_field(mocker: MockerFixture):
-    # Create mock internal API instance
-    api = Api()
-
-    mocker.patch.object(api, "settings", side_effect=lambda x: "default-" + x)
-
-    # Simulate server support for ALL known features
-    mock_server_features = dict.fromkeys(
-        chain(ServerFeature.keys(), ServerFeature.values()),
-        True,
-    )
-    mocker.patch.object(api, "_server_features", return_value=mock_server_features)
-
-    test_cases = [
-        {
-            "entity_name": "test-entity",
-            "project_name": "test-project",
-            "run_name": "test-run",
-            "artifact_id": "test-artifact-id",
-            "use_as": "test-use-as",
-            "artifact_entity_name": "test-artifact-entity",
-            "artifact_project_name": "test-artifact-project",
-        },
-        {
-            "entity_name": None,
-            "project_name": None,
-            "run_name": None,
-            "artifact_id": "test-artifact-id",
-            "use_as": None,
-            "artifact_entity_name": "test-artifact-entity",
-            "artifact_project_name": "test-artifact-project",
-        },
-    ]
-
-    for case in test_cases:
-        query, variables = api._construct_use_artifact_query(
-            entity_name=case["entity_name"],
-            project_name=case["project_name"],
-            run_name=case["run_name"],
-            artifact_id=case["artifact_id"],
-            use_as=case["use_as"],
-            artifact_entity_name=case["artifact_entity_name"],
-            artifact_project_name=case["artifact_project_name"],
-        )
-
-        # Verify variables are correctly set
-        expected_variables = {
-            "entityName": case["entity_name"] or "default-entity",
-            "projectName": case["project_name"] or "default-project",
-            "runName": case["run_name"],
-            "artifactID": case["artifact_id"],
-            "usedAs": case["use_as"],
-            "artifactEntityName": case["artifact_entity_name"],
-            "artifactProjectName": case["artifact_project_name"],
-        }
-        assert variables == expected_variables
-
-        query_str = str(query)
-        assert "artifactEntityName" in query_str
-        assert "artifactProjectName" in query_str
-        if case["use_as"]:
-            assert "usedAs" in query_str
-        else:
-            assert "usedAs" not in query_str
-
-
-def test_construct_use_artifact_query_without_entity_project():
-    # Test when server doesn't support entity/project information
-    api = Api()
-    api.settings = Mock(side_effect=lambda x: "default-" + x)
-
-    # Mock methods to return False for entity/project support
-    api._server_features = Mock(return_value={})
-
-    query, variables = api._construct_use_artifact_query(
-        entity_name="test-entity",
-        project_name="test-project",
-        run_name="test-run",
-        artifact_id="test-artifact-id",
-        use_as="test-use-as",
-        artifact_entity_name="test-artifact-entity",
-        artifact_project_name="test-artifact-project",
-    )
-    query_str = str(query)
-
-    # Verify entity/project information is not in variables
-    assert "artifactEntityName" not in variables
-    assert "artifactProjectName" not in variables
-    assert "artifactEntityName" not in query_str
-    assert "artifactProjectName" not in query_str
-
-
-def test_construct_use_artifact_query_without_used_as():
-    # Test when no use_as value is provided.
-    api = Api()
-    api.settings = Mock(side_effect=lambda x: "default-" + x)
-
-    # Simulate server support for ALL known features
-    mock_server_features = dict.fromkeys(
-        chain(ServerFeature.keys(), ServerFeature.values()),
-        True,
-    )
-    api._server_features = Mock(return_value=mock_server_features)
-
-    query, variables = api._construct_use_artifact_query(
-        entity_name="test-entity",
-        project_name="test-project",
-        run_name="test-run",
-        artifact_id="test-artifact-id",
-        use_as=None,
-        artifact_entity_name="test-artifact-entity",
-        artifact_project_name="test-artifact-project",
-    )
-    query_str = str(query)
-
-    # Verify usedAs is still in variables but not in query.
-    assert "usedAs" in variables
-    assert "usedAs:" not in query_str
 
 
 class TestJWTAuth:

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -55,13 +55,12 @@ from wandb.apis._generated.get_agent_runs import GetAgentRuns
 from wandb.apis.attrs import Attrs
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import SizedPaginator
-from wandb.apis.public.const import RETRY_TIMEDELTA
 from wandb.apis.public.service_api import ServiceApi
 from wandb.errors import CommError
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk import wandb_setup
-from wandb.sdk.internal.internal_api import Api as InternalApi
+from wandb.sdk.artifacts._gqlutils import create_artifact_version, record_artifact_use
 from wandb.sdk.lib import ipython, json_util
 from wandb.sdk.lib.paths import LogicalPath
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
@@ -1506,18 +1505,16 @@ class Run(Attrs):
         Returns:
             An `Artifact` object.
         """
-        api = InternalApi(
-            default_settings={"entity": self.entity, "project": self.project},
-            retry_timedelta=RETRY_TIMEDELTA,
-        )
-        api.set_current_run_id(self.id)
-
         if isinstance(artifact, wandb.Artifact) and not artifact.is_draft():
-            api.use_artifact(
-                artifact.id,
-                use_as=use_as or artifact.name,
+            record_artifact_use(
+                self._service_api,
+                artifact_id=artifact.id,
+                entity_name=self.entity,
+                project_name=self.project,
+                run_name=self.id,
                 artifact_entity_name=artifact.entity,
                 artifact_project_name=artifact.project,
+                use_as=use_as or artifact.name,
             )
             return artifact
         elif isinstance(artifact, wandb.Artifact) and artifact.is_draft():
@@ -1546,12 +1543,6 @@ class Run(Attrs):
         Returns:
             A `Artifact` object.
         """
-        api = InternalApi(
-            default_settings={"entity": self.entity, "project": self.project},
-            retry_timedelta=RETRY_TIMEDELTA,
-        )
-        api.set_current_run_id(self.id)
-
         if not isinstance(artifact, wandb.Artifact):
             raise TypeError("You must pass a wandb.Api().artifact() to use_artifact")
         if artifact.is_draft():
@@ -1566,15 +1557,20 @@ class Run(Attrs):
             raise ValueError("A run can't log an artifact to a different project.")
 
         artifact_collection_name = artifact.source_name.split(":")[0]
-        api.create_artifact(
-            artifact.type,
-            artifact_collection_name,
-            artifact.digest,
+        create_artifact_version(
+            self._service_api,
+            artifact_type_name=artifact.type,
+            artifact_collection_name=artifact_collection_name,
+            digest=artifact.digest,
+            digest_algorithm=artifact.digest_algorithm,
             entity_name=self.entity,
             project_name=self.project,
-            aliases=aliases,
-            tags=tags,
-            digest_algorithm=artifact.digest_algorithm,
+            run_name=self.id,
+            aliases=[
+                {"artifactCollectionName": artifact_collection_name, "alias": alias}
+                for alias in aliases or []
+            ],
+            tags=[{"tagName": tag} for tag in tags or []],
         )
         return artifact
 

--- a/wandb/sdk/artifacts/_gqlutils.py
+++ b/wandb/sdk/artifacts/_gqlutils.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import json
 from contextlib import suppress
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from wandb import util
 from wandb._iterutils import one
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk.internal._generated import SERVER_FEATURES_QUERY_GQL, ServerFeaturesQuery
 
 if TYPE_CHECKING:
     from wandb.apis.public.service_api import ServiceApi
+    from wandb.sdk.artifacts._generated.enums import ArtifactDigestAlgorithm
     from wandb.sdk.artifacts._generated.fetch_org_info_from_entity import (
         FetchOrgInfoFromEntityEntity,
     )
@@ -199,3 +202,158 @@ def omit_artifact_fields(service_api: ServiceApi) -> set[str]:
         omit_fields.add("digestAlgorithm")
 
     return omit_fields
+
+
+def record_artifact_use(
+    service_api: ServiceApi,
+    *,
+    artifact_id: str | None,
+    entity_name: str | None,
+    project_name: str | None,
+    run_name: str | None,
+    artifact_entity_name: str | None = None,
+    artifact_project_name: str | None = None,
+    use_as: str | None = None,
+) -> dict[str, Any] | None:
+    """Declare an artifact as an input of a run."""
+    query_vars = [
+        "$entityName: String!",
+        "$projectName: String!",
+        "$runName: String!",
+        "$artifactID: ID!",
+    ]
+    query_args = [
+        "entityName: $entityName",
+        "projectName: $projectName",
+        "runName: $runName",
+        "artifactID: $artifactID",
+    ]
+    variables: dict[str, Any] = {
+        "entityName": entity_name,
+        "projectName": project_name,
+        "runName": run_name,
+        "artifactID": artifact_id,
+        "usedAs": use_as,
+    }
+    if use_as:
+        query_vars.append("$usedAs: String")
+        query_args.append("usedAs: $usedAs")
+    if service_api.feature_enabled(
+        ServerFeature.USE_ARTIFACT_WITH_ENTITY_AND_PROJECT_INFORMATION
+    ):
+        query_vars += ["$artifactEntityName: String", "$artifactProjectName: String"]
+        query_args += [
+            "artifactEntityName: $artifactEntityName",
+            "artifactProjectName: $artifactProjectName",
+        ]
+        variables["artifactEntityName"] = artifact_entity_name
+        variables["artifactProjectName"] = artifact_project_name
+
+    mutation = f"""
+        mutation UseArtifact({", ".join(query_vars)}) {{
+            useArtifact(input: {{{", ".join(query_args)}}}) {{
+                artifact {{
+                    id
+                    digest
+                    description
+                    state
+                    createdAt
+                    metadata
+                }}
+            }}
+        }}
+        """
+    response = service_api.execute_graphql(mutation, variables)
+    return response["useArtifact"]["artifact"] or None
+
+
+def create_artifact_version(
+    service_api: ServiceApi,
+    *,
+    artifact_type_name: str,
+    artifact_collection_name: str,
+    digest: str,
+    digest_algorithm: ArtifactDigestAlgorithm,
+    entity_name: str,
+    project_name: str,
+    run_name: str | None,
+    client_id: str | None = None,
+    sequence_client_id: str | None = None,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    aliases: list[dict[str, str]] | None = None,
+    tags: list[dict[str, str]] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Create an artifact version from a digest.
+
+    Returns the created artifact and the collection's latest artifact before
+    the call, which is None for a new collection.
+    """
+    mutation = """
+        mutation CreateArtifact(
+            $artifactTypeName: String!,
+            $artifactCollectionNames: [String!],
+            $entityName: String!,
+            $projectName: String!,
+            $runName: String,
+            $description: String,
+            $digest: String!,
+            $digestAlgorithm: ArtifactDigestAlgorithm!,
+            $aliases: [ArtifactAliasInput!],
+            $metadata: JSONString,
+            $clientID: ID,
+            $sequenceClientID: ID,
+            $tags: [TagInput!],
+        ) {
+            createArtifact(input: {
+                artifactTypeName: $artifactTypeName,
+                artifactCollectionNames: $artifactCollectionNames,
+                entityName: $entityName,
+                projectName: $projectName,
+                runName: $runName,
+                description: $description,
+                digest: $digest,
+                digestAlgorithm: $digestAlgorithm,
+                aliases: $aliases,
+                metadata: $metadata,
+                clientID: $clientID,
+                sequenceClientID: $sequenceClientID,
+                enableDigestDeduplication: true,
+                tags: $tags,
+            }) {
+                artifact {
+                    id
+                    state
+                    artifactSequence {
+                        id
+                        latestArtifact {
+                            id
+                            versionIndex
+                        }
+                    }
+                }
+            }
+        }
+        """
+    response = service_api.execute_graphql(
+        mutation,
+        {
+            "entityName": entity_name,
+            "projectName": project_name,
+            "runName": run_name,
+            "artifactTypeName": artifact_type_name,
+            "artifactCollectionNames": [artifact_collection_name],
+            "clientID": client_id,
+            "sequenceClientID": sequence_client_id,
+            "digest": digest,
+            "digestAlgorithm": digest_algorithm,
+            "description": description,
+            "aliases": list(aliases or []),
+            "tags": list(tags or []),
+            "metadata": json.dumps(util.make_safe_for_json(metadata))
+            if metadata
+            else None,
+        },
+    )
+    artifact = response["createArtifact"]["artifact"]
+    return artifact, artifact["artifactSequence"].get("latestArtifact")

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import json
 import logging
 import os
@@ -26,7 +25,6 @@ from wandb.proto.wandb_api_pb2 import (
 )
 from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk import wandb_setup
-from wandb.sdk.artifacts._generated.enums import ArtifactDigestAlgorithm
 from wandb.sdk.internal._generated import SERVER_FEATURES_QUERY_GQL, ServerFeaturesQuery
 from wandb.sdk.lib.hashutil import B64Digest, md5_file_b64
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
@@ -85,7 +83,6 @@ class Api:
             | None
         ) = None,
         load_settings: bool = True,
-        retry_timedelta: datetime.timedelta | None = None,
         environ: MutableMapping[str, str] = os.environ,
         api_key: str | None = None,
         telemetry_recorder: TelemetryRecorder | None = None,
@@ -118,8 +115,6 @@ class Api:
             self._settings = global_settings.read_system_settings().all()
         else:
             self._settings = {}
-
-        self.retry_timedelta = retry_timedelta or datetime.timedelta(days=7)
 
         # todo: remove these hacky hacks after settings refactor is complete
         #  keeping this code here to limit scope and so that it is easy to remove later
@@ -171,7 +166,6 @@ class Api:
         self._service_api = self._new_service_api()
         self._telemetry_recorder = telemetry_recorder or get_telemetry_recorder()
 
-        self._current_run_id: str | None = None
         self._max_cli_version: str | None = None
 
         self._server_features_cache: dict[str, bool] | None = None
@@ -216,13 +210,6 @@ class Api:
             settings=settings,
             timeout=self.HTTP_TIMEOUT,
         )
-
-    def set_current_run_id(self, run_id: str) -> None:
-        self._current_run_id = run_id
-
-    @property
-    def current_run_id(self) -> str | None:
-        return self._current_run_id
 
     @property
     def user_agent(self) -> str:
@@ -353,7 +340,7 @@ class Api:
             project = project or self.settings().get("project")
             if project is None:
                 raise CommError("No default project configured.")
-            run = run or slug or self.current_run_id or env.get_run(env=self._environ)
+            run = run or slug or env.get_run(env=self._environ)
             assert run, "run must be specified"
         return project, run
 
@@ -1551,7 +1538,6 @@ class Api:
             }
         }
         """
-        run = run or self.current_run_id
         assert run, "run must be specified"
         entity = entity or self.settings("entity")
         query_result = self.execute(
@@ -1938,240 +1924,6 @@ class Api:
     def file_current(fname: str, md5: B64Digest) -> bool:
         """Checksum a file and compare the md5 with the known md5."""
         return os.path.isfile(fname) and md5_file_b64(fname) == md5
-
-    def _construct_use_artifact_query(
-        self,
-        artifact_id: str,
-        entity_name: str | None = None,
-        project_name: str | None = None,
-        run_name: str | None = None,
-        use_as: str | None = None,
-        artifact_entity_name: str | None = None,
-        artifact_project_name: str | None = None,
-    ) -> tuple[str, dict[str, Any]]:
-        query_vars = [
-            "$entityName: String!",
-            "$projectName: String!",
-            "$runName: String!",
-            "$artifactID: ID!",
-        ]
-        query_args = [
-            "entityName: $entityName",
-            "projectName: $projectName",
-            "runName: $runName",
-            "artifactID: $artifactID",
-        ]
-
-        if use_as:
-            query_vars.append("$usedAs: String")
-            query_args.append("usedAs: $usedAs")
-
-        entity_name = entity_name or self.settings("entity")
-        project_name = project_name or self.settings("project")
-        run_name = run_name or self.current_run_id
-
-        variables: dict[str, Any] = {
-            "entityName": entity_name,
-            "projectName": project_name,
-            "runName": run_name,
-            "artifactID": artifact_id,
-            "usedAs": use_as,
-        }
-
-        server_allows_entity_project_information = self._server_supports(
-            ServerFeature.USE_ARTIFACT_WITH_ENTITY_AND_PROJECT_INFORMATION
-        )
-        if server_allows_entity_project_information:
-            query_vars.extend(
-                [
-                    "$artifactEntityName: String",
-                    "$artifactProjectName: String",
-                ]
-            )
-            query_args.extend(
-                [
-                    "artifactEntityName: $artifactEntityName",
-                    "artifactProjectName: $artifactProjectName",
-                ]
-            )
-            variables["artifactEntityName"] = artifact_entity_name
-            variables["artifactProjectName"] = artifact_project_name
-
-        vars_str = ", ".join(query_vars)
-        args_str = ", ".join(query_args)
-
-        query = f"""
-            mutation UseArtifact({vars_str}) {{
-                useArtifact(input: {{{args_str}}}) {{
-                    artifact {{
-                        id
-                        digest
-                        description
-                        state
-                        createdAt
-                        metadata
-                    }}
-                }}
-            }}
-            """
-        return query, variables
-
-    def use_artifact(
-        self,
-        artifact_id: str,
-        entity_name: str | None = None,
-        project_name: str | None = None,
-        run_name: str | None = None,
-        artifact_entity_name: str | None = None,
-        artifact_project_name: str | None = None,
-        use_as: str | None = None,
-    ) -> dict[str, Any] | None:
-        query, variables = self._construct_use_artifact_query(
-            artifact_id,
-            entity_name,
-            project_name,
-            run_name,
-            use_as,
-            artifact_entity_name,
-            artifact_project_name,
-        )
-        response = self.execute(query, variables)
-
-        if response["useArtifact"]["artifact"]:
-            artifact: dict[str, Any] = response["useArtifact"]["artifact"]
-            return artifact
-        return None
-
-    def _get_create_artifact_mutation(
-        self,
-        history_step: int | None,
-        distributed_id: str | None,
-    ) -> str:
-        types = ""
-        values = ""
-
-        if history_step not in [0, None]:
-            types += "$historyStep: Int64!,"
-            values += "historyStep: $historyStep,"
-
-        if distributed_id:
-            types += "$distributedID: String,"
-            values += "distributedID: $distributedID,"
-
-        query_template = """
-            mutation CreateArtifact(
-                $artifactTypeName: String!,
-                $artifactCollectionNames: [String!],
-                $entityName: String!,
-                $projectName: String!,
-                $runName: String,
-                $description: String,
-                $digest: String!,
-                $digestAlgorithm: ArtifactDigestAlgorithm!,
-                $aliases: [ArtifactAliasInput!],
-                $metadata: JSONString,
-                $clientID: ID,
-                $sequenceClientID: ID,
-                $ttlDurationSeconds: Int64,
-                $tags: [TagInput!],
-                _CREATE_ARTIFACT_ADDITIONAL_TYPE_
-            ) {
-                createArtifact(input: {
-                    artifactTypeName: $artifactTypeName,
-                    artifactCollectionNames: $artifactCollectionNames,
-                    entityName: $entityName,
-                    projectName: $projectName,
-                    runName: $runName,
-                    description: $description,
-                    digest: $digest,
-                    digestAlgorithm: $digestAlgorithm,
-                    aliases: $aliases,
-                    metadata: $metadata,
-                    clientID: $clientID,
-                    sequenceClientID: $sequenceClientID,
-                    enableDigestDeduplication: true,
-                    ttlDurationSeconds: $ttlDurationSeconds,
-                    tags: $tags,
-                    _CREATE_ARTIFACT_ADDITIONAL_VALUE_
-                }) {
-                    artifact {
-                        id
-                        state
-                        artifactSequence {
-                            id
-                            latestArtifact {
-                                id
-                                versionIndex
-                            }
-                        }
-                    }
-                }
-            }
-        """
-
-        return query_template.replace(
-            "_CREATE_ARTIFACT_ADDITIONAL_TYPE_", types
-        ).replace("_CREATE_ARTIFACT_ADDITIONAL_VALUE_", values)
-
-    def create_artifact(
-        self,
-        artifact_type_name: str,
-        artifact_collection_name: str,
-        digest: str,
-        client_id: str | None = None,
-        sequence_client_id: str | None = None,
-        entity_name: str | None = None,
-        project_name: str | None = None,
-        run_name: str | None = None,
-        description: str | None = None,
-        metadata: dict | None = None,
-        ttl_duration_seconds: int | None = None,
-        aliases: list[dict[str, str]] | None = None,
-        tags: list[dict[str, str]] | None = None,
-        distributed_id: str | None = None,
-        is_user_created: bool | None = False,
-        history_step: int | None = None,
-        digest_algorithm: ArtifactDigestAlgorithm = ArtifactDigestAlgorithm.MANIFEST_MD5,
-    ) -> tuple[dict, dict]:
-        query_template = self._get_create_artifact_mutation(
-            history_step,
-            distributed_id,
-        )
-
-        entity_name = entity_name or self.settings("entity")
-        project_name = project_name or self.settings("project")
-        if not is_user_created:
-            run_name = run_name or self.current_run_id
-
-        mutation = query_template
-        response = self.execute(
-            mutation,
-            variables={
-                "entityName": entity_name,
-                "projectName": project_name,
-                "runName": run_name,
-                "artifactTypeName": artifact_type_name,
-                "artifactCollectionNames": [artifact_collection_name],
-                "clientID": client_id,
-                "sequenceClientID": sequence_client_id,
-                "digest": digest,
-                "digestAlgorithm": digest_algorithm,
-                "description": description,
-                "aliases": list(aliases or []),
-                "tags": list(tags or []),
-                "metadata": json.dumps(util.make_safe_for_json(metadata))
-                if metadata
-                else None,
-                "ttlDurationSeconds": ttl_duration_seconds,
-                "distributedID": distributed_id,
-                "historyStep": history_step,
-            },
-        )
-        av = response["createArtifact"]["artifact"]
-        latest = response["createArtifact"]["artifact"]["artifactSequence"].get(
-            "latestArtifact"
-        )
-        return av, latest
 
     def update_artifact_metadata(
         self, artifact_id: str, metadata: dict[str, Any]

--- a/wandb/sdk/launch/create_job.py
+++ b/wandb/sdk/launch/create_job.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import wandb
 from wandb.sdk.artifacts._generated.enums import ArtifactDigestAlgorithm
+from wandb.sdk.artifacts._gqlutils import create_artifact_version
 from wandb.sdk.artifacts._internal_artifact import InternalArtifact
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.internal.internal_api import Api
@@ -220,7 +221,8 @@ def _create_job(
             }
         }
 
-    res, _ = api.create_artifact(
+    res, _ = create_artifact_version(
+        api._service_api,
         artifact_type_name="job",
         artifact_collection_name=name,
         digest=artifact.digest,
@@ -232,7 +234,6 @@ def _create_job(
         run_name=run.id,  # type: ignore # run will be deleted after creation
         description=description,
         metadata=metadata,
-        is_user_created=True,
         aliases=[{"artifactCollectionName": name, "alias": a} for a in aliases],
     )
     action = "No changes detected for"
@@ -481,7 +482,8 @@ def _make_code_artifact(
         except FileNotFoundError:
             pass
 
-    res, _ = api.create_artifact(
+    res, _ = create_artifact_version(
+        api._service_api,
         artifact_type_name="code",
         artifact_collection_name=artifact_name,
         digest=code_artifact.digest,
@@ -493,7 +495,6 @@ def _make_code_artifact(
         run_name=run.id,  # run will be deleted after creation
         description="Code artifact for job",
         metadata={"codePath": path, "entrypoint": entrypoint_file},
-        is_user_created=True,
         aliases=[
             {"artifactCollectionName": artifact_name, "alias": a} for a in ["latest"]
         ],

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3098,19 +3098,11 @@ class Run:
         ```
 
         """
+        from wandb.sdk.artifacts._gqlutils import record_artifact_use
         from wandb.sdk.artifacts.artifact import Artifact
-        from wandb.sdk.internal.internal_api import Api as InternalApi
 
         if self._settings._offline:
             raise TypeError("Cannot use artifact when in offline mode.")
-
-        api = InternalApi(
-            default_settings={
-                "entity": self._settings.entity,
-                "project": self._settings.project,
-            }
-        )
-        api.set_current_run_id(self._settings.run_id)
 
         if use_as is not None:
             deprecation.warn_and_record_deprecation(
@@ -3128,10 +3120,12 @@ class Run:
                 raise ValueError(
                     f"Supplied type {type} does not match type {artifact.type} of artifact {artifact.name}"
                 )
-            api.use_artifact(
-                artifact.id,
+            record_artifact_use(
+                public_api._service_api,
+                artifact_id=artifact.id,
                 entity_name=self._settings.entity,
                 project_name=self._settings.project,
+                run_name=self._settings.run_id,
                 artifact_entity_name=artifact.entity,
                 artifact_project_name=artifact.project,
             )
@@ -3154,8 +3148,12 @@ class Run:
                 )
                 artifact.wait()
             elif isinstance(artifact, Artifact) and not artifact.is_draft():
-                api.use_artifact(
-                    artifact.id,
+                record_artifact_use(
+                    self._public_api()._service_api,
+                    artifact_id=artifact.id,
+                    entity_name=self._settings.entity,
+                    project_name=self._settings.project,
+                    run_name=self._settings.run_id,
                     artifact_entity_name=artifact.entity,
                     artifact_project_name=artifact.project,
                 )


### PR DESCRIPTION
Description
-----------

`Run.use_artifact()` and `Run.log_artifact()` in the public API, `run.use_artifact()` on a live run and `wandb job create` all built an `InternalApi` just to send the `useArtifact` or `createArtifact` mutation. Both mutations now live in `wandb.sdk.artifacts._gqlutils` as functions that take the caller's `ServiceApi`, and `InternalApi` loses them together with the current-run bookkeeping only they used.

The public `Run.log_artifact()` also passed its `aliases` and `tags` arguments to the mutation as plain strings, which the server rejects; they are now sent as the alias and tag inputs the mutation expects.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Ported the `useArtifact` query construction tests to the new helper.
