### PR TITLE
chore: run the non-sweep CLI commands and `wandb verify` on the public API

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -27,6 +27,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Changed
 
+- `wandb status --settings` no longer prints the API key, and `wandb projects` no longer prints project descriptions (@dmitryduev in https://github.com/wandb/wandb/pull/12723)
 - LEET loads long runs faster: while a run's history is loading, the charts are redrawn at most ten times a second instead of after every 1000 records, which made loading time grow with the square of the run's length. A 100-metric run with 400k steps now opens in about 0.3 s instead of 3.8 s (@dmitryduev in https://github.com/wandb/wandb/pull/12734)
 - LEET is faster on long runs: a 50k-step run loads in about half the time, frames render about 30 percent faster, and live chart updates no longer re-render every point (@dmitryduev in https://github.com/wandb/wandb/pull/12535, https://github.com/wandb/wandb/pull/12536, https://github.com/wandb/wandb/pull/12537, https://github.com/wandb/wandb/pull/12538, https://github.com/wandb/wandb/pull/12539)
 - System metrics from Apple Silicon Macs become available about 1.5 seconds sooner after monitoring starts (@dmitryduev in https://github.com/wandb/wandb/pull/12679)

--- a/tests/system_tests/test_core/test_wandb_verify.py
+++ b/tests/system_tests/test_core/test_wandb_verify.py
@@ -2,14 +2,13 @@ import unittest.mock
 
 import wandb
 import wandb.sdk.verify.verify as wandb_verify
-from wandb.sdk.internal.internal_api import Api as InternalApi
 
 
 def test_check_logged_in(user):
-    internal_api = unittest.mock.MagicMock(spec=InternalApi)
-    internal_api.api_key = None
-    assert not wandb_verify.check_logged_in(internal_api, "localhost:8000")
+    api = unittest.mock.MagicMock(spec=wandb.Api)
+    api.api_key = None
+    assert not wandb_verify.check_logged_in(api, "localhost:8000")
 
     run = wandb.init()
-    assert wandb_verify.check_logged_in(InternalApi(), run.settings.base_url)
+    assert wandb_verify.check_logged_in(wandb.Api(), run.settings.base_url)
     run.finish()

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -12,6 +12,8 @@ import wandb
 import wandb.docker
 from wandb import env
 from wandb.cli import cli
+from wandb.sdk import wandb_setup
+from wandb.sdk.lib import config_util
 
 DOCKER_SHA = (
     "wandb/deepo@sha256:"
@@ -26,10 +28,7 @@ def docker(request, mocker, monkeypatch):
     if marker:
         wandb_args.update(marker.kwargs)
     docker = mocker.MagicMock()
-    api_key = mocker.patch(
-        "wandb.sdk.internal.internal_api.Api.api_key", new_callable=mocker.PropertyMock
-    )
-    api_key.return_value = "test"
+    mocker.patch("wandb.cli.cli._configured_api_key", return_value="test")
     monkeypatch.setattr(cli, "_HAS_NVIDIA_DOCKER", True)
     monkeypatch.setattr(cli, "_HAS_DOCKER", True)
     old_call = subprocess.call
@@ -84,6 +83,74 @@ def test_no_project_bad_command(runner):
         result = runner.invoke(cli.cli, ["fsd"])
         assert "No such command" in result.output
         assert result.exit_code == 2
+
+
+@pytest.mark.usefixtures("skip_verify_login")
+def test_projects_with_sagemaker_credentials(runner, monkeypatch, mocker):
+    monkeypatch.setenv("SM_TRAINING_ENV", "{}")
+    with open("secrets.env", "w") as f:
+        f.write(f"WANDB_API_KEY={'sagemaker' * 5}\n")
+    mocker.patch.object(wandb.Api, "projects", return_value=[])
+
+    result = runner.invoke(cli.projects, ["--entity", "example"])
+
+    assert result.exit_code == 0, result.output
+    assert "No projects found for example" in result.output
+
+
+@pytest.fixture
+def cli_run(mocker, patch_apikey):
+    mocker.patch("wandb.sdk.wandb_login._verify_login")
+    run_class = mocker.patch("wandb.apis.public.Run")
+    run = run_class.return_value
+    run.id = "run-id"
+    run.project = "configured-project"
+    run.commit = None
+    run.rawconfig = {}
+    run.metadata = {}
+    file = mocker.Mock()
+    file.name = "file.txt"
+    run.files.side_effect = lambda names=None: [] if names else [file]
+    return run_class
+
+
+@pytest.mark.parametrize("command", [cli.pull, cli.restore])
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("run-id", ("option-entity", "configured-project", "run-id")),
+        ("path-project/run-id", ("option-entity", "path-project", "run-id")),
+        ("path-project:run-id", ("option-entity", "path-project", "run-id")),
+        (
+            "path-entity/path-project/run-id",
+            ("path-entity", "path-project", "run-id"),
+        ),
+    ],
+)
+def test_run_commands_resolve_path(
+    runner, cli_run, monkeypatch, command, path, expected
+):
+    monkeypatch.delenv("WANDB_PROJECT", raising=False)
+    wandb_setup.singleton().settings.project = "configured-project"
+    args = ["--entity", "option-entity", path]
+    if command is cli.restore:
+        args.insert(0, "--no-git")
+
+    result = runner.invoke(command, args)
+
+    assert result.exit_code == 0, result.output
+    assert cli_run.call_args.args[1:] == expected
+
+
+def test_restore_config_can_be_loaded(runner, cli_run, tmp_path, monkeypatch):
+    config = {"epochs": 10, "layers": [32, 64], "nested": {"value": "original"}}
+    cli_run.return_value.rawconfig = {**config, "_wandb": {}, "wandb_version": 1}
+    monkeypatch.setattr(cli, "_get_wandb_dir", lambda: str(tmp_path / "wandb"))
+
+    result = runner.invoke(cli.restore, ["--no-git", "entity/project/run-id"])
+
+    assert result.exit_code == 0, result.output
+    assert config_util.dict_from_config_file(tmp_path / "wandb/config.yaml") == config
 
 
 @pytest.mark.parametrize(
@@ -192,11 +259,7 @@ def test_docker_run_nvidia(runner, docker):
 
 
 def test_docker_run_api_key_not_in_args(runner, docker, mocker, monkeypatch):
-    mocker.patch(
-        "wandb.sdk.internal.internal_api.Api.api_key",
-        new_callable=mocker.PropertyMock,
-        return_value="fake-api-key",
-    )
+    mocker.patch("wandb.cli.cli._configured_api_key", return_value="fake-api-key")
     monkeypatch.setenv("DOCKER_HOST", "tcp://localhost:2375")
 
     result = runner.invoke(cli.docker_run, ["rad"])
@@ -437,11 +500,7 @@ def test_docker_args(runner, docker):
 
 
 def test_docker_api_key_not_in_args(runner, docker, mocker, monkeypatch):
-    mocker.patch(
-        "wandb.sdk.internal.internal_api.Api.api_key",
-        new_callable=mocker.PropertyMock,
-        return_value="fake-api-key",
-    )
+    mocker.patch("wandb.cli.cli._configured_api_key", return_value="fake-api-key")
     monkeypatch.setenv("DOCKER_HOST", "tcp://localhost:2375")
 
     with runner.isolated_filesystem():

--- a/tests/unit_tests/test_internal_api.py
+++ b/tests/unit_tests/test_internal_api.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import base64
-import hashlib
-import os
 import pathlib
-import tempfile
-from unittest.mock import Mock
 
 import pytest
 import wandb.errors
@@ -40,54 +35,6 @@ def test_execute_propagates_service_api_errors(mocker: MockerFixture):
     service_api.execute_graphql.assert_called_once_with(
         "query Viewer { viewer { id } }"
     )
-
-
-@pytest.mark.parametrize(
-    "existing_contents,expect_download",
-    [
-        (None, True),
-        ("outdated contents", True),
-        ("current contents", False),
-    ],
-)
-def test_download_write_file_fetches_iff_file_checksum_mismatched(
-    existing_contents: str | None,
-    expect_download: bool,
-):
-    url = "https://example.com/path/to/file.txt"
-    current_contents = "current contents"
-    with tempfile.TemporaryDirectory() as tmpdir:
-        filepath = os.path.join(tmpdir, "file.txt")
-
-        if existing_contents is not None:
-            with open(filepath, "w") as f:
-                f.write(existing_contents)
-
-        api = Api()
-
-        # Stand in for wandb-core, writing the file a real download would.
-        def fake_download(request):
-            path = request.download_file_request.path
-            with open(path, "w") as f:
-                f.write(current_contents)
-
-        api._service_api.send_api_request = Mock(side_effect=fake_download)
-
-        path, downloaded = api.download_write_file(
-            metadata={
-                "name": filepath,
-                "md5": base64.b64encode(
-                    hashlib.md5(current_contents.encode()).digest()
-                ).decode(),
-                "url": url,
-            },
-            out_dir=tmpdir,
-        )
-
-        assert downloaded == expect_download
-        # Either way, the file on disk holds the current contents afterward.
-        with open(path) as f:
-            assert f.read() == current_contents
 
 
 def test_internal_api_with_no_write_global_config_dir(

--- a/tests/unit_tests/test_lib/test_auth.py
+++ b/tests/unit_tests/test_lib/test_auth.py
@@ -3,7 +3,9 @@ import textwrap
 from unittest.mock import MagicMock
 
 import pytest
-from wandb.errors import AuthenticationError
+from wandb.errors import AuthenticationError, UsageError
+from wandb.sdk import wandb_setup
+from wandb.sdk.lib import wbauth
 from wandb.sdk.lib.wbauth import (
     AuthApiKey,
     AuthIdentityTokenFile,
@@ -189,6 +191,37 @@ def test_reads_netrc(
     mock_wandb_log.assert_logged(
         f"[test] Loaded credentials for https://example.com from {netrc}"
     )
+
+
+@pytest.mark.parametrize("source", ["settings", "environment", "netrc", "identity"])
+def test_settings_credentials_are_a_fallback(monkeypatch, source):
+    settings = wandb_setup.singleton().settings
+    settings.api_key = "settings" * 5
+    expected = settings.api_key
+    if source == "environment":
+        expected = "from_env" * 5
+        monkeypatch.setenv("WANDB_API_KEY", expected)
+    elif source == "netrc":
+        expected = "netrc" * 8
+        wbauth.write_netrc_auth(host=settings.base_url, api_key=expected)
+    elif source == "identity":
+        monkeypatch.setenv("WANDB_IDENTITY_TOKEN_FILE", "identity.jwt")
+
+    auth = authenticate_session(host=settings.base_url, source="test")
+
+    if source == "identity":
+        assert isinstance(auth, AuthIdentityTokenFile)
+    else:
+        assert isinstance(auth, AuthApiKey)
+        assert auth.api_key == expected
+
+
+def test_settings_credentials_are_scoped_to_host():
+    settings = wandb_setup.singleton().settings
+    settings.api_key = "settings" * 5
+
+    with pytest.raises(UsageError, match="No API key configured"):
+        authenticate_session(host="https://other.invalid", source="test")
 
 
 def test_jwt_bypasses_validation():

--- a/tests/unit_tests/test_wandb_verify.py
+++ b/tests/unit_tests/test_wandb_verify.py
@@ -83,15 +83,14 @@ def test_check_large_post_reports_core_413(monkeypatch, capsys):
 
 def test_check_wandb_version(capsys):
     api = unittest.mock.Mock()
-    api.viewer_server_info.return_value = (
-        None,
-        {
+    api._service_api.execute_graphql.return_value = {
+        "serverInfo": {
             "cliVersionInfo": {
                 "min_cli_version": "0.10.0",
                 "max_cli_version": "1.0.0",
             }
-        },
-    )
+        }
+    }
 
     with unittest.mock.patch.object(wandb, "__version__", "0.0.1"):
         wandb_verify.check_wandb_version(api)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import shlex
 import shutil
 import subprocess
@@ -24,7 +25,7 @@ from click.exceptions import ClickException
 import wandb
 import wandb.errors
 import wandb.sdk.verify.verify as wandb_verify
-from wandb import Config, Error, env, util, wandb_agent
+from wandb import Error, env, util, wandb_agent
 from wandb.analytics import get_telemetry_recorder
 from wandb.apis import PublicApi
 from wandb.apis.public.sweeps import _sweep_with_runs, _upsert_sweep
@@ -40,7 +41,10 @@ from wandb.sdk.launch.api import LaunchApi
 from wandb.sdk.launch.errors import ExecutionError, LaunchError
 from wandb.sdk.launch.sweeps import utils as sweep_utils
 from wandb.sdk.launch.sweeps.scheduler import Scheduler
-from wandb.sdk.lib import filesystem, settings_file
+from wandb.sdk.lib import config_util, filesystem, settings_file, wbauth
+from wandb.sdk.lib.filenames import DIFF_FNAME
+from wandb.sdk.lib.hashutil import md5_file_b64
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 from wandb.sdk.sweeps import SweepNotFoundError
 
 from .beta import beta
@@ -193,17 +197,38 @@ def _get_cling_api(reset=None):
     return _api
 
 
-def prompt_for_project(ctx, entity):
+def _configured_api_key() -> str | None:
+    """The API key from the environment or netrc, without prompting for one."""
+    settings = wandb_setup.singleton().settings
+    return settings.api_key or wbauth.read_netrc_auth(host=settings.base_url)
+
+
+def _run_file_text(api_run, name: str) -> str | None:
+    """Return the contents of a run's file, or None if the run has no such file."""
+    for file in api_run.files(names=[name]):
+        if file.updated_at:
+            with (
+                tempfile.TemporaryDirectory() as tmpdir,
+                file.download(root=tmpdir) as f,
+            ):
+                return f.read()
+    return None
+
+
+def _format_project(project: str) -> str:
+    return re.sub(r"\W+", "-", project.lower()).strip("-_")
+
+
+def prompt_for_project(ctx, entity, api):
     """Ask the user for a project, creating one if necessary."""
     result = ctx.invoke(projects, entity=entity, display=False)
-    api = _get_cling_api()
     try:
         if len(result) == 0:
             project = click.prompt("Enter a name for your first project")
-            # description = editor()
-            project = api.upsert_project(project, entity=entity)["name"]
+            project = _format_project(project)
+            api.create_project(project, entity)
         else:
-            project_names = [project["name"] for project in result] + ["Create New"]
+            project_names = [project.name for project in result] + ["Create New"]
             wandb.termlog("Which project should we use?")
             result = util.prompt_choices(project_names)
             if result:
@@ -213,12 +238,11 @@ def prompt_for_project(ctx, entity):
             # TODO: check with the server if the project exists
             if project == "Create New":
                 project = click.prompt(
-                    "Enter a name for your new project", value_proc=api.format_project
+                    "Enter a name for your new project", value_proc=_format_project
                 )
-                # description = editor()
-                project = api.upsert_project(project, entity=entity)["name"]
+                api.create_project(project, entity)
 
-    except wandb.errors.CommError as e:
+    except (wandb.Error, WandbApiFailedError) as e:
         raise ClickException(str(e))
 
     return project
@@ -255,8 +279,9 @@ def cli(ctx):
 @display_error
 def projects(entity, display=True):
     """List projects for the current entity."""
-    api = _get_cling_api()
-    projects = api.list_projects(entity=entity)
+    api = wandb.Api()
+    entity = entity or api.settings["entity"] or api.default_entity
+    projects = api.projects(entity)
     if len(projects) == 0:
         message = f"No projects found for {entity}"
     else:
@@ -264,15 +289,7 @@ def projects(entity, display=True):
     if display:
         click.echo(click.style(message, bold=True))
         for project in projects:
-            click.echo(
-                "".join(
-                    (
-                        click.style(project["name"], fg="blue", bold=True),
-                        " - ",
-                        str(project["description"] or "").split("\n")[0],
-                    )
-                )
-            )
+            click.echo(click.style(project.name, fg="blue", bold=True))
     return projects
 
 
@@ -469,44 +486,11 @@ def init(ctx, project, entity, reset, mode):
         click.echo(
             click.style("Let's setup this directory for W&B!", fg="green", bold=True)
         )
-    api = _get_cling_api()
-    if api.api_key is None:
-        ctx.invoke(login)
-        api = _get_cling_api(reset=True)
+    api = wandb.Api()
+    viewer = api.viewer
 
-    viewer = api.viewer()
-
-    # Viewer can be `None` in case your API information became invalid, or
-    # in testing if you switch hosts.
-    if not viewer:
-        click.echo(
-            click.style(
-                "Your login information seems to be invalid: can you log in again please?",
-                fg="red",
-                bold=True,
-            )
-        )
-        ctx.invoke(login)
-        api = _get_cling_api(reset=True)
-
-    # This shouldn't happen.
-    viewer = api.viewer()
-    if not viewer:
-        click.echo(
-            click.style(
-                "We're sorry, there was a problem logging you in. "
-                "Please send us a note at support@wandb.com and tell us how this happened.",
-                fg="red",
-                bold=True,
-            )
-        )
-        sys.exit(1)
-
-    # At this point we should be logged in successfully.
-    if len(viewer["teams"]["edges"]) > 1:
-        team_names = [e["node"]["name"] for e in viewer["teams"]["edges"]] + [
-            "Manual entry"
-        ]
+    if len(viewer.teams) > 1:
+        team_names = viewer.teams + ["Manual entry"]
         wandb.termlog(
             "Which team should we use?",
         )
@@ -519,13 +503,11 @@ def init(ctx, project, entity, reset, mode):
         if entity == "Manual Entry":
             entity = click.prompt("Enter the name of the team you want to use")
     else:
-        entity = viewer.get("entity") or click.prompt(
-            "What username or team should we use?"
-        )
+        entity = viewer.entity or click.prompt("What username or team should we use?")
 
     # TODO: this error handling sucks and the output isn't pretty
     try:
-        project = prompt_for_project(ctx, entity)
+        project = prompt_for_project(ctx, entity, api)
     except ClickWandbException:
         raise ClickException(f"Could not find team: {entity}")
 
@@ -2316,7 +2298,7 @@ def docker_run(ctx, docker_run_args):
     """
     import wandb.docker
 
-    api = InternalApi()
+    api_key = _configured_api_key()
     args = list(docker_run_args)
     if len(args) > 0 and args[0] == "run":
         args.pop(0)
@@ -2335,9 +2317,9 @@ def docker_run(ctx, docker_run_args):
             "Couldn't detect image argument, running command without the WANDB_DOCKER env variable"
         )
     env = dict(os.environ)
-    if api.api_key:
+    if api_key:
         args = ["-e", "WANDB_API_KEY"] + args
-        env["WANDB_API_KEY"] = api.api_key
+        env["WANDB_API_KEY"] = api_key
     else:
         wandb.termlog(
             "Not logged in, run `wandb login` from the host machine to enable result logging"
@@ -2419,7 +2401,7 @@ def docker(
 
         $ wandb docker wandb/deepo:keras-gpu --no-tty --cmd "python train.py"
     """
-    api = InternalApi()
+    api_key = _configured_api_key()
     if not _HAS_DOCKER:
         raise ClickException("Docker not installed, install it from https://docker.com")
 
@@ -2475,9 +2457,9 @@ def docker(
         #  TODO: We should default to the working directory if defined
         command.extend(["-v", cwd + ":" + dir, "-w", dir])
     env = dict(os.environ)
-    if api.api_key:
+    if api_key:
         command.extend(["-e", "WANDB_API_KEY"])
-        env["WANDB_API_KEY"] = api.api_key
+        env["WANDB_API_KEY"] = api_key
     else:
         wandb.termlog(
             "Couldn't find WANDB_API_KEY, run `wandb login` to enable streaming metrics"
@@ -2589,7 +2571,7 @@ def start(ctx, port, env, daemon, upgrade, edge):
 
         $ wandb server start --no-daemon
     """
-    api = InternalApi()
+    api_key = _configured_api_key()
     if not _HAS_DOCKER:
         raise ClickException("Docker not installed, install it from https://docker.com")
 
@@ -2665,7 +2647,7 @@ def start(ctx, port, env, daemon, upgrade, edge):
         else:
             wandb.termlog(f"W&B server started at http://localhost:{port} \U0001f680")
             wandb.termlog("You can stop the server by running `wandb server stop`")
-            if not api.api_key:
+            if not api_key:
                 # Let the server start before potentially launching a browser
                 time.sleep(2)
                 ctx.invoke(login, host=host)
@@ -3006,19 +2988,25 @@ def pull(run, project, entity):
 
         $ wandb pull -p foobar -e team-awesome abcd1234
     """
-    api = InternalApi()
-    project, run = api.parse_slug(run, project=project)
-    urls = api.download_urls(project, run=run, entity=entity)
-    if len(urls) == 0:
+    api = wandb.Api(
+        overrides={
+            key: value
+            for key, value in {"project": project, "entity": entity}.items()
+            if value is not None
+        }
+    )
+    api_run = api.run(run)
+    files = api_run.files()
+    if len(files) == 0:
         raise ClickException("Run has no files")
-    click.echo(f"Downloading: {click.style(project, bold=True)}/{run}")
+    click.echo(f"Downloading: {click.style(api_run.project, bold=True)}/{api_run.id}")
 
-    for name in urls:
-        if api.file_current(name, urls[name]["md5"]):
-            click.echo(f"File {name} is up to date")
+    for file in files:
+        if os.path.isfile(file.name) and md5_file_b64(file.name) == file.md5:
+            click.echo(f"File {file.name} is up to date")
         else:
-            api.download_file(urls[name]["url"], name)
-            click.echo(f"File {name}")
+            file.download(replace=True)
+            click.echo(f"File {file.name}")
 
 
 @cli.command(context_settings=CONTEXT)
@@ -3101,26 +3089,25 @@ def restore(ctx, run, no_git, branch, project, entity):
     """
     from wandb.sdk.lib.gitlib import GitRepo
 
-    api = _get_cling_api()
-    if ":" in run:
-        if "/" in run:
-            entity, rest = run.split("/", 1)
-        else:
-            rest = run
-        project, run = rest.split(":", 1)
-    elif run.count("/") > 1:
-        entity, run = run.split("/", 1)
-
-    project, run = api.parse_slug(run, project=project)
-    commit, json_config, patch_content, metadata = api.run_config(
-        project, run=run, entity=entity
+    api = wandb.Api(
+        overrides={
+            key: value
+            for key, value in {"project": project, "entity": entity}.items()
+            if value is not None
+        }
     )
+    api_run = api.run(run)
+    project, run = api_run.project, api_run.id
+    commit = api_run.commit
+    json_config = api_run.rawconfig
+    patch_content = _run_file_text(api_run, DIFF_FNAME)
+    metadata = api_run.metadata or {}
     repo = metadata.get("git", {}).get("repo")
     image = metadata.get("docker")
     restore_message = f"""`wandb restore` needs to be run from the same git repository as the original run.
 Run `git clone {repo}` and restore from there or pass the --no-git flag."""
 
-    git = GitRepo(remote=api.settings("git_remote"))
+    git = GitRepo(remote=wandb_setup.singleton().settings.git_remote)
 
     if no_git:
         commit = None
@@ -3138,19 +3125,19 @@ Run `git clone {repo}` and restore from there or pass the --no-git flag."""
         if not git.has_commit(commit):
             wandb.termlog(f"Couldn't find original commit: {commit}")
             commit = None
-            files = api.download_urls(project, run=run, entity=entity)
-            for filename in files:
-                if filename.startswith("upstream_diff_") and filename.endswith(
-                    ".patch"
-                ):
-                    commit = filename[len("upstream_diff_") : -len(".patch")]
+            upstream_patch = None
+            for file in api_run.files():
+                name = file.name
+                if name.startswith("upstream_diff_") and name.endswith(".patch"):
+                    commit = name[len("upstream_diff_") : -len(".patch")]
                     if git.has_commit(commit):
+                        upstream_patch = file
                         break
-                    commit = None
 
-            if commit:
+            if upstream_patch:
                 wandb.termlog(f"Falling back to upstream commit: {commit}")
-                patch_path, _ = api.download_write_file(files[filename])
+                with upstream_patch.download(root=_get_wandb_dir(), replace=True) as f:
+                    patch_path = f.name
             else:
                 raise ClickException(restore_message)
         else:
@@ -3192,23 +3179,15 @@ Run `git clone {repo}` and restore from there or pass the --no-git flag."""
                 )
 
     wandb_dir = _get_wandb_dir()
-    filesystem.mkdir_exists_ok(wandb_dir)
     config_path = os.path.join(wandb_dir, "config.yaml")
-    config = Config()
-    for k, v in json_config.items():
-        if k not in ("_wandb", "wandb_version"):
-            config[k] = v
-    s = b"wandb_version: 1"
-    s += b"\n\n" + yaml.dump(
-        config._as_dict(),
-        Dumper=yaml.SafeDumper,
-        default_flow_style=False,
-        allow_unicode=True,
-        encoding="utf-8",
+    config_util.save_config_file_from_dict(
+        config_path,
+        {
+            key: {"value": value}
+            for key, value in json_config.items()
+            if key not in ("_wandb", "wandb_version")
+        },
     )
-    s = s.decode("utf-8")
-    with open(config_path, "w") as f:
-        f.write(s)
 
     wandb.termlog(f"Restored config variables to {config_path}")
     if image:
@@ -3313,10 +3292,21 @@ def status(settings):
 
         $ wandb status
     """
-    api = _get_cling_api()
     if settings:
         click.echo(click.style("Current Settings", bold=True))
-        settings = api.settings()
+        global_settings = wandb_setup.singleton().settings
+        settings = {
+            key: getattr(global_settings, key)
+            for key in (
+                "base_url",
+                "entity",
+                "project",
+                "organization",
+                "git_remote",
+                "ignore_globs",
+                "root_dir",
+            )
+        }
         click.echo(
             json.dumps(settings, sort_keys=True, indent=2, separators=(",", ": "))
         )
@@ -3422,13 +3412,9 @@ def verify(host):
     os.environ["WANDB_SILENT"] = "true"
     os.environ["WANDB_PROJECT"] = "verify"
     settings = wandb_setup.singleton().settings
-    reinit = False
     if host is None:
         host = settings.base_url
         wandb.termlog(f"Default host selected: {host}")
-    # if the given host does not match the default host, re-run init
-    elif host != settings.base_url:
-        reinit = True
 
     tmp_dir = tempfile.mkdtemp()
     wandb.termlog(
@@ -3437,7 +3423,7 @@ def verify(host):
     os.chdir(tmp_dir)
     os.environ["WANDB_BASE_URL"] = host
     wandb.login(host=host)
-    api = _get_cling_api(reset=reinit)
+    api = wandb.Api()
     if not wandb_verify.check_host(host):
         sys.exit(1)
     if not wandb_verify.check_logged_in(api, host):

--- a/wandb/sdk/internal/internal_api.py
+++ b/wandb/sdk/internal/internal_api.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
-import tempfile
 from collections.abc import Mapping, MutableMapping
 from copy import deepcopy
 from pathlib import Path
@@ -14,14 +12,11 @@ import wandb
 from wandb import env
 from wandb.analytics import TelemetryRecorder, get_telemetry_recorder
 from wandb.apis.normalize import normalize_exceptions
-from wandb.errors import AuthenticationError, CommError, UsageError
+from wandb.errors import AuthenticationError, UsageError
 from wandb.integration.sagemaker import parse_sm_secrets
-from wandb.proto.wandb_api_pb2 import ApiRequest, DownloadFileRequest
 from wandb.sdk import wandb_setup
-from wandb.sdk.lib.hashutil import B64Digest, md5_file_b64
 
 from ..lib import wbauth
-from ..lib.filenames import DIFF_FNAME, METADATA_FNAME
 
 logger = logging.getLogger(__name__)
 
@@ -155,21 +150,12 @@ class Api:
         self._service_api = self._new_service_api()
         self._telemetry_recorder = telemetry_recorder or get_telemetry_recorder()
 
-        self._max_cli_version: str | None = None
-
     def relocate(self) -> None:
         """Ensure the current api points to the right server."""
         self._service_api = self._new_service_api()
 
     def execute(self, *args: Any, **kwargs: Any) -> _Response:
         return self._service_api.execute_graphql(*args, **kwargs)  # type: ignore[return-value]
-
-    @normalize_exceptions
-    def download_file(self, url: str, path: str) -> None:
-        """Download the file at `url` to `path` via wandb-core's file transfer subsystem."""
-        self._service_api.send_api_request(
-            ApiRequest(download_file_request=DownloadFileRequest(url=url, path=path))
-        )
 
     @property
     def request_auth(self) -> tuple[str, str] | None:
@@ -224,14 +210,6 @@ class Api:
     @property
     def api_url(self) -> str:
         return self.settings("base_url")  # type: ignore
-
-    @property
-    def app_url(self) -> str:
-        return wandb.util.app_url(self.api_url)
-
-    @property
-    def default_entity(self) -> str:
-        return self.viewer().get("entity")  # type: ignore
 
     @overload
     def settings(self, key: None = None) -> dict[str, Any]: ...
@@ -303,154 +281,6 @@ class Api:
             env.set_project(value, env=self._environ)
         elif key == "base_url":
             self.relocate()
-
-    def parse_slug(
-        self, slug: str, project: str | None = None, run: str | None = None
-    ) -> tuple[str, str]:
-        """Parse a slug into a project and run.
-
-        Args:
-            slug (str): The slug to parse
-            project (str, optional): The project to use, if not provided it will be
-            inferred from the slug
-            run (str, optional): The run to use, if not provided it will be inferred
-            from the slug
-
-        Returns:
-            A dict with the project and run
-        """
-        if slug and "/" in slug:
-            parts = slug.split("/")
-            project = parts[0]
-            run = parts[1]
-        else:
-            project = project or self.settings().get("project")
-            if project is None:
-                raise CommError("No default project configured.")
-            run = run or slug or env.get_run(env=self._environ)
-            assert run, "run must be specified"
-        return project, run
-
-    @normalize_exceptions
-    def viewer(self) -> dict[str, Any]:
-        query = """
-        query Viewer{
-            viewer {
-                id
-                entity
-                username
-                flags
-                teams {
-                    edges {
-                        node {
-                            name
-                        }
-                    }
-                }
-            }
-        }
-        """
-        res = self.execute(query)
-        return res.get("viewer") or {}
-
-    @normalize_exceptions
-    def max_cli_version(self) -> str | None:
-        if self._max_cli_version is not None:
-            return self._max_cli_version
-
-        _, server_info = self.viewer_server_info()
-        self._max_cli_version = server_info.get("cliVersionInfo", {}).get(
-            "max_cli_version"
-        )
-        return self._max_cli_version
-
-    @normalize_exceptions
-    def viewer_server_info(self) -> tuple[dict[str, Any], dict[str, Any]]:
-        query = """
-        query Viewer{
-            viewer {
-                id
-                entity
-                username
-                email
-                flags
-                teams {
-                    edges {
-                        node {
-                            name
-                        }
-                    }
-                }
-            }
-            serverInfo {
-                cliVersionInfo
-                latestLocalVersionInfo {
-                    outOfDate
-                    latestVersionString
-                    versionOnThisInstanceString
-                }
-            }
-        }
-        """
-        res = self.execute(query)
-        return res.get("viewer") or {}, res.get("serverInfo") or {}
-
-    @normalize_exceptions
-    def list_projects(self, entity: str | None = None) -> list[dict[str, str]]:
-        """List projects in W&B scoped by entity.
-
-        Args:
-            entity (str, optional): The entity to scope this project to.
-
-        Returns:
-                [{"id","name","description"}]
-        """
-        query = """
-        query EntityProjects($entity: String) {
-            models(first: 10, entityName: $entity) {
-                edges {
-                    node {
-                        id
-                        name
-                        description
-                    }
-                }
-            }
-        }
-        """
-        project_list: list[dict[str, str]] = self._flatten_edges(
-            self.execute(
-                query, variables={"entity": entity or self.settings("entity")}
-            )["models"]
-        )
-        return project_list
-
-    @normalize_exceptions
-    def project(self, project: str, entity: str | None = None) -> _Response:
-        """Retrieve project.
-
-        Args:
-            project (str): The project to get details for
-            entity (str, optional): The entity to scope this project to.
-
-        Returns:
-                [{"id","name","repo","dockerImage","description"}]
-        """
-        query = """
-        query ProjectDetails($entity: String, $project: String) {
-            model(name: $project, entityName: $entity) {
-                id
-                name
-                repo
-                dockerImage
-                description
-            }
-        }
-        """
-        response: _Response = self.execute(
-            query, variables={"entity": entity, "project": project}
-        )["model"]
-        return response
 
     @normalize_exceptions
     def sweep(
@@ -526,211 +356,6 @@ class Api:
         if data:
             data["runs"] = self._flatten_edges(data["runs"])
         return data
-
-    @normalize_exceptions
-    def run_config(
-        self, project: str, run: str | None = None, entity: str | None = None
-    ) -> tuple[str, dict[str, Any], str | None, dict[str, Any]]:
-        """Get the relevant configs for a run.
-
-        Args:
-            project (str): The project to download, (can include bucket)
-            run (str, optional): The run to download
-            entity (str, optional): The entity to scope this project to.
-        """
-        query = """
-        query RunConfigs(
-            $name: String!,
-            $entity: String,
-            $run: String!,
-            $pattern: String!,
-            $includeConfig: Boolean!,
-        ) {
-            model(name: $name, entityName: $entity) {
-                bucket(name: $run) {
-                    config @include(if: $includeConfig)
-                    commit @include(if: $includeConfig)
-                    files(pattern: $pattern) {
-                        pageInfo {
-                            hasNextPage
-                            endCursor
-                        }
-                        edges {
-                            node {
-                                name
-                                directUrl
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        """
-
-        variables = {
-            "name": project,
-            "run": run,
-            "entity": entity,
-            "includeConfig": True,
-        }
-
-        commit: str = ""
-        config: dict[str, Any] = {}
-        patch: str | None = None
-        metadata: dict[str, Any] = {}
-
-        # If we use the `names` parameter on the `files` node, then the server
-        # will helpfully give us and 'open' file handle to the files that don't
-        # exist. This is so that we can upload data to it. However, in this
-        # case, we just want to download that file and not upload to it, so
-        # let's instead query for the files that do exist using `pattern`
-        # (with no wildcards).
-        #
-        # Unfortunately we're unable to construct a single pattern that matches
-        # our 2 files, we would need something like regex for that.
-        with tempfile.TemporaryDirectory() as tmpdir:
-            for filename in [DIFF_FNAME, METADATA_FNAME]:
-                variables["pattern"] = filename
-                response = self.execute(query, variables=variables)
-                if response["model"] is None:
-                    raise CommError(f"Run {entity}/{project}/{run} not found")
-                run_obj: dict = response["model"]["bucket"]
-                # we only need to fetch this config once
-                if variables["includeConfig"]:
-                    commit = run_obj["commit"]
-                    config = json.loads(run_obj["config"] or "{}")
-                    variables["includeConfig"] = False
-                if run_obj["files"] is not None:
-                    for file_edge in run_obj["files"]["edges"]:
-                        name = file_edge["node"]["name"]
-                        url = file_edge["node"]["directUrl"]
-                        path = Path(tmpdir, name)
-                        self.download_file(url, str(path))
-                        if name == METADATA_FNAME:
-                            with path.open(encoding="utf-8") as file:
-                                metadata = json.load(file)
-                        elif name == DIFF_FNAME:
-                            patch = path.read_text(encoding="utf-8")
-
-        return commit, config, patch, metadata
-
-    def format_project(self, project: str) -> str:
-        return re.sub(r"\W+", "-", project.lower()).strip("-_")
-
-    @normalize_exceptions
-    def upsert_project(
-        self,
-        project: str,
-        id: str | None = None,
-        description: str | None = None,
-        entity: str | None = None,
-    ) -> dict[str, Any]:
-        """Create a new project.
-
-        Args:
-            project (str): The project to create
-            description (str, optional): A description of this project
-            entity (str, optional): The entity to scope this project to.
-        """
-        mutation = """
-        mutation UpsertModel($name: String!, $id: String, $entity: String!, $description: String, $repo: String)  {
-            upsertModel(input: { id: $id, name: $name, entityName: $entity, description: $description, repo: $repo }) {
-                model {
-                    name
-                    description
-                }
-            }
-        }
-        """
-        response = self.execute(
-            mutation,
-            variables={
-                "name": self.format_project(project),
-                "entity": entity or self.settings("entity"),
-                "description": description,
-                "id": id,
-            },
-        )
-        result: dict[str, Any] = response["upsertModel"]["model"]
-        return result
-
-    @normalize_exceptions
-    def download_urls(
-        self,
-        project: str,
-        run: str | None = None,
-        entity: str | None = None,
-    ) -> dict[str, dict[str, str]]:
-        """Generate download urls.
-
-        Args:
-            project (str): The project to download
-            run (str): The run to upload to
-            entity (str, optional): The entity to scope this project to.  Defaults to wandb models
-
-        Returns:
-            A dict of extensions and urls
-
-                {
-                    'weights.h5': { "url": "https://weights.url", "updatedAt": '2013-04-26T22:22:23.832Z', 'md5': 'mZFLkyvTelC5g8XnyQrpOw==' },
-                    'model.json': { "url": "https://model.url", "updatedAt": '2013-04-26T22:22:23.832Z', 'md5': 'mZFLkyvTelC5g8XnyQrpOw==' }
-                }
-        """
-        query = """
-        query RunDownloadUrls($name: String!, $entity: String, $run: String!)  {
-            model(name: $name, entityName: $entity) {
-                bucket(name: $run) {
-                    files {
-                        edges {
-                            node {
-                                name
-                                url
-                                md5
-                                updatedAt
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        """
-        assert run, "run must be specified"
-        entity = entity or self.settings("entity")
-        query_result = self.execute(
-            query,
-            variables={
-                "name": project,
-                "run": run,
-                "entity": entity,
-            },
-        )
-        if query_result["model"] is None:
-            raise CommError(f"Run does not exist {entity}/{project}/{run}.")
-        files = self._flatten_edges(query_result["model"]["bucket"]["files"])
-        return {file["name"]: file for file in files if file}
-
-    @normalize_exceptions
-    def download_write_file(
-        self,
-        metadata: dict[str, str],
-        out_dir: str | None = None,
-    ) -> tuple[str, bool]:
-        """Download a file from a run and write it to wandb/.
-
-        Args:
-            metadata (obj): The metadata object for the file to download. Comes from Api.download_urls().
-            out_dir (str, optional): The directory to write the file to. Defaults to wandb/
-
-        Returns:
-            A tuple of the file's local path and whether it was downloaded.
-        """
-        filename = metadata["name"]
-        path = os.path.join(out_dir or self.settings("wandb_dir"), filename)
-        if self.file_current(path, B64Digest(metadata["md5"])):
-            return path, False
-
-        self.download_file(metadata["url"], path)
-        return path, True
 
     @staticmethod
     def _validate_config_and_fill_distribution(config: dict) -> dict:
@@ -956,39 +581,6 @@ class Api:
 
         warnings = response["upsertSweep"].get("configValidationWarnings", [])
         return response["upsertSweep"]["sweep"]["name"], warnings
-
-    @staticmethod
-    def file_current(fname: str, md5: B64Digest) -> bool:
-        """Checksum a file and compare the md5 with the known md5."""
-        return os.path.isfile(fname) and md5_file_b64(fname) == md5
-
-    def update_artifact_metadata(
-        self, artifact_id: str, metadata: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Set the metadata of the given artifact version."""
-        mutation = """
-        mutation UpdateArtifact(
-            $artifactID: ID!,
-            $metadata: JSONString,
-        ) {
-            updateArtifact(input: {
-                artifactID: $artifactID,
-                metadata: $metadata,
-            }) {
-                artifact {
-                    id
-                }
-            }
-        }
-        """
-        response = self.execute(
-            mutation,
-            variables={
-                "artifactID": artifact_id,
-                "metadata": json.dumps(metadata),
-            },
-        )
-        return response["updateArtifact"]["artifact"]
 
     def set_sweep_state(
         self,

--- a/wandb/sdk/lib/wbauth/authenticate.py
+++ b/wandb/sdk/lib/wbauth/authenticate.py
@@ -164,7 +164,7 @@ def _use_system_auth(
 ) -> Auth | None:
     """Load (or reload) session credentials from external sources.
 
-    Loads credentials from environment variables or the .netrc file.
+    Loads credentials from environment variables, .netrc, or global settings.
     If no credentials are found, the session credentials are unchanged.
 
     Args:
@@ -184,6 +184,13 @@ def _use_system_auth(
         _try_env_auth(host=host)  #
         or wbnetrc.read_netrc_auth_with_source(host=host)
     )
+    if auth is None:
+        settings = wandb_setup.singleton().settings
+        if settings.api_key and host.is_same_url(settings.base_url):
+            auth = AuthWithSource(
+                auth=AuthApiKey(host=host, api_key=settings.api_key),
+                source="settings",
+            )
 
     if verify and auth:
         auth.auth.verify()

--- a/wandb/sdk/verify/verify.py
+++ b/wandb/sdk/verify/verify.py
@@ -17,11 +17,10 @@ import click
 import requests
 
 import wandb
+from wandb.apis.public import Api
 from wandb.sdk.artifacts.artifact import Artifact
 from wandb.sdk.lib import runid
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
-
-from ..internal.internal_api import Api
 
 PROJECT_NAME = "verify"
 GET_RUN_MAX_TIME = 10
@@ -71,15 +70,6 @@ def check_logged_in(api: Api, host: str) -> bool:
                 click.style(login_doc_url, underline=True, fg="blue")
             )
         )
-    # check that api key is correct
-    # TODO: Better check for api key is correct
-    else:
-        res = api.viewer()
-        if not res:
-            fail_string = (
-                "Could not get viewer with default API key. "
-                f"Please relogin using `WANDB_BASE_URL={host} wandb login --relogin` and try again"
-            )
 
     print_results(fail_string, False)
     return fail_string is None
@@ -467,7 +457,9 @@ def check_large_post() -> bool:
 
 def check_wandb_version(api: Api) -> None:
     print("Checking wandb package version is up to date".ljust(72, "."), end="")  # noqa: T201
-    _, server_info = api.viewer_server_info()
+    server_info = api._service_api.execute_graphql(
+        "query ServerInfo { serverInfo { cliVersionInfo } }"
+    )["serverInfo"]
     fail_string = None
     warning = False
     max_cli_version = server_info.get("cliVersionInfo", {}).get("max_cli_version", None)


### PR DESCRIPTION
Description
-----------

`wandb init`, `projects`, `pull`, `restore`, `status`, `docker`, `docker-run`, `server start` and `wandb verify` still went through `InternalApi`. They now use `wandb.Api()` and its `Run`, `File` and `Project` objects. `pull` and `restore` pass `--project` and `--entity` to the API as overrides and let it resolve the run path, so the configured project and entity stay the defaults and the `project/run` and `project:run` forms keep working without the hand-rolled parsing. `restore` writes `wandb/config.yaml` through the same config file writer runs use, so the restored file has the layout `wandb.init(config=...)` reads. `init` creates projects with `Api.create_project()`, and `verify` queries the server version directly. `docker`, `docker-run` and `server start` only forward an API key to a container; they read it from the settings and netrc without prompting.

`InternalApi` fell back to the API key in the settings when neither `WANDB_API_KEY` nor netrc had one, which is how the SageMaker secrets file and the `api_key` entry of a settings file reached it. `wandb.Api()` gets its credentials from `wbauth`, shared with `wandb.login()` and `wandb.init()`, which now falls back to the settings key for the same host after the environment and netrc. The migrated commands keep working in SageMaker, and the settings file key that the `wandb.login()` docs list as a source is read again.

`wandb status --settings` prints the resolved global settings, which no longer include the API key, and `wandb projects` prints names only, since the public API does not return descriptions. `InternalApi` loses the file download, project and viewer methods this leaves unused.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Unit tests for the CLI, `wandb verify` and the credential fallback. `init`, `pull` and `restore` need a server and are covered by system tests.
