### PR TITLE
feat(leet): remember filters per wandb directory

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Added
 
+- LEET remembers the metrics, system metrics and runs filters for each wandb directory: the next time you open the directory, in the workspace or the single-run view, the filters from the previous session are already applied. They are stored in `.wandb-leet.json` inside the directory; clearing a filter (`ctrl+/`, `ctrl+\`, `ctrl+f`) forgets it (@dmitryduev in https://github.com/wandb/wandb/pull/12735)
 - LEET charts metrics against the custom x-axes set with `run.define_metric()`. A metric defined with a `step_metric`, directly or through a glob like `run.define_metric("train/*", step_metric="train/step")`, is plotted against that metric instead of the step counter, with the axis name shown as `[x: train/step]` in the chart header. Applies to runs viewed from local `.wandb` files. Each chart has a single x-axis, so a run that plots a metric against a different axis is not shown on that chart (@dmitryduev in https://github.com/wandb/wandb/pull/12568, https://github.com/wandb/wandb/pull/12728)
 - The automations API now supports sending a prompt to ARIA (`SendPromptToAria`) as an automation action. (@gdecarvalhovaz-lgtm in https://github.com/wandb/wandb/pull/12594)
 

--- a/core/internal/leet/dirfilters.go
+++ b/core/internal/leet/dirfilters.go
@@ -1,0 +1,98 @@
+package leet
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wandb/wandb/core/internal/observability"
+)
+
+// dirFiltersName is the file in a wandb directory that remembers the
+// filters last used there.
+const dirFiltersName = ".wandb-leet.json"
+
+// filterState is a persisted filter: the applied pattern and, for glob
+// matching, the mode. Regex is the default and is not written.
+type filterState struct {
+	Query string `json:"query"`
+	Mode  string `json:"mode,omitempty"`
+}
+
+func filterStateOf(f *Filter) filterState {
+	state := filterState{Query: f.Query()}
+	if f.Mode() == FilterModeGlob {
+		state.Mode = "glob"
+	}
+	return state
+}
+
+func (s filterState) mode() FilterMatchMode {
+	if s.Mode == "glob" {
+		return FilterModeGlob
+	}
+	return FilterModeRegex
+}
+
+// dirFilters remembers the filters last used in a wandb directory so they
+// are in place the next time it is opened. Every change is saved.
+type dirFilters struct {
+	path   string
+	logger *observability.CoreLogger
+
+	Metrics       filterState `json:"metrics_filter,omitzero"`
+	SystemMetrics filterState `json:"system_metrics_filter,omitzero"`
+	Runs          filterState `json:"runs_filter,omitzero"`
+}
+
+// loadDirFilters reads the filters remembered for wandbDir.
+//
+// A missing file yields empty filters. An empty wandbDir, as for remote
+// runs, yields empty filters that are never saved.
+func loadDirFilters(wandbDir string, logger *observability.CoreLogger) *dirFilters {
+	df := &dirFilters{logger: logger}
+	if wandbDir == "" {
+		return df
+	}
+	df.path = filepath.Join(wandbDir, dirFiltersName)
+
+	data, err := os.ReadFile(df.path)
+	if err == nil {
+		err = json.Unmarshal(data, df)
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		logger.Error(fmt.Sprintf("leet: ignoring %s: %v", df.path, err))
+	}
+	return df
+}
+
+// bind restores f from slot, applies it, and saves slot whenever f changes.
+func (df *dirFilters) bind(slot *filterState, f *Filter, apply func()) {
+	f.restore(slot.Query, slot.mode())
+	if apply != nil {
+		apply()
+	}
+	f.onChange = func() {
+		*slot = filterStateOf(f)
+		df.save()
+	}
+}
+
+func (df *dirFilters) save() {
+	if df.path == "" {
+		return
+	}
+
+	data, err := json.MarshalIndent(df, "", "  ")
+	if err == nil {
+		tmp := df.path + ".tmp"
+		if err = os.WriteFile(tmp, data, 0o644); err == nil {
+			err = os.Rename(tmp, df.path)
+		}
+	}
+	if err != nil {
+		df.logger.Error(fmt.Sprintf("leet: failed to save %s: %v", df.path, err))
+	}
+}

--- a/core/internal/leet/filter.go
+++ b/core/internal/leet/filter.go
@@ -34,6 +34,10 @@ type Filter struct {
 	draft       string          // what the user is typing (preview)
 	applied     string          // committed pattern
 	mode        FilterMatchMode // current match mode
+
+	// onChange, when set, runs after the applied pattern or the match mode
+	// settles: on commit, cancel and clear.
+	onChange func()
 }
 
 func NewFilter() *Filter {
@@ -51,12 +55,14 @@ func (f *Filter) Commit() {
 	f.applied = f.draft
 	f.draft = ""
 	f.inputActive = false
+	f.changed()
 }
 
 // Cancel discards the draft and exits input mode without changing the applied pattern.
 func (f *Filter) Cancel() {
 	f.draft = ""
 	f.inputActive = false
+	f.changed()
 }
 
 // Clear removes any applied filter and exits input mode.
@@ -64,6 +70,19 @@ func (f *Filter) Clear() {
 	f.applied = ""
 	f.draft = ""
 	f.inputActive = false
+	f.changed()
+}
+
+// restore sets the applied pattern and match mode without reporting a change.
+func (f *Filter) restore(query string, mode FilterMatchMode) {
+	f.applied = query
+	f.mode = mode
+}
+
+func (f *Filter) changed() {
+	if f.onChange != nil {
+		f.onChange()
+	}
 }
 
 func (f *Filter) ToggleMode() {

--- a/core/internal/leet/model.go
+++ b/core/internal/leet/model.go
@@ -64,6 +64,9 @@ type Model struct {
 	// schemes, sidebar visibility, etc.).
 	config *ConfigManager
 
+	// filters are the filters remembered for the wandb directory.
+	filters *dirFilters
+
 	logger *observability.CoreLogger
 }
 
@@ -111,11 +114,14 @@ func NewModel(params ModelParams) *Model {
 		workspace: NewWorkspace(params.WandbDir, params.Config, params.Logger),
 		help:      NewHelp(),
 		config:    params.Config,
+		filters:   loadDirFilters(params.WandbDir, params.Logger),
 		logger:    params.Logger,
 	}
+	m.workspace.attachFilters(m.filters)
 
 	if params.RunParams != nil {
 		m.run = NewRun(params.RunParams, params.Config, params.Logger)
+		m.run.attachFilters(m.filters)
 		m.mode = viewModeRun
 	}
 
@@ -432,6 +438,7 @@ func (m *Model) enterRunView() tea.Cmd {
 	}
 
 	m.run = NewRun(&RunParams{RunFile: wandbFile}, m.config, m.logger)
+	m.run.attachFilters(m.filters)
 	m.mode = viewModeRun
 
 	// Share the workspace's media store so data persists across transitions.

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -799,6 +799,14 @@ type Layout struct {
 	consoleLogsHeight      int
 }
 
+// attachFilters restores the filters remembered for the run's wandb
+// directory and keeps them saved.
+func (r *Run) attachFilters(df *dirFilters) {
+	df.bind(&df.Metrics, r.metricsGrid.filter, r.metricsGrid.ApplyFilter)
+	df.bind(&df.SystemMetrics,
+		r.rightSidebar.metricsGrid.filter, r.rightSidebar.metricsGrid.ApplyFilter)
+}
+
 // computeViewports returns (leftW, contentW, rightW, contentH).
 func (r *Run) computeViewports() Layout {
 	leftW, rightW := fitSidebarWidths(r.width, r.leftSidebar.Width(), r.rightSidebar.Width())

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -537,6 +537,15 @@ func (w *Workspace) recalculateLayout() {
 	w.focusMgr.Resolve()
 }
 
+// attachFilters restores the filters remembered for the wandb directory and
+// keeps them saved. System metrics grids are created per run and pick up the
+// shared filter as their charts arrive.
+func (w *Workspace) attachFilters(df *dirFilters) {
+	df.bind(&df.Metrics, w.metricsGrid.filter, w.metricsGrid.ApplyFilter)
+	df.bind(&df.SystemMetrics, w.systemMetricsFilter, nil)
+	df.bind(&df.Runs, w.filter, w.applyRunFilter)
+}
+
 // computeViewports returns the computed layout dimensions.
 //
 // Separator lines between visible sections are subtracted from available height

--- a/core/internal/leet/workspace_test.go
+++ b/core/internal/leet/workspace_test.go
@@ -57,6 +57,31 @@ func TestModel_WorkspaceFilterDoesNotLeakIntoRunView(t *testing.T) {
 	require.NotContains(t, view, `"trainx"`)
 }
 
+func TestModel_FiltersPersistPerWandbDir(t *testing.T) {
+	logger := observability.NewNoOpLogger()
+	wandbDir := t.TempDir()
+	open := func() tea.Model {
+		cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)
+		var model tea.Model = leet.NewModel(leet.ModelParams{
+			WandbDir: wandbDir,
+			Config:   cfg,
+			Logger:   logger,
+		})
+		model, _ = model.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+		return model
+	}
+
+	model := open()
+	model, _ = model.Update(keyPressMsg('/'))
+	for _, r := range "train" {
+		model, _ = model.Update(keyPressMsg(r))
+	}
+	model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	reopened := open()
+	require.Contains(t, stripANSI(reopened.View().Content), `"train"`)
+}
+
 func TestModel_CtrlLInRunViewDoesNotClearWorkspaceFilter(t *testing.T) {
 	logger := observability.NewNoOpLogger()
 	cfg := leet.NewConfigManager(filepath.Join(t.TempDir(), "config.json"), logger)


### PR DESCRIPTION
Description
-----------
With a few hundred metrics, `loss` lands on page 14 of the grid and the first thing you do every time you open LEET is type the same filter again. The metrics, system metrics and runs filters are now saved per wandb directory in `<wandb-dir>/.wandb-leet.json` and restored when the directory is opened again, in both the workspace and the single-run view. A run opened from the workspace starts with the saved filters too.

A `Filter` now takes an optional `onChange` hook that fires when a pattern is committed, cancelled or cleared. `dirFilters` binds each persisted filter to its `Filter`: restore on attach, save on change. The file lives next to the runs so it follows the directory around; when it cannot be written (a read-only shared filesystem) the failure is logged and LEET works as before. Remote runs have no directory and nothing is saved. Within a session the workspace and run views keep independent filters, as before.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Added a test that reopens a directory and finds the filter applied.
