### PR TITLE
fix(leet): do not send telemetry in offline or disabled mode

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -35,6 +35,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Fixed
 
+- `wandb leet` no longer sends usage telemetry when W&B is in offline or disabled mode (`WANDB_MODE=offline` or `WANDB_MODE=disabled`), like the rest of the SDK (@dmitryduev in https://github.com/wandb/wandb/pull/12733)
 - `wandb leet` now prints an error message when it cannot start, for example when it is run without a terminal; previously it exited with status 1 and no output. Debug logs (`WANDB_DEBUG=true`) are written next to the LEET config file instead of the current directory (@dmitryduev in https://github.com/wandb/wandb/pull/12732)
 - Passing `aliases` or `tags` to `Run.log_artifact()` in the public API no longer fails with a server error (@dmitryduev in https://github.com/wandb/wandb/pull/12719)
 - LEET now hides the workspace's run overview sidebar, and then the runs list, when together they would leave the charts fewer than 24 columns wide; previously an 80-column terminal showed the charts as a one-column sliver between the two sidebars. The single-run view, which already did this, uses the same 24-column minimum instead of 10 (@dmitryduev in https://github.com/wandb/wandb/pull/12731)

--- a/tests/unit_tests/test_cli_leet.py
+++ b/tests/unit_tests/test_cli_leet.py
@@ -16,6 +16,8 @@ def core_calls(monkeypatch) -> list[list[str]]:
 
     class _StubSettings:
         base_url = _BASE_URL
+        _offline = False
+        _noop = False
 
     class _StubSingleton:
         settings = _StubSettings()
@@ -79,6 +81,22 @@ def test_leet_defaults_to_run_command(runner, core_calls, tmp_path: pathlib.Path
     assert result.exit_code == 0
     assert core_calls == [
         ["wandb-core", "leet", "--base-url", _BASE_URL, str(wandb_dir.resolve())]
+    ]
+
+
+@pytest.mark.parametrize("mode_attr", ["_offline", "_noop"])
+def test_leet_offline_disables_telemetry(
+    runner, core_calls, tmp_path: pathlib.Path, mode_attr: str
+):
+    wandb_dir = tmp_path / "wandb"
+    wandb_dir.mkdir()
+    setattr(leet.wandb_setup.singleton().settings, mode_attr, True)
+
+    result = runner.invoke(cli.cli, ["leet", str(wandb_dir)])
+
+    assert result.exit_code == 0
+    assert core_calls == [
+        ["wandb-core", "leet", "--no-observability", str(wandb_dir.resolve())]
     ]
 
 

--- a/wandb/cli/leet.py
+++ b/wandb/cli/leet.py
@@ -223,11 +223,12 @@ def _base_args() -> list[str]:
 
     args = [core_path, "leet"]
 
-    if not error_reporting_enabled():
+    settings = wandb_setup.singleton().settings
+    if settings._offline or settings._noop or not error_reporting_enabled():
         args.append("--no-observability")
     else:
         # Tell wandb-core which W&B server to upload telemetry to.
-        args.extend(["--base-url", wandb_setup.singleton().settings.base_url])
+        args.extend(["--base-url", settings.base_url])
 
     if is_debug(default="False"):
         args.extend(["--log-level", "-4"])


### PR DESCRIPTION
Description
-----------
`wandb leet` uploaded usage telemetry regardless of `WANDB_MODE`. The rest of the SDK stays off the network in offline and disabled mode, and labs that run offline on purpose expect the same from a tool that reads local files. The launcher now passes `--no-observability` to wandb-core when the settings are offline or disabled, in addition to the existing `WANDB_ERROR_REPORTING=false` switch.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Unit test for both modes.
