### PR TITLE
fix(leet): report startup errors on stderr instead of a discarded log

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Fixed
 
+- `wandb leet` now prints an error message when it cannot start, for example when it is run without a terminal; previously it exited with status 1 and no output. Debug logs (`WANDB_DEBUG=true`) are written next to the LEET config file instead of the current directory (@dmitryduev in https://github.com/wandb/wandb/pull/12732)
 - Passing `aliases` or `tags` to `Run.log_artifact()` in the public API no longer fails with a server error (@dmitryduev in https://github.com/wandb/wandb/pull/12719)
 - LEET now hides the workspace's run overview sidebar, and then the runs list, when together they would leave the charts fewer than 24 columns wide; previously an 80-column terminal showed the charts as a one-column sliver between the two sidebars. The single-run view, which already did this, uses the same 24-column minimum instead of 10 (@dmitryduev in https://github.com/wandb/wandb/pull/12731)
 - `wandb.Image` masks are no longer silently corrupted when `mask_data` is a float array with values outside 0-255. The range check previously only ran for integer dtypes, so out-of-range class ids were written to the saved mask wrapped modulo 256; they now raise `TypeError` like their integer equivalents already did (@Kayvan-Zahiri in https://github.com/wandb/wandb/pull/12685)

--- a/core/cmd/wandb-core/main.go
+++ b/core/cmd/wandb-core/main.go
@@ -233,7 +233,7 @@ func leetMain(args []string) int {
 
 	logger, closeLogger, err := newLeetLogger(opts.logLevel, recorder)
 	if err != nil {
-		fmt.Println("fatal:", err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		return exitCodeErrorInternal
 	}
 	defer closeLogger()
@@ -305,7 +305,8 @@ func bindLeetFlags(fs *flag.FlagSet, opts *leetOptions) {
 		&opts.logLevel,
 		"log-level",
 		0,
-		"Specifies the log level to use for logging. -4: debug, 0: info, 4: warn, 8: error.",
+		"Specifies the log level to use for logging. -4: debug, 0: info, 4: warn, 8: error."+
+			" Debug logs are written to wandb-leet.debug.log next to the LEET config file.",
 	)
 	fs.BoolVar(
 		&opts.disableAnalytics,
@@ -460,7 +461,7 @@ func newLeetLogger(
 	// TODO: Create a log file not only if debug logging is requested.
 	if logLevel == -4 {
 		loggerFile, err := os.OpenFile(
-			"wandb-leet.debug.log",
+			leet.DebugLogPath(),
 			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 			0o644,
 		)
@@ -515,6 +516,7 @@ func runLeetInspector(opts *leetOptions, logger *observability.CoreLogger) int {
 	_, err := program.Run()
 	m.Cleanup()
 	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		logger.CaptureError(
 			"main",
 			fmt.Errorf("wandb-leet-inspect: %v", err),
@@ -534,7 +536,7 @@ func runLeetConfigEditor(logger *observability.CoreLogger) int {
 	editor := leet.NewConfigEditor(leet.ConfigEditorParams{Logger: logger})
 	program := tea.NewProgram(editor)
 	if _, err := program.Run(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		return exitCodeErrorInternal
 	}
 	return exitCodeSuccess
@@ -551,6 +553,7 @@ func runSymon(opts *leetOptions, logger *observability.CoreLogger) int {
 		finalModel, err := program.Run()
 		m.Cleanup()
 		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
 			logger.CaptureError(
 				"main",
 				fmt.Errorf("wandb-symon: %v", err),
@@ -583,6 +586,7 @@ func runLeetWorkspace(opts *leetOptions, logger *observability.CoreLogger) int {
 
 		finalModel, err := program.Run()
 		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
 			logger.CaptureError(
 				"main",
 				fmt.Errorf("wandb-leet: %v", err),

--- a/core/internal/leet/config.go
+++ b/core/internal/leet/config.go
@@ -1029,6 +1029,11 @@ func (cm *ConfigManager) SetWorkspaceMediaVisible(visible bool) error {
 //
 // Matches the Python logic (same directory as the system "settings" file),
 // with fallbacks to UserConfigDir and a temp dir.
+// DebugLogPath returns the path of the debug log, next to the config file.
+func DebugLogPath() string {
+	return filepath.Join(filepath.Dir(leetConfigPath()), "wandb-leet.debug.log")
+}
+
 func leetConfigPath() string {
 	// 1) Honor WANDB_CONFIG_DIR (like in Python)
 	if raw := strings.TrimSpace(os.Getenv(envConfigDir)); raw != "" {


### PR DESCRIPTION
Description
-----------
When the TUI failed to start, the error went to the leet logger, which writes to `io.Discard` unless `--log-level -4` is set. Running `wandb leet` without a terminal (from a script, an agent, a cron job) therefore exited with status 1 and no output at all. Every TUI mode now prints the error on stderr as well:

```
$ wandb leet ./wandb < /dev/null
Error: bubbletea: error opening TTY: bubbletea: could not open TTY: open /dev/tty: device not configured
```

The debug log moves from the current directory to `wandb-leet.debug.log` next to the LEET config file (`~/.config/wandb/` by default, or `WANDB_CONFIG_DIR`), so debugging a run from its project directory no longer leaves a stray file there. The `--log-level` help says where the file goes.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Ran the built binary without a TTY in every mode and checked stderr, the exit code and the debug log location.
