### PR TITLE
chore(leet): redraw charts at most every 100 ms while a run is loading

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -25,6 +25,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Changed
 
+- LEET loads long runs faster: while a run's history is loading, the charts are redrawn at most ten times a second instead of after every 1000 records, which made loading time grow with the square of the run's length. A 100-metric run with 400k steps now opens in about 0.3 s instead of 3.8 s (@dmitryduev in https://github.com/wandb/wandb/pull/12734)
 - LEET is faster on long runs: a 50k-step run loads in about half the time, frames render about 30 percent faster, and live chart updates no longer re-render every point (@dmitryduev in https://github.com/wandb/wandb/pull/12535, https://github.com/wandb/wandb/pull/12536, https://github.com/wandb/wandb/pull/12537, https://github.com/wandb/wandb/pull/12538, https://github.com/wandb/wandb/pull/12539)
 - System metrics from Apple Silicon Macs become available about 1.5 seconds sooner after monitoring starts (@dmitryduev in https://github.com/wandb/wandb/pull/12679)
 

--- a/core/internal/leet/historysource.go
+++ b/core/internal/leet/historysource.go
@@ -15,6 +15,12 @@ const (
 	BootLoadChunkSize = 1000
 	BootLoadMaxTime   = 100 * time.Millisecond
 
+	// bootRedrawInterval bounds how often the visible charts are redrawn
+	// while chunks are still arriving. A redraw rasterizes every point of
+	// every visible chart, so drawing after each chunk made loading
+	// quadratic in the run's length.
+	bootRedrawInterval = 100 * time.Millisecond
+
 	// Live monitoring parameters
 	LiveMonitorChunkSize = 2000
 	LiveMonitorMaxTime   = 50 * time.Millisecond

--- a/core/internal/leet/liveread_test.go
+++ b/core/internal/leet/liveread_test.go
@@ -1,8 +1,10 @@
 package leet_test
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -113,6 +115,71 @@ func TestWorkspace_ReadAvailableCmd_DropsEmptyChunk(t *testing.T) {
 
 	run := &leet.WorkspaceRun{Key: "run-1", Reader: &stubHistorySource{msg: leet.ChunkedBatchMsg{}}}
 	require.Nil(t, w.ReadAvailableCmd(run)())
+}
+
+func TestRun_ReadErrorDrawsPendingHistory(t *testing.T) {
+	// Keep both boot chunks inside the redraw interval.
+	synctest.Test(t, func(t *testing.T) {
+		r, _ := newTestRun(t, 160, 50, nil)
+		defer r.Cleanup()
+		r.Update(leet.ChunkedBatchMsg{HasMore: true, Msgs: []tea.Msg{
+			leet.RunMsg{ID: "run-1"},
+			leet.HistoryMsg{Metrics: map[string]leet.MetricData{
+				"loss": {X: []float64{0, 1}, Y: []float64{0, 1}},
+			}},
+		}})
+		r.Update(leet.ChunkedBatchMsg{HasMore: true, Msgs: []tea.Msg{
+			leet.HistoryMsg{Metrics: map[string]leet.MetricData{
+				"loss": {X: []float64{2, 3}, Y: []float64{5, 10}},
+			}},
+		}})
+
+		r.Update(leet.ErrorMsg{Err: errors.New("truncated transaction log")})
+		view := r.View().Content
+		require.Contains(t, stripANSI(view), "loss")
+		require.Contains(t, stripANSI(view), "Error: truncated transaction log")
+
+		// Forcing a redraw must not reveal history omitted by the error handler.
+		r.Update(tea.WindowSizeMsg{Width: 160, Height: 50})
+		require.Equal(t, r.View().Content, view)
+	})
+}
+
+func TestWorkspace_ReadErrorDrawsPendingHistory(t *testing.T) {
+	// Keep both boot chunks inside the redraw interval.
+	synctest.Test(t, func(t *testing.T) {
+		logger := observability.NewNoOpLogger()
+		cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+		w := leet.NewWorkspace(t.TempDir(), cfg, logger)
+		defer w.Cleanup()
+		w.Update(tea.WindowSizeMsg{Width: 160, Height: 50})
+		w.TestAttachRun(&leet.WorkspaceRun{Key: "run-1"}, true)
+		w.Update(leet.WorkspaceChunkedBatchMsg{RunKey: "run-1", Batch: leet.ChunkedBatchMsg{
+			HasMore: true,
+			Msgs: []tea.Msg{leet.HistoryMsg{Metrics: map[string]leet.MetricData{
+				"loss": {X: []float64{0, 1}, Y: []float64{0, 1}},
+			}}},
+		}})
+		w.Update(leet.WorkspaceChunkedBatchMsg{RunKey: "run-1", Batch: leet.ChunkedBatchMsg{
+			HasMore: true,
+			Msgs: []tea.Msg{leet.HistoryMsg{Metrics: map[string]leet.MetricData{
+				"loss": {X: []float64{2, 3}, Y: []float64{5, 10}},
+			}}},
+		}})
+
+		w.Update(
+			leet.WorkspaceRunReadErrMsg{
+				RunKey: "run-1",
+				Err:    errors.New("truncated transaction log"),
+			},
+		)
+		view := w.View().Content
+		require.Contains(t, stripANSI(view), "loss")
+
+		// Forcing a redraw must not reveal history omitted by the error handler.
+		w.Update(tea.WindowSizeMsg{Width: 160, Height: 50})
+		require.Equal(t, w.View().Content, view)
+	})
 }
 
 func TestParseHistory_UsesHistoryStepFallback(t *testing.T) {

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -117,6 +117,7 @@ type Run struct {
 
 	// Coalesce expensive redraws during batch processing.
 	suppressDraw bool
+	lastDrawAt   time.Time
 
 	// Logger.
 	logger *observability.CoreLogger

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -901,23 +901,27 @@ func (r *Run) ReadLiveBatchCmd(source HistorySource) tea.Cmd {
 	}
 }
 
-// handleRecordsBatch processes a batch of sub-messages and manages redraw + loading flags.
-func (r *Run) handleRecordsBatch(subMsgs []tea.Msg, suppressRedraw bool) []tea.Cmd {
+// handleRecordsBatch processes a batch of sub-messages and redraws the
+// visible charts once at the end. While more chunks are on the way, redraws
+// are rate-limited to bootRedrawInterval.
+func (r *Run) handleRecordsBatch(subMsgs []tea.Msg, hasMore bool) []tea.Cmd {
 	defer timeit(r.logger, "Model.handleRecordsBatch")()
 
 	var cmds []tea.Cmd
 
-	prev := r.suppressDraw
-	r.suppressDraw = suppressRedraw
+	r.suppressDraw = true
 	for _, subMsg := range subMsgs {
 		if cmd := r.handleRecordMsg(subMsg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	}
-	r.suppressDraw = prev
-	if !r.suppressDraw {
-		r.metricsGrid.drawVisible()
+	r.suppressDraw = false
+
+	if hasMore && time.Since(r.lastDrawAt) < bootRedrawInterval {
+		return cmds
 	}
+	r.lastDrawAt = time.Now()
+	r.metricsGrid.drawVisible()
 	r.rightSidebar.metricsGrid.drawVisible()
 
 	return cmds
@@ -944,8 +948,7 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 
 	r.recordsLoaded += msg.Progress
 
-	// Draw once per boot chunk instead of once per history record.
-	cmds := r.handleRecordsBatch(msg.Msgs, true)
+	cmds := r.handleRecordsBatch(msg.Msgs, msg.HasMore)
 
 	if msg.HasMore {
 		cmds = append(
@@ -982,7 +985,7 @@ func (r *Run) handleChunkedBatch(msg ChunkedBatchMsg) []tea.Cmd {
 // handleBatched handles live drain batches.
 func (r *Run) handleBatched(msg BatchedRecordsMsg) []tea.Cmd {
 	r.logger.Debug(fmt.Sprintf("model: BatchedRecordsMsg received with %d messages", len(msg.Msgs)))
-	cmds := r.handleRecordsBatch(msg.Msgs, true)
+	cmds := r.handleRecordsBatch(msg.Msgs, false)
 	if r.runState != RunStateRunning {
 		return cmds
 	}

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -87,6 +87,9 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 		r.logger.Debug("model: stopping heartbeats and finishing watcher due to error")
 		r.heartbeatMgr.Stop()
 		r.watcherMgr.Finish()
+		// No final boot chunk will arrive to draw any throttled history.
+		r.metricsGrid.drawVisible()
+		r.rightSidebar.metricsGrid.drawVisible()
 	}
 
 	return nil

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -32,6 +32,9 @@ type Workspace struct {
 	// drag owns in-progress pane-boundary resizing (mouse drag).
 	drag paneDragger
 
+	// lastDrawAt is when the charts were last redrawn while a run was loading.
+	lastDrawAt time.Time
+
 	// Configuration and key bindings.
 	config *ConfigManager
 	keyMap map[string]func(*Workspace, tea.KeyPressMsg) tea.Cmd

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -684,9 +684,12 @@ func (w *Workspace) handleWorkspaceChunkedBatch(msg WorkspaceChunkedBatchMsg) te
 	for _, sub := range msg.Batch.Msgs {
 		w.handleWorkspaceRecord(run, sub)
 	}
-	w.metricsGrid.drawVisible()
-	if g := w.systemMetrics[msg.RunKey]; g != nil {
-		g.drawVisible()
+	if !msg.Batch.HasMore || time.Since(w.lastDrawAt) >= bootRedrawInterval {
+		w.lastDrawAt = time.Now()
+		w.metricsGrid.drawVisible()
+		if g := w.systemMetrics[msg.RunKey]; g != nil {
+			g.drawVisible()
+		}
 	}
 
 	if msg.Batch.HasMore {

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -834,6 +834,11 @@ func (w *Workspace) handleRunReadErr(msg WorkspaceRunReadErrMsg) tea.Cmd {
 	if !w.anyRunRunning() {
 		w.heartbeatMgr.Stop()
 	}
+	// No final boot chunk will arrive to draw any throttled history.
+	w.metricsGrid.drawVisible()
+	if g := w.systemMetrics[msg.RunKey]; g != nil {
+		g.drawVisible()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Description
-----------
Loading a run reads the transaction log in 1000-record chunks and redrew every visible chart after each chunk. A redraw rasterizes all points of a chart, so the total work grew with the square of the run's length: a 100-metric run took 0.33 s to load at 100k steps, 1.07 s at 200k and 3.84 s at 400k, almost all of it redrawing.

Redraws now happen at most every 100 ms while more chunks are on the way, and once more when the last chunk lands, in both the single-run and the workspace views. The charts still fill in as the file loads; they just do it ten times a second instead of once per chunk. Live updates after the initial load are unchanged.

The same runs now load in 0.09 s, 0.15 s and 0.30 s.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Timed the boot load before and after with a throwaway test; existing tests pass.
