### PR TITLE
fix(leet): keep the top y-axis label from being cut off

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -45,6 +45,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 - Fixed CPU frequency metrics on the MacBook Neo being reported about 1000 times too high (@dmitryduev in https://github.com/wandb/wandb/pull/12681)
 - Fixed missing CPU utilization and frequency metrics for the efficiency cores of Apple M5 Macs and the performance cores of M5 Pro and M5 Max Macs (@dmitryduev in https://github.com/wandb/wandb/pull/12682)
 - `wandb.init()` and `wandb.Api()` no longer stall for up to 10 seconds when the W&B server is slow to respond. This was a regression in 0.29.0 (@mitja-kleider and @jacobromero in https://github.com/wandb/wandb/pull/12697)
+- Fixed the top y-axis label of LEET charts being cut off when it is wider than the other labels, showing for example `+03` instead of `1.09e+03` (@dmitryduev in https://github.com/wandb/wandb/pull/12727)
 
 ### Removed
 

--- a/core/internal/leet/epochlinechart.go
+++ b/core/internal/leet/epochlinechart.go
@@ -250,8 +250,16 @@ func NewEpochLineChart(title string) *EpochLineChart {
 	chart.XLabelFormatter = func(_ int, v float64) string {
 		return FormatXAxisTick(v, chart.maxXLabelWidth())
 	}
+	// ntcharts sizes the label column from the stepped ticks only, so pad
+	// labels to the width of the top label when drawYLabels adds one.
 	chart.YLabelFormatter = func(_ int, v float64) string {
-		return chart.formatYTick(v)
+		s := chart.formatYTick(v)
+		if hasTopYTick(chart.GraphHeight(), chart.YStep()) {
+			if top := chart.formatYTick(chart.ViewMaxY()); len(top) > len(s) {
+				s = strings.Repeat(" ", len(top)-len(s)) + s
+			}
+		}
+		return s
 	}
 
 	return chart
@@ -704,16 +712,19 @@ func (c *EpochLineChart) drawYLabels() {
 	}
 
 	var lastVal string
-	lastI := 0
 	for i := 0; i <= graphH; i += yStep {
 		lastVal = draw(i, lastVal)
-		lastI = i
 	}
-	// Add a top tick when the last stepped tick fell short of graphHeight
-	// and there's room for a non-adjacent label.
-	if lastI < graphH && graphH-lastI >= (yStep+1)/2 {
+	if hasTopYTick(graphH, yStep) {
 		draw(graphH, lastVal)
 	}
+}
+
+// hasTopYTick reports whether drawYLabels labels the top of the axis, which
+// it does when the top is not a stepped tick and there is room for a
+// non-adjacent label above the last one.
+func hasTopYTick(graphH, yStep int) bool {
+	return yStep > 0 && graphH%yStep >= (yStep+1)/2
 }
 
 // drawSeries renders a single series onto the canvas.

--- a/core/internal/leet/epochlinechart_test.go
+++ b/core/internal/leet/epochlinechart_test.go
@@ -445,3 +445,18 @@ func TestTimeSeriesLineChart_LogY_FormatsTicksWithMetricUnits(t *testing.T) {
 	require.True(t, ch.TestIsLogY())
 	require.Equal(t, "10%", ch.TestFormatYTick(1))
 }
+
+func TestEpochLineChart_YLabelsFitTopTick(t *testing.T) {
+	c := leet.NewEpochLineChart("norm")
+	c.AddData("run", leet.MetricData{X: []float64{0, 1, 2}, Y: []float64{0, 500, 1090}})
+
+	// Height 10 adds a top tick whose label is wider than the stepped ones.
+	c.Resize(30, 10)
+	c.Draw()
+	require.Contains(t, stripANSI(c.View()), "1.2e+03│")
+
+	// Height 8 has no top tick, so the column stays as wide as "999".
+	c.Resize(30, 8)
+	c.Draw()
+	require.Contains(t, stripANSI(c.View()), "\n  0└")
+}


### PR DESCRIPTION
Description
-----------
The top y-axis label of a LEET chart was clipped from the left when it was wider than the other labels, showing for example `+03` instead of `1.09e+03`.

ntcharts reserves the label column from the tick labels at multiples of the y step only, while the chart also labels the top of the axis when it falls far enough above the last stepped tick. The label formatter now pads labels to the width of that top label whenever the chart draws one, so the column is wide enough for it.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Unit test with a chart whose top label is the widest one, plus a local run whose gradient norms cross 1000.
