### PR TITLE
chore: drop `InternalApi` from artifact downloads and linking

### DIFF
--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -13,7 +13,6 @@ import wandb.sdk.internal.internal_api
 from pytest_mock import MockerFixture
 from wandb.errors import CommError
 from wandb.proto import wandb_api_pb2 as apb
-from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk import wandb_setup
 from wandb.sdk.internal.internal_api import Api
 from wandb.sdk.lib import wbauth
@@ -148,125 +147,6 @@ def test_internal_api_with_no_write_global_config_dir(
         Api()
     finally:
         config_dir.chmod(0o711)  # allow test to clean up
-
-
-ENABLED_FEATURE_RESPONSE = {
-    "serverInfo": {
-        "features": [
-            {"name": "LARGE_FILENAMES", "isEnabled": True},
-            {"name": "ARTIFACT_TAGS", "isEnabled": False},
-        ]
-    }
-}
-
-
-@pytest.fixture
-def mock_service_api(mocker: MockerFixture):
-    mock = mocker.Mock()
-    mock.settings.base_url = "https://api.wandb.ai"
-    mock.settings.api_key = "test-api-key"
-    mock.settings.identity_token_file = None
-    mocker.patch(
-        "wandb.sdk.internal.internal_api.Api._new_service_api",
-        return_value=mock,
-    )
-    yield mock
-
-
-@pytest.fixture
-def mock_service_api_with_enabled_features(mock_service_api):
-    mock_service_api.execute_graphql.return_value = ENABLED_FEATURE_RESPONSE
-    yield mock_service_api
-
-
-NO_FEATURES_RESPONSE = {"serverInfo": {"features": []}}
-
-
-@pytest.fixture
-def mock_service_api_with_no_features(mock_service_api):
-    mock_service_api.execute_graphql.return_value = NO_FEATURES_RESPONSE
-    yield mock_service_api
-
-
-@pytest.fixture
-def mock_service_api_with_error_no_field(mock_service_api):
-    error_msg = 'Cannot query field "features" on type "ServerInfo".'
-    mock_service_api.execute_graphql.side_effect = Exception(error_msg)
-    yield mock_service_api
-
-
-@pytest.fixture
-def mock_service_api_with_random_error(mock_service_api):
-    error_msg = "Some random error"
-    mock_service_api.execute_graphql.side_effect = Exception(error_msg)
-    yield mock_service_api
-
-
-@pytest.mark.parametrize(
-    "fixture_name, feature, expected_result, expected_error",
-    [
-        (
-            # Test enabled features
-            mock_service_api_with_enabled_features.__name__,
-            ServerFeature.LARGE_FILENAMES,
-            True,
-            False,
-        ),
-        (
-            # Test disabled features
-            mock_service_api_with_enabled_features.__name__,
-            ServerFeature.ARTIFACT_TAGS,
-            False,
-            False,
-        ),
-        (
-            # Test features not in response
-            mock_service_api_with_enabled_features.__name__,
-            ServerFeature.ARTIFACT_REGISTRY_SEARCH,
-            False,
-            False,
-        ),
-        (
-            # Test empty features list
-            mock_service_api_with_no_features.__name__,
-            ServerFeature.LARGE_FILENAMES,
-            False,
-            False,
-        ),
-        (
-            # Test server not supporting features
-            mock_service_api_with_error_no_field.__name__,
-            ServerFeature.LARGE_FILENAMES,
-            False,
-            False,
-        ),
-        (
-            # Test other server errors
-            mock_service_api_with_random_error.__name__,
-            ServerFeature.LARGE_FILENAMES,
-            False,
-            True,
-        ),
-    ],
-)
-@pytest.mark.usefixtures("patch_apikey", "patch_prompt")
-def test_server_feature_checks(
-    request,
-    fixture_name,
-    feature: ServerFeature,
-    expected_result,
-    expected_error,
-):
-    """Test check_server_feature with various scenarios."""
-    request.getfixturevalue(fixture_name)
-    api = Api()
-
-    if expected_error:
-        with pytest.raises(Exception, match="Some random error"):
-            api._server_supports(feature)
-    else:
-        result = api._server_supports(feature)
-        assert result == expected_result
 
 
 class TestJWTAuth:

--- a/wandb/apis/public/service_api.py
+++ b/wandb/apis/public/service_api.py
@@ -60,6 +60,10 @@ class ServiceApi:
         return self._settings.base_url
 
     @property
+    def api_key(self) -> str | None:
+        return self._settings.api_key
+
+    @property
     def initialized(self) -> bool:
         """Returns whether the lazy connection to wandb-core has been made.
 

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -2509,7 +2509,6 @@ class Artifact:
             The linked artifact.
         """
         from wandb import Api
-        from wandb.sdk.internal.internal_api import Api as InternalApi
 
         from ._generated import LINK_ARTIFACT_GQL, LinkArtifact, LinkArtifactInput
         from ._validators import ArtifactPath, FullArtifactPath, validate_aliases
@@ -2532,11 +2531,9 @@ class Artifact:
         if (service_api := self._service_api) is None:
             raise RuntimeError("Client not initialized for artifact mutations")
 
-        # FIXME: Find a way to avoid using InternalApi here, due to the perf overhead
-        settings = InternalApi().settings()
-
+        global_settings = wandb_setup.singleton().settings
         target = ArtifactPath.from_str(target_path).with_defaults(
-            project=settings.get("project") or "uncategorized",
+            project=env.get_project(global_settings.project) or "uncategorized",
         )
 
         # Parse the entity (first part of the path) appropriately,
@@ -2544,7 +2541,11 @@ class Artifact:
         if target.is_registry_path():
             # In a Registry linking, the entity is used to fetch the organization of the
             # artifact, therefore the source artifact's entity is passed to the backend
-            org = target.prefix or settings.get("organization") or None
+            org = (
+                target.prefix
+                or env.get_organization(global_settings.organization)
+                or None
+            )
             target.prefix = resolve_org_entity_name(
                 service_api, self.source_entity, org
             )

--- a/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policies/wandb_storage_policy.py
@@ -22,7 +22,6 @@ from wandb.sdk.artifacts.storage_layout import StorageLayout
 from wandb.sdk.artifacts.storage_policies._multipart import KiB, multipart_download
 from wandb.sdk.artifacts.storage_policies.register import WANDB_STORAGE_POLICY
 from wandb.sdk.artifacts.storage_policy import StoragePolicy
-from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.lib.hashutil import b64_to_hex_id
 from wandb.sdk.lib.paths import FilePathStr, URIStr
 
@@ -48,7 +47,6 @@ class WandbStoragePolicy(StoragePolicy):
         self,
         config: StoragePolicyConfig | None = None,
         cache: ArtifactFileCache | None = None,
-        api: InternalApi | None = None,
     ) -> None:
         self._config = StoragePolicyConfig.model_validate(config or {})
 
@@ -56,7 +54,6 @@ class WandbStoragePolicy(StoragePolicy):
         # first time they're needed. Otherwise, at the time of writing, this
         # significantly slows down `Artifact.__init__()`.
         self._maybe_cache = cache
-        self._maybe_api = api
         self._maybe_session: requests.Session | None = None
         self._maybe_handler: MultiHandler | None = None
 
@@ -65,16 +62,6 @@ class WandbStoragePolicy(StoragePolicy):
         if self._maybe_cache is None:
             self._maybe_cache = get_artifact_file_cache()
         return self._maybe_cache
-
-    @property
-    def _api(self) -> InternalApi:
-        if self._maybe_api is None:
-            self._maybe_api = InternalApi()
-        return self._maybe_api
-
-    @_api.setter
-    def _api(self, api: InternalApi) -> None:
-        self._maybe_api = api
 
     @property
     def _session(self) -> requests.Session:
@@ -162,12 +149,13 @@ class WandbStoragePolicy(StoragePolicy):
         if manifest_entry._download_url is None:
             auth = None
             headers: dict[str, str] = {}
+            service_api = artifact._get_service_api()
 
             # For auth, prefer using (in order): auth header, cookies, HTTP Basic Auth
-            if token := self._api._service_api.access_token():
+            if token := service_api.access_token():
                 headers = {"Authorization": f"Bearer {token}"}
             else:
-                auth = ("api", self._api.api_key or "")
+                auth = ("api", service_api.api_key or "")
 
             file_url = self._file_url(artifact, manifest_entry)
             response = self._session.get(
@@ -207,8 +195,8 @@ class WandbStoragePolicy(StoragePolicy):
         return self._handler.load_path(manifest_entry, local)
 
     def _file_url(self, artifact: Artifact, entry: ArtifactManifestEntry) -> str:
-        api = self._api
-        base_url: str = api.settings("base_url")
+        service_api = artifact._get_service_api()
+        base_url = service_api.base_url
 
         layout = self._config.storage_layout or StorageLayout.V1
         region = self._config.storage_region or "default"
@@ -224,7 +212,7 @@ class WandbStoragePolicy(StoragePolicy):
 
         if layout is StorageLayout.V2:
             birth_artifact_id = entry.birth_artifact_id or ""
-            if api._server_supports(
+            if service_api.feature_enabled(
                 pb.ARTIFACT_V2_DOWNLOAD_HANDLER_SUPPORTS_ARTIFACT_ID
             ):
                 artifact_id = artifact.id or ""

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -6,7 +6,6 @@ import concurrent.futures
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.lib.paths import FilePathStr, URIStr
 
 if TYPE_CHECKING:
@@ -19,8 +18,6 @@ _POLICY_REGISTRY: dict[str, type[StoragePolicy]] = {}
 
 
 class StoragePolicy(ABC):
-    _api: InternalApi | None = None
-
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         _POLICY_REGISTRY[cls.name()] = cls

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -166,7 +166,6 @@ class Api:
 
         self._max_cli_version: str | None = None
 
-
     def relocate(self) -> None:
         """Ensure the current api points to the right server."""
         self._service_api = self._new_service_api()

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -23,9 +23,7 @@ from wandb.proto.wandb_api_pb2 import (
     DownloadFileRequest,
     RunQueueOperationRequest,
 )
-from wandb.proto.wandb_internal_pb2 import ServerFeature
 from wandb.sdk import wandb_setup
-from wandb.sdk.internal._generated import SERVER_FEATURES_QUERY_GQL, ServerFeaturesQuery
 from wandb.sdk.lib.hashutil import B64Digest, md5_file_b64
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
@@ -168,7 +166,6 @@ class Api:
 
         self._max_cli_version: str | None = None
 
-        self._server_features_cache: dict[str, bool] | None = None
 
     def relocate(self) -> None:
         """Ensure the current api points to the right server."""
@@ -378,48 +375,6 @@ class Api:
         response = self.execute(mutation, variables=variables)
         result: bool = response["failRunQueueItem"]["success"]
         return result
-
-    def _server_features(self) -> dict[str, bool]:
-        # NOTE: Avoid caching via `@cached_property`, due to undocumented
-        # locking behavior before Python 3.12.
-        # See: https://github.com/python/cpython/issues/87634
-        query = SERVER_FEATURES_QUERY_GQL
-        try:
-            response = self.execute(query)
-        except Exception as e:
-            # Unfortunately we currently have to match on the text of the error message,
-            # as the `gql` client raises `Exception` rather than a more specific error.
-            if 'Cannot query field "features" on type "ServerInfo".' in str(e):
-                self._server_features_cache = {}
-            else:
-                raise
-        else:
-            info = ServerFeaturesQuery.model_validate(response).server_info
-            if info and (feats := info.features):
-                self._server_features_cache = {f.name: f.is_enabled for f in feats if f}
-            else:
-                self._server_features_cache = {}
-        return self._server_features_cache
-
-    def _server_supports(self, feature: int | str) -> bool:
-        """Return whether the current server supports the given feature.
-
-        NOTE: This is deprecated. Outside of this file, please use
-        `ServiceApi.feature_enabled()`. The `ServiceApi` is a sort of
-        replacement to this "internal" `Api` class.
-
-        This also caches the underlying lookup of server feature flags,
-        and it maps {feature_name (str) -> is_enabled (bool)}.
-
-        Good to use for features that have a fallback mechanism for older servers.
-        """
-        # If we're given the protobuf enum value, convert to a string name.
-        # NOTE: We deliberately use names (str) instead of enum values (int)
-        # as the keys here, since:
-        # - the server identifies features by their name, rather than (client-side) enum value
-        # - the defined list of client-side flags may be behind the server-side list of flags
-        key = ServerFeature.Name(feature) if isinstance(feature, int) else feature
-        return self._server_features().get(key) or False
 
     @normalize_exceptions
     def update_run_queue_item_warning(


### PR DESCRIPTION
Description
-----------

`WandbStoragePolicy` built an `InternalApi` for the credentials, base URL and server feature check it needs to download artifact files directly, and `Artifact.link()` built one only to read the default project. The storage policy now takes all three from the artifact's own `ServiceApi`, which is also where its GraphQL requests go, and `Artifact.link()` reads the project from the global settings. `ServiceApi` gains an `api_key` property for the direct download, and `InternalApi` loses its server feature cache.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Existing unit tests.
