### PR TITLE
chore: run sweeps through the public API instead of `InternalApi`

### DIFF
--- a/tests/system_tests/test_sweep/mock_scripts/parent_script_with_term_timeout.py
+++ b/tests/system_tests/test_sweep/mock_scripts/parent_script_with_term_timeout.py
@@ -5,21 +5,15 @@ import sys
 import threading
 import time
 
+import wandb.wandb_agent as wandb_agent
 from wandb.wandb_agent import Agent
 
 child_script = sys.argv[1]
 term_timeout = int(sys.argv[2])
 
-
-class _StubApi:
-    def sweep(self, sweep_id, spec):
-        return None
-
-    def register_agent(self, host, sweep_id=None):
-        return {"id": "agent-1"}
-
-    def agent_heartbeat(self, agent_id, spec, run_status):
-        return []
+wandb_agent._sweep_with_runs = lambda api, sweep_id, spec: None
+wandb_agent._register_agent = lambda api, host, sweep_id=None: {"id": "agent-1"}
+wandb_agent._agent_heartbeat = lambda api, agent_id, spec, run_status: []
 
 
 # Seed agent command queue to run the child script
@@ -35,7 +29,7 @@ command_queue.put(
 )
 
 agent = Agent(
-    _StubApi(),
+    None,
     command_queue,
     sweep_id="sweep-1",
     term_timeout=term_timeout,

--- a/tests/system_tests/test_sweep/test_launch_scheduler.py
+++ b/tests/system_tests/test_sweep/test_launch_scheduler.py
@@ -486,7 +486,10 @@ def test_sweep_scheduler_sweeps_stop_agent_heartbeat(user, monkeypatch):
     def mock_agent_heartbeat(*args, **kwargs):
         return [{"type": "stop"}]
 
-    api.agent_heartbeat = mock_agent_heartbeat
+    monkeypatch.setattr(
+        "wandb.apis.public.sweeps._agent_heartbeat",
+        lambda api, *args, **kwargs: mock_agent_heartbeat(*args, **kwargs),
+    )
 
     def mock_get_run_state(*args, **kwargs):
         if args[2] == "sweep-scheduler":
@@ -525,7 +528,10 @@ def test_sweep_scheduler_sweep_deleted(user, monkeypatch):
     def mock_agent_heartbeat(*args, **kwargs):
         raise SweepNotFoundError("Sweep not found")
 
-    api.agent_heartbeat = mock_agent_heartbeat
+    monkeypatch.setattr(
+        "wandb.apis.public.sweeps._agent_heartbeat",
+        lambda api, *args, **kwargs: mock_agent_heartbeat(*args, **kwargs),
+    )
 
     def mock_get_run_state(*args, **kwargs):
         if args[2] == "sweep-scheduler":
@@ -565,7 +571,10 @@ def test_sweep_scheduler_sweeps_invalid_agent_heartbeat(user, monkeypatch):
     def mock_agent_heartbeat(*args, **kwargs):
         return [{"type": "foo"}]
 
-    api.agent_heartbeat = mock_agent_heartbeat
+    monkeypatch.setattr(
+        "wandb.apis.public.sweeps._agent_heartbeat",
+        lambda api, *args, **kwargs: mock_agent_heartbeat(*args, **kwargs),
+    )
 
     def mock_get_run_state(*args, **kwargs):
         if args[2] == "sweep-scheduler":
@@ -589,10 +598,15 @@ def test_sweep_scheduler_sweeps_invalid_agent_heartbeat(user, monkeypatch):
     assert _scheduler.state == SchedulerState.FAILED
     assert _scheduler.is_alive is False
 
-    def mock_agent_heartbeat(*args, **kwargs):
+    def mock_agent_heartbeat_without_run_id(*args, **kwargs):
         return [{"type": "run"}]  # No run_id should throw error
 
-    api.agent_heartbeat = mock_agent_heartbeat
+    monkeypatch.setattr(
+        "wandb.apis.public.sweeps._agent_heartbeat",
+        lambda api, *args, **kwargs: mock_agent_heartbeat_without_run_id(
+            *args, **kwargs
+        ),
+    )
     api.get_run_state = mock_get_run_state
 
     sweep_id = wandb.sweep(sweep_config, entity=user, project=_project)

--- a/tests/system_tests/test_sweep/test_launch_scheduler.py
+++ b/tests/system_tests/test_sweep/test_launch_scheduler.py
@@ -636,7 +636,7 @@ def test_sweep_scheduler_sweeps_run_and_heartbeat(user, monkeypatch):
 
     api = internal.Api()
     # Mock agent heartbeat stops after 10 heartbeats
-    api.agent_heartbeat = Mock(
+    agent_heartbeat = Mock(
         side_effect=[
             [
                 {
@@ -650,6 +650,7 @@ def test_sweep_scheduler_sweeps_run_and_heartbeat(user, monkeypatch):
         * 10
         + [[{"type": "stop", "run_cap": 7}]]
     )
+    monkeypatch.setattr("wandb.apis.public.sweeps._agent_heartbeat", agent_heartbeat)
 
     def mock_launch_add(*args, **kwargs):
         return Mock(spec=public.QueuedRun)
@@ -687,6 +688,7 @@ def test_sweep_scheduler_sweeps_run_and_heartbeat(user, monkeypatch):
     assert _scheduler.state == SchedulerState.PENDING
     assert _scheduler.is_alive is True
     _scheduler.start()
+    assert agent_heartbeat.call_count == 11
     assert "mock-run-id-1" not in _scheduler._runs
 
 

--- a/tests/system_tests/test_sweep/test_wandb_sweep.py
+++ b/tests/system_tests/test_sweep/test_wandb_sweep.py
@@ -149,6 +149,17 @@ def test_sweep_create(user, upsert_sweep_spy, sweep_config):
     assert upsert_sweep_spy.total_calls == 1
 
 
+def test_sweep_cli_create(user, runner, tmp_path):
+    config_path = tmp_path / "sweep.json"
+    config_path.write_text(json.dumps(SWEEP_CONFIG_GRID))
+
+    result = runner.invoke(cli.sweep, [str(config_path), "--project", "cli-sweep"])
+
+    assert result.exit_code == 0, result.output
+    assert f"/{user}/cli-sweep/sweeps/" in result.output
+    assert f"wandb agent {user}/cli-sweep/" in result.output
+
+
 @pytest.mark.parametrize("sweep_config", VALID_SWEEP_CONFIGS_MINIMAL)
 def test_sweep_entity_project_callable(user, upsert_sweep_spy, sweep_config):
     def sweep_callable():

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 import pathlib
 import tempfile
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 import wandb.errors
@@ -18,36 +18,6 @@ from wandb.sdk.internal.internal_api import Api
 from wandb.sdk.lib import wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 from wandb.sdk.sweeps import SweepNotFoundError
-
-
-def test_agent_heartbeat_with_no_agent_id_fails():
-    a = Api()
-    with pytest.raises(ValueError):
-        a.agent_heartbeat(None, {}, {})
-
-
-def test_agent_heartbeat_raises_sweep_not_found_on_404():
-    """Test that agent_heartbeat raises SweepNotFoundError on 404."""
-    a = Api()
-
-    error_response = apb.ApiErrorResponse(message="not found", http_status=404)
-    error = WandbApiFailedError(error_response.message, error_response)
-
-    with patch.object(a, "execute", side_effect=error):
-        with pytest.raises(SweepNotFoundError):
-            a.agent_heartbeat("test-agent-id", {}, {})
-
-
-def test_agent_heartbeat_returns_empty_on_non_404_error():
-    """Test that non-404 HTTP errors return empty list instead of raising."""
-    a = Api()
-
-    error_response = apb.ApiErrorResponse(message="server error", http_status=500)
-    error = WandbApiFailedError(error_response.message, error_response)
-
-    with patch.object(a, "execute", side_effect=error):
-        result = a.agent_heartbeat("test-agent-id", {}, {})
-        assert result == []
 
 
 def test_get_run_state_invalid_kwargs():

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -17,7 +17,6 @@ from wandb.sdk import wandb_setup
 from wandb.sdk.internal.internal_api import Api
 from wandb.sdk.lib import wbauth
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
-from wandb.sdk.sweeps import SweepNotFoundError
 
 
 def test_get_run_state_invalid_kwargs():

--- a/tests/unit_tests/test_public_api/test_sweeps.py
+++ b/tests/unit_tests/test_public_api/test_sweeps.py
@@ -1,9 +1,13 @@
 import json
+from unittest.mock import Mock
 
 import pytest
-from wandb.apis.public.sweeps import Sweep
+from wandb.apis.public.sweeps import Sweep, _agent_heartbeat
 from wandb.errors import UnsupportedError
+from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.sweeps import SweepNotFoundError
 
 
 def _make_sweep(
@@ -97,3 +101,26 @@ def test_enqueue_run_raises_when_feature_unsupported(mocker):
         sweep.enqueue_run({"lr": {"value": 0.1}})
 
     sweep._service_api.execute_graphql.assert_not_called()
+
+
+def _api_failing_with(http_status: int) -> Mock:
+    api = Mock()
+    response = apb.ApiErrorResponse(message="error", http_status=http_status)
+    api._service_api.execute_graphql.side_effect = WandbApiFailedError(
+        response.message, response
+    )
+    return api
+
+
+def test_agent_heartbeat_with_no_agent_id_fails():
+    with pytest.raises(ValueError):
+        _agent_heartbeat(Mock(), None, {}, {})
+
+
+def test_agent_heartbeat_raises_sweep_not_found_on_404():
+    with pytest.raises(SweepNotFoundError):
+        _agent_heartbeat(_api_failing_with(404), "test-agent-id", {}, {})
+
+
+def test_agent_heartbeat_returns_empty_on_non_404_error():
+    assert _agent_heartbeat(_api_failing_with(500), "test-agent-id", {}, {}) == []

--- a/tests/unit_tests/test_public_api/test_sweeps.py
+++ b/tests/unit_tests/test_public_api/test_sweeps.py
@@ -2,7 +2,12 @@ import json
 from unittest.mock import Mock
 
 import pytest
-from wandb.apis.public.sweeps import Sweep, _agent_heartbeat
+from wandb.apis.public.sweeps import (
+    Sweep,
+    _agent_heartbeat,
+    _sweep_with_runs,
+    _upsert_sweep,
+)
 from wandb.errors import UnsupportedError
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
@@ -124,3 +129,34 @@ def test_agent_heartbeat_raises_sweep_not_found_on_404():
 
 def test_agent_heartbeat_returns_empty_on_non_404_error():
     assert _agent_heartbeat(_api_failing_with(500), "test-agent-id", {}, {}) == []
+
+
+def test_created_sweep_can_be_read_with_same_api(monkeypatch):
+    monkeypatch.delenv("WANDB_ENTITY", raising=False)
+    monkeypatch.delenv("WANDB_PROJECT", raising=False)
+    api = Mock()
+    api.settings = {"entity": None, "project": None}
+    api._service_api.execute_graphql.side_effect = [
+        {
+            "upsertSweep": {
+                "sweep": {
+                    "name": "test-sweep",
+                    "project": {
+                        "name": "uncategorized",
+                        "entity": {"name": "test-entity"},
+                    },
+                }
+            }
+        },
+        {"project": {"sweep": {"runs": {"edges": []}}}},
+    ]
+
+    sweep, _ = _upsert_sweep(api, {"method": "grid", "parameters": {}})
+    _sweep_with_runs(api, sweep["name"], "{}")
+
+    assert api._service_api.execute_graphql.call_args.kwargs["variables"] == {
+        "entity": "test-entity",
+        "project": "uncategorized",
+        "sweep": "test-sweep",
+        "specs": "{}",
+    }

--- a/tests/unit_tests/test_wandb_agent/conftest.py
+++ b/tests/unit_tests/test_wandb_agent/conftest.py
@@ -81,12 +81,28 @@ class WandbAgentTestEnv:
     def mock_api(
         self, *, for_cli: bool = False, agent_id: str = DEFAULT_AGENT_ID
     ) -> mock.MagicMock:
-        """Return a mock InternalApi with agent registration stubbed out."""
+        """Return a mock API with agent registration stubbed out."""
         api = mock.MagicMock()
         api.register_agent.return_value = {"id": agent_id}
         if for_cli:
             api.sweep.return_value = None
+        self.patch_sweep_helpers("wandb.wandb_agent", api)
+        self.patch_sweep_helpers("wandb.agents.pyagent", api)
         return api
+
+    def patch_sweep_helpers(self, module: str, api: mock.MagicMock) -> None:
+        """Route the module's sweep API helpers to the mock API's methods."""
+        self.monkeypatch.setattr(wandb, "Api", lambda *args, **kwargs: api)
+        for helper, method in [
+            ("_sweep_with_runs", api.sweep),
+            ("_register_agent", api.register_agent),
+            ("_agent_heartbeat", api.agent_heartbeat),
+        ]:
+            self.monkeypatch.setattr(
+                f"{module}.{helper}",
+                lambda _api, *args, _method=method, **kwargs: _method(*args, **kwargs),
+                raising=False,
+            )
 
     def patch_cli(self, sweep_id: str | None = None) -> None:
         """Avoid slow queue reads and noisy teardown when unit-testing CLI agents."""
@@ -107,12 +123,7 @@ class WandbAgentTestEnv:
         *,
         mock_finish: bool = True,
     ) -> Iterator[None]:
-        """Apply pyagent env isolation and mock API for an agent run.
-
-        `_run_job` recreates `InternalApi()` after `wandb.teardown()`, so
-        `agent_heartbeat` is patched on the underlying `Api` class rather than
-        only on the constructor return value.
-        """
+        """Apply pyagent env isolation for an agent run."""
         self.monkeypatch.chdir(self.tmp_path)
         self.monkeypatch.setenv(wandb.env.DIR, str(self.tmp_path))
         if mock_finish:
@@ -128,14 +139,7 @@ class WandbAgentTestEnv:
 
         self.monkeypatch.setattr(queue.Queue, "get", fast_queue_get)
 
-        with (
-            mock.patch("wandb.agents.pyagent.InternalApi", return_value=api),
-            mock.patch(
-                "wandb.sdk.internal.internal_api.Api.agent_heartbeat",
-                api.agent_heartbeat,
-            ),
-        ):
-            yield
+        yield
 
     def make_pyagent(
         self,

--- a/tests/unit_tests/test_wandb_agent_signals.py
+++ b/tests/unit_tests/test_wandb_agent_signals.py
@@ -7,6 +7,23 @@ import pytest
 from wandb import wandb_agent
 
 
+@pytest.fixture(autouse=True)
+def _sweep_helpers_call_the_mock_api(monkeypatch):
+    """Route the sweep helpers to the methods of the mock API they receive."""
+    for helper, method in [
+        ("_sweep_with_runs", "sweep"),
+        ("_register_agent", "register_agent"),
+        ("_agent_heartbeat", "agent_heartbeat"),
+    ]:
+        monkeypatch.setattr(
+            wandb_agent,
+            helper,
+            lambda api, *args, _method=method, **kwargs: getattr(api, _method)(
+                *args, **kwargs
+            ),
+        )
+
+
 class _DummyPopen:
     def __init__(self, *args, **kwargs):
         self.stdin = mock.Mock()

--- a/wandb/agents/pyagent.py
+++ b/wandb/agents/pyagent.py
@@ -16,7 +16,7 @@ import traceback
 from typing import Any
 
 import wandb
-from wandb.sdk.internal.internal_api import Api as InternalApi
+from wandb.apis.public.sweeps import _agent_heartbeat, _register_agent
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.lib import config_util
 from wandb.sdk.sweeps import SweepNotFoundError
@@ -95,7 +95,7 @@ class Agent:
         # glob_config = os.path.expanduser('~/.config/wandb/settings')
         # loc_config = 'wandb/settings'
         # files = (glob_config, loc_config)
-        self._api = InternalApi()
+        self._api = wandb.Api()
         self._api_lock = threading.Lock()
         self._agent_id = None
         self._max_initial_failures = wandb.env.get_agent_max_initial_failures(
@@ -117,7 +117,13 @@ class Agent:
 
     def _register(self):
         logger.debug("Agent._register()")
-        agent = self._api.register_agent(socket.gethostname(), sweep_id=self._sweep_id)
+        agent = _register_agent(
+            self._api,
+            socket.gethostname(),
+            sweep_id=self._sweep_id,
+            entity=self._entity,
+            project=self._project,
+        )
         self._agent_id = agent["id"]
         logger.debug(f"agent_id = {self._agent_id}")
 
@@ -129,15 +135,15 @@ class Agent:
         if err:
             wandb.termerror(err)
             return
-        entity = parts.get("entity") or self._entity
-        project = parts.get("project") or self._project
+        self._entity = parts.get("entity") or self._entity
+        self._project = parts.get("project") or self._project
         sweep_id = parts.get("name") or self._sweep_id
         if sweep_id:
             os.environ[wandb.env.SWEEP_ID] = sweep_id
-        if entity:
-            wandb.env.set_entity(entity)
-        if project:
-            wandb.env.set_project(project)
+        if self._entity:
+            wandb.env.set_entity(self._entity)
+        if self._project:
+            wandb.env.set_project(self._project)
         if sweep_id:
             self._sweep_id = sweep_id
         self._register()
@@ -172,7 +178,7 @@ class Agent:
 
         try:
             with self._api_lock:
-                return self._api.agent_heartbeat(self._agent_id, {}, run_status)
+                return _agent_heartbeat(self._api, self._agent_id, {}, run_status)
         except SweepNotFoundError:
             self._sweep_not_found = True
             if self._has_running_thread():
@@ -331,7 +337,7 @@ class Agent:
                 wandb.teardown()
                 # The agent outlives user jobs, but teardown closes the
                 # service-backed API resources used for heartbeats.
-                self._api = InternalApi()
+                self._api = wandb.Api()
 
             wandb.termlog(f"Agent Starting Run: {run_id} with config:")
             for k, v in job.config.items():

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -30,24 +30,32 @@ Note:
 from __future__ import annotations
 
 import json
+import logging
 import urllib
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, ClassVar
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from typing_extensions import override
 
 import wandb
-from wandb import util
+from wandb import env, util
 from wandb.apis import public
 from wandb.apis.attrs import Attrs
+from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import SizedPaginator
-from wandb.errors import Error, UnsupportedError
+from wandb.errors import Error, UnsupportedError, UsageError
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.lib import ipython
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 # Minimum W&B server release that supports filtering sweeps via the `filters`
 # argument on the `sweeps` field.
 _SWEEP_FILTERS_MIN_SERVER_VERSION = "0.81.4"
+
+logger = logging.getLogger(__name__)
+
+SweepState = Literal["RUNNING", "PAUSED", "CANCELED", "FINISHED"]
 
 if TYPE_CHECKING:
     from wandb.apis._generated import GetSweeps
@@ -628,3 +636,450 @@ class Agent(Attrs):
         state = self._attrs.get("state", "Unknown State")
         name = self._attrs.get("id", "Unknown")
         return f"<Agent {name} ({state})>"
+
+
+def _validate_config_and_fill_distribution(config: dict) -> dict:
+    # verify that parameters are well specified.
+    # TODO(dag): deprecate this in favor of jsonschema validation once
+    # apiVersion 2 is released and local controller is integrated with
+    # wandb/client.
+
+    # avoid modifying the original config dict in
+    # case it is reused outside the calling func
+    config = deepcopy(config)
+
+    # explicitly cast to dict in case config was passed as a sweepconfig
+    # sweepconfig does not serialize cleanly to yaml and breaks graphql,
+    # but it is a subclass of dict, so this conversion is clean
+    config = dict(config)
+
+    if "parameters" not in config:
+        # still shows an anaconda warning, but doesn't error
+        return config
+
+    for parameter_name in config["parameters"]:
+        parameter = config["parameters"][parameter_name]
+        if (
+            "min" in parameter
+            and "max" in parameter
+            and "distribution" not in parameter
+        ):
+            if isinstance(parameter["min"], int) and isinstance(parameter["max"], int):
+                parameter["distribution"] = "int_uniform"
+            elif isinstance(parameter["min"], float) and isinstance(
+                parameter["max"], float
+            ):
+                parameter["distribution"] = "uniform"
+            else:
+                raise ValueError(
+                    f"Parameter {parameter_name} is ambiguous, please specify bounds as both floats (for a float_"
+                    "uniform distribution) or ints (for an int_uniform distribution)."
+                )
+    return config
+
+
+@normalize_exceptions
+def _upsert_sweep(
+    api: Api,
+    config: dict,
+    *,
+    controller: str | None = None,
+    launch_scheduler: str | None = None,
+    scheduler: str | None = None,
+    obj_id: str | None = None,
+    project: str | None = None,
+    entity: str | None = None,
+    state: str | None = None,
+    prior_runs: list[str] | None = None,
+    display_name: str | None = None,
+    template_variable_values: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Create or update a sweep.
+
+    Returns the sweep as the server returned it and the config validation
+    warnings. The sweep's project and entity become the process defaults so
+    that agents started afterwards in the same process find the sweep.
+    """
+    import yaml
+
+    project_query = """
+        project {
+            id
+            name
+            entity {
+                id
+                name
+            }
+        }
+    """
+    mutation_str = """
+    mutation UpsertSweep(
+        $id: ID,
+        $config: String,
+        $description: String,
+        $entityName: String,
+        $projectName: String,
+        $controller: JSONString,
+        $scheduler: JSONString,
+        $state: String,
+        $priorRunsFilters: JSONString,
+        $displayName: String,
+    ) {
+        upsertSweep(input: {
+            id: $id,
+            config: $config,
+            description: $description,
+            entityName: $entityName,
+            projectName: $projectName,
+            controller: $controller,
+            scheduler: $scheduler,
+            state: $state,
+            priorRunsFilters: $priorRunsFilters,
+            displayName: $displayName,
+        }) {
+            sweep {
+                name
+                _PROJECT_QUERY_
+            }
+            configValidationWarnings
+        }
+    }
+    """
+    # TODO(jhr): we need protocol versioning to know schema is not supported
+    # for now we will just try both new and old query
+    mutation_5 = (
+        mutation_str.replace(
+            "$controller: JSONString,",
+            "$controller: JSONString,$launchScheduler: JSONString, $templateVariableValues: JSONString,",
+        )
+        .replace(
+            "controller: $controller,",
+            "controller: $controller,launchScheduler: $launchScheduler,templateVariableValues: $templateVariableValues,",
+        )
+        .replace("_PROJECT_QUERY_", project_query)
+    )
+    # launchScheduler was introduced in core v0.14.0
+    mutation_4 = (
+        mutation_str.replace(
+            "$controller: JSONString,",
+            "$controller: JSONString,$launchScheduler: JSONString,",
+        )
+        .replace(
+            "controller: $controller,",
+            "controller: $controller,launchScheduler: $launchScheduler",
+        )
+        .replace("_PROJECT_QUERY_", project_query)
+    )
+
+    # mutation 3 maps to backend that can support CLI version of at least 0.10.31
+    mutation_3 = mutation_str.replace("_PROJECT_QUERY_", project_query)
+    mutation_2 = mutation_str.replace("_PROJECT_QUERY_", project_query).replace(
+        "configValidationWarnings", ""
+    )
+    mutation_1 = mutation_str.replace("_PROJECT_QUERY_", "").replace(
+        "configValidationWarnings", ""
+    )
+
+    # TODO(dag): replace this with a query for protocol versioning
+    mutations = [mutation_5, mutation_4]
+    if launch_scheduler is None:
+        mutations.extend([mutation_3, mutation_2, mutation_1])
+
+    config = _validate_config_and_fill_distribution(config)
+
+    # Silly, but attr-dicts like Easydicts don't serialize correctly to yaml.
+    # This sanitizes them with a round trip pass through json to get a regular dict.
+    class NonOctalStringDumper(yaml.Dumper):
+        """Prevents strings containing non-octal values like "008" and "009" from being converted to numbers in in the yaml string saved as the sweep config."""
+
+        def represent_scalar(self, tag, value, style=None):
+            if (
+                tag == "tag:yaml.org,2002:str"
+                and value.startswith("0")
+                and len(value) > 1
+            ):
+                return super().represent_scalar(tag, value, style="'")
+            return super().represent_scalar(tag, value, style)
+
+    config_str = yaml.dump(json.loads(json.dumps(config)), Dumper=NonOctalStringDumper)
+    filters = None
+    if prior_runs:
+        filters = json.dumps({"$or": [{"name": r} for r in prior_runs]})
+
+    err: Exception | None = None
+    for mutation in mutations:
+        try:
+            variables = {
+                "id": obj_id,
+                "config": config_str,
+                "description": config.get("description"),
+                "entityName": entity or api.settings["entity"],
+                "projectName": project or api.settings["project"],
+                "controller": controller,
+                "launchScheduler": launch_scheduler,
+                "templateVariableValues": json.dumps(template_variable_values),
+                "scheduler": scheduler,
+                "priorRunsFilters": filters,
+                "displayName": display_name,
+            }
+            if state:
+                variables["state"] = state
+
+            response = api._service_api.execute_graphql(mutation, variables=variables)
+        except UsageError:
+            raise
+        except Exception as e:
+            # graphql schema exception is generic
+            err = e
+            continue
+        err = None
+        break
+    if err:
+        raise err
+
+    sweep: dict[str, Any] = response["upsertSweep"]["sweep"]
+    if project_obj := sweep.get("project"):
+        env.set_project(project_obj["name"])
+        if entity_obj := project_obj.get("entity"):
+            env.set_entity(entity_obj["name"])
+
+    return sweep, response["upsertSweep"].get("configValidationWarnings", [])
+
+
+@normalize_exceptions
+def _sweep_with_runs(
+    api: Api,
+    sweep: str,
+    specs: str,
+    *,
+    project: str | None = None,
+    entity: str | None = None,
+) -> dict[str, Any]:
+    """Fetch a sweep with its runs and their sampled history.
+
+    Args:
+        sweep: The sweep to get details for.
+        specs: History specs.
+        project: The project to scope this sweep to.
+        entity: The entity to scope this sweep to.
+    """
+    query = """
+    query SweepWithRuns($entity: String, $project: String, $sweep: String!, $specs: [JSONString!]!) {
+        project(name: $project, entityName: $entity) {
+            sweep(sweepName: $sweep) {
+                id
+                name
+                method
+                state
+                description
+                config
+                createdAt
+                heartbeatAt
+                updatedAt
+                earlyStopJobRunning
+                bestLoss
+                controller
+                scheduler
+                runs {
+                    edges {
+                        node {
+                            name
+                            state
+                            config
+                            exitcode
+                            heartbeatAt
+                            shouldStop
+                            failed
+                            stopped
+                            running
+                            summaryMetrics
+                            sampledHistory(specs: $specs)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    entity = entity or api.settings["entity"]
+    project = project or api.settings["project"]
+    response = api._service_api.execute_graphql(
+        query,
+        variables={
+            "entity": entity,
+            "project": project,
+            "sweep": sweep,
+            "specs": specs,
+        },
+    )
+    if response["project"] is None or response["project"]["sweep"] is None:
+        raise ValueError(f"Sweep {entity}/{project}/{sweep} not found")
+    data: dict[str, Any] = response["project"]["sweep"]
+    if data:
+        data["runs"] = [edge["node"] for edge in data["runs"]["edges"]]
+    return data
+
+
+@normalize_exceptions
+def _register_agent(
+    api: Api,
+    host: str,
+    *,
+    sweep_id: str,
+    project: str | None = None,
+    entity: str | None = None,
+) -> dict[str, Any]:
+    """Register a new sweep agent and return it."""
+    mutation = """
+    mutation CreateAgent(
+        $host: String!
+        $projectName: String,
+        $entityName: String,
+        $sweep: String!
+    ) {
+        createAgent(input: {
+            host: $host,
+            projectName: $projectName,
+            entityName: $entityName,
+            sweep: $sweep,
+        }) {
+            agent {
+                id
+            }
+        }
+    }
+    """
+    response = api._service_api.execute_graphql(
+        mutation,
+        variables={
+            "host": host,
+            "entityName": entity or api.settings["entity"],
+            "projectName": project or api.settings["project"],
+            "sweep": sweep_id,
+        },
+    )
+    return response["createAgent"]["agent"]
+
+
+def _agent_heartbeat(
+    api: Api, agent_id: str, metrics: dict, run_states: dict
+) -> list[dict[str, Any]]:
+    """Notify the server about agent state and receive commands to execute.
+
+    Raises:
+        SweepNotFoundError: If the server returns a 404, indicating the
+            sweep was likely deleted.
+    """
+    from wandb.sdk.sweeps import SweepNotFoundError
+
+    mutation = """
+    mutation Heartbeat(
+        $id: ID!,
+        $metrics: JSONString,
+        $runState: JSONString
+    ) {
+        agentHeartbeat(input: {
+            id: $id,
+            metrics: $metrics,
+            runState: $runState
+        }) {
+            agent {
+                id
+            }
+            commands
+        }
+    }
+    """
+
+    if agent_id is None:
+        raise ValueError("Cannot call heartbeat with an unregistered agent.")
+
+    try:
+        response = api._service_api.execute_graphql(
+            mutation,
+            variables={
+                "id": agent_id,
+                "metrics": json.dumps(metrics),
+                "runState": json.dumps(run_states),
+            },
+            timeout=60,
+        )
+    except WandbApiFailedError as e:
+        if e.response is not None and e.response.http_status == 404:
+            raise SweepNotFoundError(
+                "Sweep not found. The sweep may have been deleted."
+            ) from e
+        logger.exception("Error communicating with W&B.")
+        return []
+    except Exception:
+        logger.exception("Error communicating with W&B.")
+        return []
+    return json.loads(response["agentHeartbeat"]["commands"])
+
+
+def _get_sweep_state(
+    api: Api, sweep: str, *, entity: str | None = None, project: str | None = None
+) -> SweepState:
+    query = """
+        query GetSweepState($entity: String, $project: String, $sweep: String!) {
+            project(name: $project, entityName: $entity) {
+                sweep(sweepName: $sweep) {
+                    state
+                }
+            }
+        }
+        """
+    response = api._service_api.execute_graphql(
+        query,
+        variables={
+            "sweep": sweep,
+            "entity": entity or api.settings["entity"],
+            "project": project or api.settings["project"],
+        },
+    )
+    return response["project"]["sweep"]["state"]
+
+
+def _set_sweep_state(
+    api: Api,
+    sweep: str,
+    state: SweepState,
+    *,
+    entity: str | None = None,
+    project: str | None = None,
+) -> None:
+    assert state in ("RUNNING", "PAUSED", "CANCELED", "FINISHED")
+    s = _sweep_with_runs(api, sweep, "{}", entity=entity, project=project)
+    curr_state = s["state"].upper()
+    if state == "PAUSED" and curr_state not in ("PAUSED", "RUNNING"):
+        raise Exception(f"Cannot pause {curr_state.lower()} sweep.")
+    elif state != "RUNNING" and curr_state not in ("RUNNING", "PAUSED", "PENDING"):
+        raise Exception(f"Sweep already {curr_state.lower()}.")
+    mutation = """
+    mutation UpsertSweep(
+        $id: ID,
+        $state: String,
+        $entityName: String,
+        $projectName: String
+    ) {
+        upsertSweep(input: {
+            id: $id,
+            state: $state,
+            entityName: $entityName,
+            projectName: $projectName
+        }){
+            sweep {
+                name
+            }
+        }
+    }
+    """
+    api._service_api.execute_graphql(
+        mutation,
+        variables={
+            "id": s["id"],
+            "state": state,
+            "entityName": entity or api.settings["entity"],
+            "projectName": project or api.settings["project"],
+        },
+    )

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -839,8 +839,10 @@ def _upsert_sweep(
 
     sweep: dict[str, Any] = response["upsertSweep"]["sweep"]
     if project_obj := sweep.get("project"):
+        api.settings["project"] = project_obj["name"]
         env.set_project(project_obj["name"])
         if entity_obj := project_obj.get("entity"):
+            api.settings["entity"] = entity_obj["name"]
             env.set_entity(entity_obj["name"])
 
     return sweep, response["upsertSweep"].get("configValidationWarnings", [])

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -1065,7 +1065,12 @@ def sweep(
     styled_id = click.style(sweep_id, fg="yellow")
     wandb.termlog(f"{action} sweep with ID: {styled_id}")
 
-    sweep_url = wandb_sweep._get_sweep_url(api, sweep_id)
+    sweep_url = wandb_sweep._get_sweep_url(
+        base_url=api.settings("base_url"),
+        entity=api.settings("entity") or api.default_entity,
+        project=api.settings("project"),
+        sweep_id=sweep_id,
+    )
     if sweep_url:
         styled_url = click.style(sweep_url, underline=True, fg="blue")
         wandb.termlog(f"View sweep at: {styled_url}")
@@ -1334,7 +1339,12 @@ def launch_sweep(
     # Log nicely formatted sweep information
     styled_id = click.style(sweep_id, fg="yellow")
     wandb.termlog(f"{'Resumed' if resume_id else 'Created'} sweep with ID: {styled_id}")
-    sweep_url = wandb_sweep._get_sweep_url(api, sweep_id)
+    sweep_url = wandb_sweep._get_sweep_url(
+        base_url=api.settings("base_url"),
+        entity=api.settings("entity") or api.default_entity,
+        project=api.settings("project"),
+        sweep_id=sweep_id,
+    )
     if sweep_url:
         styled_url = click.style(sweep_url, underline=True, fg="blue")
         wandb.termlog(f"View sweep at: {styled_url}")

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -25,7 +25,6 @@ from wandb.proto.wandb_api_pb2 import (
 )
 from wandb.sdk import wandb_setup
 from wandb.sdk.lib.hashutil import B64Digest, md5_file_b64
-from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 from ..lib import wbauth
 from ..lib.filenames import DIFF_FNAME, METADATA_FNAME
@@ -1530,125 +1529,6 @@ class Api:
         self.download_file(metadata["url"], path)
         return path, True
 
-    @normalize_exceptions
-    def register_agent(
-        self,
-        host: str,
-        sweep_id: str | None = None,
-        project_name: str | None = None,
-        entity: str | None = None,
-    ) -> dict:
-        """Register a new agent.
-
-        Args:
-            host (str): hostname
-            sweep_id (str): sweep id
-            project_name: (str): model that contains sweep
-            entity: (str): entity that contains sweep
-        """
-        mutation = """
-        mutation CreateAgent(
-            $host: String!
-            $projectName: String,
-            $entityName: String,
-            $sweep: String!
-        ) {
-            createAgent(input: {
-                host: $host,
-                projectName: $projectName,
-                entityName: $entityName,
-                sweep: $sweep,
-            }) {
-                agent {
-                    id
-                }
-            }
-        }
-        """
-        if entity is None:
-            entity = self.settings("entity")
-        if project_name is None:
-            project_name = self.settings("project")
-
-        response = self.execute(
-            mutation,
-            variables={
-                "host": host,
-                "entityName": entity,
-                "projectName": project_name,
-                "sweep": sweep_id,
-            },
-        )
-        result: dict = response["createAgent"]["agent"]
-        return result
-
-    def agent_heartbeat(
-        self, agent_id: str, metrics: dict, run_states: dict
-    ) -> list[dict[str, Any]]:
-        """Notify server about agent state, receive commands.
-
-        Args:
-            agent_id (str): agent_id
-            metrics (dict): system metrics
-            run_states (dict): run_id: state mapping
-
-        Returns:
-            list of commands to execute.
-
-        Raises:
-            SweepNotFoundError: If the server returns a 404, indicating the
-                sweep was likely deleted.
-        """
-        from wandb.sdk.sweeps import SweepNotFoundError
-
-        mutation = """
-        mutation Heartbeat(
-            $id: ID!,
-            $metrics: JSONString,
-            $runState: JSONString
-        ) {
-            agentHeartbeat(input: {
-                id: $id,
-                metrics: $metrics,
-                runState: $runState
-            }) {
-                agent {
-                    id
-                }
-                commands
-            }
-        }
-        """
-
-        if agent_id is None:
-            raise ValueError("Cannot call heartbeat with an unregistered agent.")
-
-        try:
-            response = self.execute(
-                mutation,
-                variables={
-                    "id": agent_id,
-                    "metrics": json.dumps(metrics),
-                    "runState": json.dumps(run_states),
-                },
-                timeout=60,
-            )
-        except WandbApiFailedError as e:
-            if e.response is not None and e.response.http_status == 404:
-                raise SweepNotFoundError(
-                    "Sweep not found. The sweep may have been deleted."
-                ) from e
-            logger.exception("Error communicating with W&B.")
-            return []
-        except Exception:
-            logger.exception("Error communicating with W&B.")
-            return []
-        else:
-            result: list[dict[str, Any]] = json.loads(
-                response["agentHeartbeat"]["commands"]
-            )
-            return result
-
     @staticmethod
     def _validate_config_and_fill_distribution(config: dict) -> dict:
         # verify that parameters are well specified.
@@ -1971,17 +1851,6 @@ class Api:
                 "entityName": entity or self.settings("entity"),
                 "projectName": project or self.settings("project"),
             },
-        )
-
-    def stop_sweep(
-        self,
-        sweep: str,
-        entity: str | None = None,
-        project: str | None = None,
-    ) -> None:
-        """Finish the sweep to stop running new runs and let currently running runs finish."""
-        self.set_sweep_state(
-            sweep=sweep, state="FINISHED", entity=entity, project=project
         )
 
     def _flatten_edges(self, response: _Response) -> list[dict]:

--- a/wandb/sdk/launch/sweeps/scheduler.py
+++ b/wandb/sdk/launch/sweeps/scheduler.py
@@ -99,6 +99,7 @@ class Scheduler(ABC):
         import yaml
 
         from wandb.apis.public import Api as PublicApi
+        from wandb.apis.public.sweeps import _sweep_with_runs
 
         self._api = api
         self._public_api = PublicApi()
@@ -116,8 +117,12 @@ class Scheduler(ABC):
 
         # Make sure the provided sweep_id corresponds to a valid sweep
         try:
-            resp = self._api.sweep(
-                sweep_id, "{}", entity=self._entity, project=self._project
+            resp = _sweep_with_runs(
+                self._public_api,
+                sweep_id,
+                "{}",
+                entity=self._entity,
+                project=self._project,
             )
             if resp.get("state") == SchedulerState.CANCELLED.name:
                 self._state = SchedulerState.CANCELLED
@@ -405,15 +410,18 @@ class Scheduler(ABC):
         return bool(self._kwargs.get("image_uri"))
 
     async def _register_agents(self) -> None:
+        from wandb.apis.public.sweeps import _register_agent
+
         tasks = []
-        register_agent = event_loop_thread_exec(self._api.register_agent)
+        register_agent = event_loop_thread_exec(_register_agent)
         for worker_id in range(self._num_workers):
             _logger.debug(f"{LOG_PREFIX}Starting AgentHeartbeat worker ({worker_id})")
             try:
                 worker = register_agent(
+                    self._public_api,
                     f"{socket.gethostname()}-{worker_id}",  # host
                     sweep_id=self._sweep_id,
-                    project_name=self._project,
+                    project=self._project,
                     entity=self._entity,
                 )
                 tasks.append(worker)
@@ -501,9 +509,14 @@ class Scheduler(ABC):
             self.state = SchedulerState.COMPLETED
 
         # check sweep state for completed states, overwrite scheduler state
+        from wandb.apis.public.sweeps import _get_sweep_state
+
         try:
-            sweep_state = self._api.get_sweep_state(
-                self._sweep_id, self._entity, self._project
+            sweep_state = _get_sweep_state(
+                self._public_api,
+                self._sweep_id,
+                entity=self._entity,
+                project=self._project,
             )
         except Exception as e:
             _logger.debug(f"sweep state error: {e}")
@@ -612,9 +625,17 @@ class Scheduler(ABC):
             )
 
     def _set_sweep_state(self, state: str) -> None:
+        from wandb.apis.public.sweeps import _set_sweep_state
+
         wandb.termlog(f"{LOG_PREFIX}Updating sweep state to: {state.lower()}")
         try:
-            self._api.set_sweep_state(sweep=self._sweep_id, state=state)
+            _set_sweep_state(
+                self._public_api,
+                self._sweep_id,
+                state,
+                entity=self._entity,
+                project=self._project,
+            )
         except Exception as e:
             _logger.debug(f"[set_sweep_state] {e}")
 

--- a/wandb/sdk/launch/sweeps/scheduler_sweep.py
+++ b/wandb/sdk/launch/sweeps/scheduler_sweep.py
@@ -71,11 +71,11 @@ class SweepScheduler(Scheduler):
                 _run_states[run_id] = True
 
         _logger.debug(f"Sending states: \n{pf(_run_states)}\n")
+        from wandb.apis.public.sweeps import _agent_heartbeat
+
         try:
-            commands: list[dict[str, Any]] = self._api.agent_heartbeat(
-                agent_id=self._workers[worker_id].agent_id,
-                metrics={},
-                run_states=_run_states,
+            commands = _agent_heartbeat(
+                self._public_api, self._workers[worker_id].agent_id, {}, _run_states
             )
         except SweepNotFoundError:
             wandb.termerror(

--- a/wandb/sdk/wandb_sweep.py
+++ b/wandb/sdk/wandb_sweep.py
@@ -5,31 +5,32 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import wandb
-from wandb import env
+from wandb import env, util
 
 from . import wandb_login
 
 if TYPE_CHECKING:
+    from wandb.apis.public import Api
     from wandb.wandb_controller import _WandbController
 
 
-def _get_sweep_url(api, sweep_id):
-    """Return sweep url if we can figure it out."""
-    if api.api_key:
-        if api.settings("entity") is None:
-            viewer = api.viewer()
-            if viewer.get("entity"):
-                api.set_setting("entity", viewer["entity"])
-        project = api.settings("project")
-        if not project:
-            return
-        if api.settings("entity"):
-            return "{base}/{entity}/{project}/sweeps/{sweepid}".format(
-                base=api.app_url,
-                entity=urllib.parse.quote(api.settings("entity")),
-                project=urllib.parse.quote(project),
-                sweepid=urllib.parse.quote(sweep_id),
-            )
+def _get_sweep_url(api: Api, sweep: dict) -> str | None:
+    """Return the sweep's URL if its entity and project are known."""
+    project = sweep.get("project") or {}
+    entity_name = (
+        (project.get("entity") or {}).get("name")
+        or api.settings["entity"]
+        or api.default_entity
+    )
+    project_name = project.get("name") or api.settings["project"]
+    if not (entity_name and project_name):
+        return None
+    return "{base}/{entity}/{project}/sweeps/{sweepid}".format(
+        base=util.app_url(api.settings["base_url"]),
+        entity=urllib.parse.quote(entity_name),
+        project=urllib.parse.quote(project_name),
+        sweepid=urllib.parse.quote(sweep["name"]),
+    )
 
 
 def sweep(
@@ -68,7 +69,7 @@ def sweep(
     Returns:
       str: A unique identifier for the sweep.
     """
-    from wandb.sdk.internal.internal_api import Api as InternalApi
+    from wandb.apis.public.sweeps import _upsert_sweep
     from wandb.sdk.launch.sweeps.utils import handle_sweep_config_violations
 
     if callable(sweep):
@@ -87,11 +88,12 @@ def sweep(
     # Make sure we are logged in
     if wandb.run is None:
         wandb_login._login(_silent=True)
-    api = InternalApi()
-    sweep_id, warnings = api.upsert_sweep(sweep, prior_runs=prior_runs)
+    api = wandb.Api()
+    sweep_obj, warnings = _upsert_sweep(api, sweep, prior_runs=prior_runs)
     handle_sweep_config_violations(warnings)
+    sweep_id = sweep_obj["name"]
     print("Create sweep with ID:", sweep_id)  # noqa: T201
-    sweep_url = _get_sweep_url(api, sweep_id)
+    sweep_url = _get_sweep_url(api, sweep_obj)
     if sweep_url:
         print("Sweep URL:", sweep_url)  # noqa: T201
     return sweep_id

--- a/wandb/sdk/wandb_sweep.py
+++ b/wandb/sdk/wandb_sweep.py
@@ -10,27 +10,16 @@ from wandb import env, util
 from . import wandb_login
 
 if TYPE_CHECKING:
-    from wandb.apis.public import Api
     from wandb.wandb_controller import _WandbController
 
 
-def _get_sweep_url(api: Api, sweep: dict) -> str | None:
+def _get_sweep_url(
+    *, base_url: str, entity: str | None, project: str | None, sweep_id: str
+) -> str | None:
     """Return the sweep's URL if its entity and project are known."""
-    project = sweep.get("project") or {}
-    entity_name = (
-        (project.get("entity") or {}).get("name")
-        or api.settings["entity"]
-        or api.default_entity
-    )
-    project_name = project.get("name") or api.settings["project"]
-    if not (entity_name and project_name):
+    if not (entity and project):
         return None
-    return "{base}/{entity}/{project}/sweeps/{sweepid}".format(
-        base=util.app_url(api.settings["base_url"]),
-        entity=urllib.parse.quote(entity_name),
-        project=urllib.parse.quote(project_name),
-        sweepid=urllib.parse.quote(sweep["name"]),
-    )
+    return f"{util.app_url(base_url)}/{urllib.parse.quote(entity)}/{urllib.parse.quote(project)}/sweeps/{urllib.parse.quote(sweep_id)}"
 
 
 def sweep(
@@ -93,7 +82,12 @@ def sweep(
     handle_sweep_config_violations(warnings)
     sweep_id = sweep_obj["name"]
     print("Create sweep with ID:", sweep_id)  # noqa: T201
-    sweep_url = _get_sweep_url(api, sweep_obj)
+    sweep_url = _get_sweep_url(
+        base_url=api.settings["base_url"],
+        entity=api.settings["entity"] or api.default_entity,
+        project=api.settings["project"],
+        sweep_id=sweep_id,
+    )
     if sweep_url:
         print("Sweep URL:", sweep_url)  # noqa: T201
     return sweep_id

--- a/wandb/wandb_agent.py
+++ b/wandb/wandb_agent.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import wandb
 from wandb import util
+from wandb.apis.public.sweeps import _agent_heartbeat, _register_agent, _sweep_with_runs
 from wandb.sdk import wandb_login, wandb_setup
 from wandb.sdk.lib import config_util, ipython
 from wandb.sdk.sweeps import SweepNotFoundError
@@ -417,8 +418,6 @@ class Agent:
                     # service process open for all the agent instances and inform_finish when
                     # the run should be marked complete.  This however could require
                     # inform_finish on every run created by this process.
-                    from wandb.sdk.internal.internal_api import Api as InternalApi
-
                     exit_code = 0
                     if isinstance(poll_result, int):
                         exit_code = poll_result
@@ -428,7 +427,7 @@ class Agent:
                     # The agent outlives user jobs, but teardown closes
                     # the service-backed API resources used for the
                     # subsequent heartbeats.
-                    self._api = InternalApi()
+                    self._api = wandb.Api()
 
                     del self._run_processes[run_id]
                     self._last_report_time = None
@@ -457,7 +456,7 @@ class Agent:
         # TODO: catch exceptions, handle errors, show validation warnings, and make more generic
         import yaml
 
-        sweep_obj = self._api.sweep(self._sweep_id, "{}")
+        sweep_obj = _sweep_with_runs(self._api, self._sweep_id, "{}")
         if sweep_obj:
             sweep_yaml = sweep_obj.get("config")
             if sweep_yaml:
@@ -468,7 +467,9 @@ class Agent:
                         self._sweep_command = sweep_command
 
         # TODO: include sweep ID
-        agent = self._api.register_agent(socket.gethostname(), sweep_id=self._sweep_id)
+        agent = _register_agent(
+            self._api, socket.gethostname(), sweep_id=self._sweep_id
+        )
         agent_id = agent["id"]
 
         tier = TerminationTier.NORMAL_EXECUTION
@@ -532,7 +533,7 @@ class Agent:
             return []
 
         try:
-            return self._api.agent_heartbeat(agent_id, {}, run_status)
+            return _agent_heartbeat(self._api, agent_id, {}, run_status)
         except SweepNotFoundError:
             if not self._run_processes:
                 wandb.termerror("Sweep was deleted or agent was not found.")
@@ -628,13 +629,11 @@ class Agent:
 
         if self._function:
             # make sure that each run regenerates setup singleton
-            from wandb.sdk.internal.internal_api import Api as InternalApi
-
             wandb.teardown()
             # The agent outlives user jobs, but teardown closes the
             # service-backed API resources used for the subsequent
             # heartbeats.
-            self._api = InternalApi()
+            self._api = wandb.Api()
             proc = AgentProcess(
                 function=self._function,
                 env=env,
@@ -713,7 +712,6 @@ def run_agent(
     forward_signals=False,
     term_timeout: int | None = None,
 ):
-    from wandb.sdk.internal.internal_api import Api as InternalApi
     from wandb.sdk.launch.sweeps import utils as sweep_utils
 
     parts = dict(entity=entity, project=project, name=sweep_id)
@@ -745,7 +743,7 @@ def run_agent(
     try:
         logger.addHandler(ch)
 
-        api = InternalApi()
+        api = wandb.Api()
         queue = multiprocessing.Queue()
         agent = Agent(
             api,

--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -58,9 +58,10 @@ from collections.abc import Callable
 
 import yaml
 
+import wandb
 from wandb import env
+from wandb.apis.public.sweeps import _sweep_with_runs, _upsert_sweep
 from wandb.sdk import wandb_sweep
-from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.launch.sweeps.utils import (
     handle_sweep_config_violations,
     sweep_config_err_text_from_jsonschema_violations,
@@ -192,7 +193,7 @@ class _WandbController:
             env.set_entity(entity, env=environ)
         if project:
             env.set_project(project, env=environ)
-        self._api = InternalApi(environ=environ)
+        self._api = wandb.Api()
 
         if isinstance(sweep_id_or_config, str):
             self._sweep_id = sweep_id_or_config
@@ -395,11 +396,12 @@ class _WandbController:
         self._create = sweeps.SweepConfig(self._create)
 
         # Create sweep
-        sweep_id, warnings = self._api.upsert_sweep(self._create)
+        sweep_obj, warnings = _upsert_sweep(self._api, self._create)
         handle_sweep_config_violations(warnings)
+        sweep_id = sweep_obj["name"]
 
         print("Create sweep with ID:", sweep_id)  # noqa: T201
-        sweep_url = wandb_sweep._get_sweep_url(self._api, sweep_id)
+        sweep_url = wandb_sweep._get_sweep_url(self._api, sweep_obj)
         if sweep_url:
             print("Sweep URL:", sweep_url)  # noqa: T201
         self._sweep_id = sweep_id
@@ -436,7 +438,7 @@ class _WandbController:
             specs_json = {"keys": k, "samples": 100000}
         specs = json.dumps(specs_json)
         # TODO(jhr): catch exceptions?
-        sweep_obj = self._api.sweep(self._sweep_id, specs)
+        sweep_obj = _sweep_with_runs(self._api, self._sweep_id, specs)
         if not sweep_obj:
             return
         self._sweep_obj = sweep_obj
@@ -480,8 +482,8 @@ class _WandbController:
             return
         sweep_obj_id = self._sweep_obj["id"]
         controller = json.dumps(self._controller)
-        _, warnings = self._api.upsert_sweep(
-            self._sweep_config, controller=controller, obj_id=sweep_obj_id
+        _, warnings = _upsert_sweep(
+            self._api, self._sweep_config, controller=controller, obj_id=sweep_obj_id
         )
         handle_sweep_config_violations(warnings)
         self._controller_prev_step = self._controller.copy()

--- a/wandb/wandb_controller.py
+++ b/wandb/wandb_controller.py
@@ -401,7 +401,12 @@ class _WandbController:
         sweep_id = sweep_obj["name"]
 
         print("Create sweep with ID:", sweep_id)  # noqa: T201
-        sweep_url = wandb_sweep._get_sweep_url(self._api, sweep_obj)
+        sweep_url = wandb_sweep._get_sweep_url(
+            base_url=self._api.settings["base_url"],
+            entity=self._api.settings["entity"] or self._api.default_entity,
+            project=self._api.settings["project"],
+            sweep_id=sweep_id,
+        )
         if sweep_url:
             print("Sweep URL:", sweep_url)  # noqa: T201
         self._sweep_id = sweep_id


### PR DESCRIPTION
Description
-----------

`wandb.sweep()`, `wandb.controller()`, both sweep agents and the launch sweep scheduler used `InternalApi` for the sweep protocol: creating and reading sweeps, registering agents and heartbeating. Those operations now live in `wandb.apis.public.sweeps` as functions over a `wandb.Api`, and the callers hold a `wandb.Api` instead. `InternalApi` loses `register_agent`, `agent_heartbeat` and the unused `stop_sweep`; `sweep`, `upsert_sweep` and the sweep state helpers stay until the CLI and the launch agent move in the next PRs.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

The sweep agent unit tests mock the new helpers; the heartbeat error handling tests moved with the code.
