### PR TITLE
fix(leet): keep the charts readable when the workspace sidebars do not fit

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -36,6 +36,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 ### Fixed
 
 - Passing `aliases` or `tags` to `Run.log_artifact()` in the public API no longer fails with a server error (@dmitryduev in https://github.com/wandb/wandb/pull/12719)
+- LEET now hides the workspace's run overview sidebar, and then the runs list, when together they would leave the charts fewer than 24 columns wide; previously an 80-column terminal showed the charts as a one-column sliver between the two sidebars. The single-run view, which already did this, uses the same 24-column minimum instead of 10 (@dmitryduev in https://github.com/wandb/wandb/pull/12731)
 - `wandb.Image` masks are no longer silently corrupted when `mask_data` is a float array with values outside 0-255. The range check previously only ran for integer dtypes, so out-of-range class ids were written to the saved mask wrapped modulo 256; they now raise `TypeError` like their integer equivalents already did (@Kayvan-Zahiri in https://github.com/wandb/wandb/pull/12685)
 - File uploads and downloads no longer fail in some cases with `CommError: Failed to execute API request: the service process is busy and did not respond in time` when they take longer than 20 seconds. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12603)
 - System metrics are now collected as soon as monitoring starts instead of after the first sampling interval (@dmitryduev in https://github.com/wandb/wandb/pull/12649)

--- a/core/internal/leet/flexlayout.go
+++ b/core/internal/leet/flexlayout.go
@@ -136,6 +136,21 @@ func expandedSidebarWidth(terminalWidth int, oppositeVisible bool, frac float64)
 // squeezed to by the fixed panes below it.
 const minFlexMetricsHeight = 5
 
+// fitSidebarWidths drops the right sidebar, then the left one, when together
+// they would leave the main content column narrower than mainDragMinWidth.
+//
+// Visibility preferences and animation state are untouched: only the current
+// layout pass is clamped, so the sidebars come back when the terminal grows.
+func fitSidebarWidths(width, leftW, rightW int) (int, int) {
+	if leftW+rightW <= width-mainDragMinWidth {
+		return leftW, rightW
+	}
+	if leftW <= width-mainDragMinWidth {
+		return leftW, 0
+	}
+	return 0, 0
+}
+
 // fitSidebarFractions clamps sidebar override fractions so both expanded
 // sidebars together leave the main content column its minimum width. Only
 // overridden (non-zero) fractions are adjusted; the golden-ratio defaults

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -621,7 +621,7 @@ func (r *Run) buildActiveStatus() string {
 	// Add filter info if active.
 	if r.metricsGrid.IsFiltering() {
 		parts = append(parts, fmt.Sprintf(
-			"Filter (%s): %q [%d/%d] (/ to change, Ctrl+L to clear)",
+			"Filter (%s): %q [%d/%d] (/ to change, ctrl+/ to clear)",
 			r.metricsGrid.FilterMode().String(),
 			r.metricsGrid.FilterQuery(),
 			r.metricsGrid.FilteredChartCount(), r.metricsGrid.ChartCount()))
@@ -629,7 +629,7 @@ func (r *Run) buildActiveStatus() string {
 
 	// Add overview filter info if active.
 	if r.leftSidebar.IsFiltering() {
-		parts = append(parts, fmt.Sprintf("Overview: %q [%s] (o to change, Ctrl+K to clear)",
+		parts = append(parts, fmt.Sprintf("Overview: %q [%s] (o to change, ctrl+o to clear)",
 			r.leftSidebar.FilterQuery(),
 			r.leftSidebar.FilterInfo(),
 		))
@@ -638,7 +638,7 @@ func (r *Run) buildActiveStatus() string {
 	if r.rightSidebar.IsFiltering() {
 		grid := r.rightSidebar.metricsGrid
 		parts = append(parts, fmt.Sprintf(
-			"System filter (%s): %q [%d/%d] (\\ to change, Ctrl+\\ to clear)",
+			"System filter (%s): %q [%d/%d] (\\ to change, ctrl+\\ to clear)",
 			grid.FilterMode().String(),
 			grid.FilterQuery(),
 			grid.FilteredChartCount(),
@@ -798,35 +798,9 @@ type Layout struct {
 	consoleLogsHeight      int
 }
 
-// effectiveSidebarWidths returns the widths that can actually be rendered
-// without starving the main content area.
-//
-// The visibility preferences remain unchanged: this method only clamps the
-// current render/layout pass and does not mutate animation state.
-func (r *Run) effectiveSidebarWidths() (leftW, rightW int) {
-	const minRunMainContentWidth = 10
-
-	leftW = r.leftSidebar.Width()
-	rightW = r.rightSidebar.Width()
-
-	if leftW+rightW < r.width-minRunMainContentWidth {
-		return leftW, rightW
-	}
-	if rightW > 0 {
-		rightW = 0
-	}
-	if leftW+rightW < r.width-minRunMainContentWidth {
-		return leftW, rightW
-	}
-	if leftW > 0 {
-		leftW = 0
-	}
-	return leftW, rightW
-}
-
 // computeViewports returns (leftW, contentW, rightW, contentH).
 func (r *Run) computeViewports() Layout {
-	leftW, rightW := r.effectiveSidebarWidths()
+	leftW, rightW := fitSidebarWidths(r.width, r.leftSidebar.Width(), r.rightSidebar.Width())
 	contentW := max(r.width-leftW-rightW, 1)
 	totalH := max(r.height-StatusBarHeight, 0)
 

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -315,7 +315,7 @@ func (w *Workspace) View() tea.View {
 	runLabel, systemGrid, systemHint, mediaHint, logsHint := w.syncCurrentRunContext()
 
 	var cols []string
-	if w.runsAnimState.IsVisible() {
+	if layout.leftSidebarWidth > 0 {
 		cols = append(cols, w.renderRunsList())
 	}
 
@@ -359,7 +359,7 @@ func (w *Workspace) View() tea.View {
 	centralColumn = placeMainColumn(contentWidth, layout.totalContentAreaHeight, centralColumn)
 	cols = append(cols, centralColumn)
 
-	if w.runOverviewSidebar.IsVisible() {
+	if layout.rightSidebarWidth > 0 {
 		cols = append(cols, w.renderRunOverview())
 	}
 
@@ -538,7 +538,8 @@ func (w *Workspace) recalculateLayout() {
 // Separator lines between visible sections are subtracted from available height
 // to prevent the status bar from being pushed off screen.
 func (w *Workspace) computeViewports() Layout {
-	leftW, rightW := w.runsAnimState.Value(), w.runOverviewSidebar.Width()
+	leftW, rightW := fitSidebarWidths(
+		w.width, w.runsAnimState.Value(), w.runOverviewSidebar.Width())
 	contentW := max(w.width-leftW-rightW, 1)
 	totalH := max(w.height-StatusBarHeight, 0)
 

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -531,6 +531,7 @@ func (w *Workspace) syncCurrentRunContext() (
 func (w *Workspace) recalculateLayout() {
 	layout := w.computeViewports()
 	w.metricsGrid.UpdateDimensions(layout.mainContentAreaWidth, layout.height)
+	w.focusMgr.Resolve()
 }
 
 // computeViewports returns the computed layout dimensions.
@@ -723,7 +724,8 @@ func (w *Workspace) buildWorkspaceFocusManager() *FocusManager {
 // visible even when empty, so focus survives the empty-list windows during
 // startup and no-match filters.
 func (w *Workspace) runsFocusAvailable() bool {
-	return w.runsAnimState.TargetVisible()
+	return w.runsAnimState.TargetVisible() &&
+		(w.width == 0 || w.computeViewports().leftSidebarWidth > 0)
 }
 
 func (w *Workspace) metricsGridFocusAvailable() bool {
@@ -748,7 +750,8 @@ func (w *Workspace) logsFocusAvailable() bool {
 
 func (w *Workspace) overviewFocusAvailable() bool {
 	firstSec, _ := w.runOverviewSidebar.focusableSectionBounds()
-	return w.runOverviewSidebar.animState.TargetVisible() && firstSec != -1
+	return w.runOverviewSidebar.animState.TargetVisible() &&
+		(w.width == 0 || w.computeViewports().rightSidebarWidth > 0) && firstSec != -1
 }
 
 // ---- Focus activate ----

--- a/core/internal/leet/workspace_keyhandling_test.go
+++ b/core/internal/leet/workspace_keyhandling_test.go
@@ -156,6 +156,31 @@ func newWorkspaceWithPanels(t *testing.T) *leet.Workspace {
 	return w
 }
 
+func TestWorkspace_NarrowLayoutSkipsHiddenSidebars(t *testing.T) {
+	w := newWorkspaceWithPanels(t)
+	w.TestSetFocusTarget(int(leet.FocusTargetOverview))
+	w.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	_, right := w.TestLayoutWidths()
+	require.Zero(t, right)
+	require.Equal(t, int(leet.FocusTargetNone), w.TestCurrentFocusRegion())
+	w.TestSetFocusTarget(int(leet.FocusTargetConsoleLogs))
+	w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.Equal(t, testFocusRuns, w.TestCurrentFocusRegion())
+
+	w.Update(tea.WindowSizeMsg{Width: 50, Height: 24})
+	left, _ := w.TestLayoutWidths()
+	require.Zero(t, left)
+	require.False(t, w.RunSelectorActive())
+	w.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.Equal(t, int(leet.FocusTargetNone), w.TestCurrentFocusRegion())
+	w.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.Equal(t, testFocusLogs, w.TestCurrentFocusRegion())
+
+	w.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	w.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	require.Equal(t, testFocusRuns, w.TestCurrentFocusRegion())
+}
+
 // ---- handleToggleConsoleLogsPane ----
 
 func TestWorkspace_ToggleConsoleLogsPane_FocusClears(t *testing.T) {

--- a/core/internal/leet/workspace_test.go
+++ b/core/internal/leet/workspace_test.go
@@ -177,6 +177,20 @@ func TestWorkspace_View_ConsoleLogsPaneShowsNoDataWithoutLogs(t *testing.T) {
 		"bottom bar should show 'No data.' when no console logs exist")
 }
 
+func TestWorkspace_NarrowTerminalKeepsMainColumnUsable(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+	_ = cfg.SetWorkspaceOverviewVisible(true)
+	w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+
+	w.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	left, right := w.TestLayoutWidths()
+	require.GreaterOrEqual(t, 80-left-right, 24,
+		"the sidebars must leave room for the main content column")
+	require.Positive(t, left, "the runs list stays when only one sidebar fits")
+}
+
 func TestWorkspace_View_HiddenPanesNotRendered(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)


### PR DESCRIPTION
Description
-----------
In workspace mode the runs list and the run overview sidebar were always laid out at their full widths, so an 80-column terminal (a default ssh window, a tmux split) showed the charts as a one-column sliver between two 40-column sidebars. The single-run view already dropped the sidebars that did not fit. This moves that clamp into a shared `fitSidebarWidths` and applies it to the workspace layout as well. Both views now keep the main column at least 24 columns wide, the same minimum the drag-resize code enforces; the single-run view used 10 before. Visibility preferences are untouched, so the sidebars come back as soon as the terminal is wide enough.

Also fixes the single-run status bar hints, which pointed at Ctrl+K (not bound) and Ctrl+L (kept only for compatibility) instead of ctrl+o and ctrl+/.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Added a layout test for the 80x24 workspace. The existing drag-resize tests cover the shared minimum.
