### PR TITLE
feat(leet): filter console logs

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,6 +20,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Added
 
+- LEET filters console logs: with the logs pane focused, press `/` and type a pattern (regex, or glob after `Tab`) to show only the matching lines, following new matches as they arrive; `ctrl+/` clears the filter (@dmitryduev in https://github.com/wandb/wandb/pull/12736)
 - LEET remembers the metrics, system metrics and runs filters for each wandb directory: the next time you open the directory, in the workspace or the single-run view, the filters from the previous session are already applied. They are stored in `.wandb-leet.json` inside the directory; clearing a filter (`ctrl+/`, `ctrl+\`, `ctrl+f`) forgets it (@dmitryduev in https://github.com/wandb/wandb/pull/12735)
 - LEET charts metrics against the custom x-axes set with `run.define_metric()`. A metric defined with a `step_metric`, directly or through a glob like `run.define_metric("train/*", step_metric="train/step")`, is plotted against that metric instead of the step counter, with the axis name shown as `[x: train/step]` in the chart header. Applies to runs viewed from local `.wandb` files. Each chart has a single x-axis, so a run that plots a metric against a different axis is not shown on that chart (@dmitryduev in https://github.com/wandb/wandb/pull/12568, https://github.com/wandb/wandb/pull/12728)
 - The automations API now supports sending a prompt to ARIA (`SendPromptToAria`) as an automation action. (@gdecarvalhovaz-lgtm in https://github.com/wandb/wandb/pull/12594)

--- a/core/internal/leet/consolelogspane.go
+++ b/core/internal/leet/consolelogspane.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/mattn/go-runewidth"
@@ -65,7 +66,12 @@ func consoleLogKeyForWidth(
 type ConsoleLogsPane struct {
 	animState *AnimatedValue
 
-	logs []KeyValuePair
+	// all is every log entry. matched indexes the entries that pass the
+	// filter, in order; scanned is how many entries of all it covers.
+	all     []KeyValuePair
+	matched []int
+	scanned int
+	filter  *Filter
 
 	// cursor is the selected log index (logical row).
 	cursor int
@@ -86,6 +92,7 @@ type ConsoleLogsPane struct {
 func NewConsoleLogsPane(animState *AnimatedValue) *ConsoleLogsPane {
 	return &ConsoleLogsPane{
 		animState:  animState,
+		filter:     NewFilter(),
 		autoScroll: true,
 	}
 }
@@ -126,26 +133,114 @@ func (c *ConsoleLogsPane) UpdateExpandedHeight(maxTerminalHeight int) {
 	c.SetExpandedHeight(maxHeight)
 }
 
-// SetConsoleLogs replaces the displayed log entries and adjusts the
-// viewport. If auto-scroll is enabled, the view snaps to the tail.
+// SetConsoleLogs replaces the log entries and adjusts the viewport. If
+// auto-scroll is enabled, the view snaps to the tail.
+//
+// Entries are appended in place by their source, so only the new tail is
+// matched against the filter, unless the source was swapped for another
+// run's entries or shrank.
 func (c *ConsoleLogsPane) SetConsoleLogs(items []KeyValuePair) {
-	c.logs = items
+	if len(items) < c.scanned || (c.scanned > 0 && &items[0] != &c.all[0]) {
+		c.scanned, c.matched = 0, c.matched[:0]
+	}
+	c.all = items
+	c.scanFilter()
+	c.fitViewport()
+}
 
-	if len(c.logs) == 0 {
+// scanFilter matches the entries not yet tested against the filter.
+func (c *ConsoleLogsPane) scanFilter() {
+	if c.filter.Query() == "" {
+		c.matched, c.scanned = c.matched[:0], len(c.all)
+		return
+	}
+	matcher := c.filter.Matcher()
+	for i := c.scanned; i < len(c.all); i++ {
+		if matcher(c.all[i].Value) {
+			c.matched = append(c.matched, i)
+		}
+	}
+	c.scanned = len(c.all)
+}
+
+// rescan matches every entry against the filter again.
+func (c *ConsoleLogsPane) rescan() {
+	c.scanned, c.matched = 0, c.matched[:0]
+	c.scanFilter()
+	c.fitViewport()
+}
+
+// fitViewport keeps the cursor and the viewport within the shown entries.
+func (c *ConsoleLogsPane) fitViewport() {
+	if c.count() == 0 {
 		c.cursor = 0
 		c.top = 0
 		c.autoScroll = true
 		return
 	}
 
-	c.cursor = clamp(c.cursor, 0, len(c.logs)-1)
-	c.top = clamp(c.top, 0, len(c.logs)-1)
+	c.cursor = clamp(c.cursor, 0, c.count()-1)
+	c.top = clamp(c.top, 0, c.count()-1)
 
 	if c.autoScroll {
 		c.scrollToEnd()
 	} else {
 		c.ensureCursorVisible()
 	}
+}
+
+// count returns the number of shown entries: all of them, or the matches
+// while a filter is set.
+func (c *ConsoleLogsPane) count() int {
+	if c.filter.Query() == "" {
+		return len(c.all)
+	}
+	return len(c.matched)
+}
+
+// entry returns the i-th shown entry.
+func (c *ConsoleLogsPane) entry(i int) KeyValuePair {
+	if c.filter.Query() == "" {
+		return c.all[i]
+	}
+	return c.all[c.matched[i]]
+}
+
+// ---- Filter ----
+
+// EnterFilterMode starts editing the filter pattern.
+func (c *ConsoleLogsPane) EnterFilterMode() { c.filter.Activate() }
+
+// IsFilterMode reports whether the filter pattern is being edited.
+func (c *ConsoleLogsPane) IsFilterMode() bool { return c.filter.IsActive() }
+
+// IsFiltering reports whether an applied filter narrows the entries.
+func (c *ConsoleLogsPane) IsFiltering() bool {
+	return !c.filter.IsActive() && c.filter.Query() != ""
+}
+
+// FilterQuery returns the filter pattern (the draft while editing).
+func (c *ConsoleLogsPane) FilterQuery() string { return c.filter.Query() }
+
+// FilterMode returns the filter's match mode.
+func (c *ConsoleLogsPane) FilterMode() FilterMatchMode { return c.filter.Mode() }
+
+// FilterCounts returns the shown and total numbers of entries.
+func (c *ConsoleLogsPane) FilterCounts() (shown, total int) {
+	return c.count(), len(c.all)
+}
+
+// HandleFilterKey edits the filter pattern; the entries follow live.
+func (c *ConsoleLogsPane) HandleFilterKey(msg tea.KeyPressMsg) {
+	if c.filter.HandleKey(msg) {
+		c.rescan()
+	}
+}
+
+// ClearFilter shows every entry again.
+func (c *ConsoleLogsPane) ClearFilter() {
+	c.filter.Clear()
+	c.rescan()
 }
 
 // View renders the console logs pane at the given width.
@@ -180,7 +275,7 @@ func (c *ConsoleLogsPane) View(width int, runLabel, hint string) string {
 
 	end := c.visibleEnd(c.top, maxValueWidth, contentLines)
 
-	header := c.renderHeader(contentW, runLabel, c.top, end, len(c.logs))
+	header := c.renderHeader(contentW, runLabel, c.top, end, c.count())
 	content := c.renderContent(maxKeyWidth, maxValueWidth, contentLines, c.top, end, hint)
 
 	body := lipgloss.JoinVertical(lipgloss.Left, header, content)
@@ -188,7 +283,7 @@ func (c *ConsoleLogsPane) View(width int, runLabel, hint string) string {
 }
 
 // HasData reports whether the pane has any log entries to display.
-func (c *ConsoleLogsPane) HasData() bool { return len(c.logs) > 0 }
+func (c *ConsoleLogsPane) HasData() bool { return len(c.all) > 0 }
 
 // renderHeader returns the "Console Logs • <runLabel>     [X-Y of N]" line,
 func (c *ConsoleLogsPane) renderHeader(
@@ -231,7 +326,7 @@ func (c *ConsoleLogsPane) renderContent(
 	if contentLines <= 0 {
 		return ""
 	}
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		if hint == "" {
 			hint = "No data."
 		}
@@ -242,8 +337,8 @@ func (c *ConsoleLogsPane) renderContent(
 			hint + strings.Repeat("\n", contentLines-1))
 	}
 
-	startIdx = clamp(startIdx, 0, len(c.logs)-1)
-	endIdx = clamp(endIdx, startIdx, len(c.logs))
+	startIdx = clamp(startIdx, 0, c.count()-1)
+	endIdx = clamp(endIdx, startIdx, c.count())
 
 	var out []string
 	used := 0
@@ -251,7 +346,7 @@ func (c *ConsoleLogsPane) renderContent(
 	for i := startIdx; i < endIdx && used < contentLines; i++ {
 		remaining := contentLines - used
 		entry, lines := c.renderEntry(
-			c.logs[i], i == c.cursor && c.active, maxKeyWidth, maxValueWidth, remaining)
+			c.entry(i), i == c.cursor && c.active, maxKeyWidth, maxValueWidth, remaining)
 		out = append(out, entry)
 		used += lines
 	}
@@ -318,11 +413,11 @@ func (c *ConsoleLogsPane) renderEntry(
 // Up moves the cursor one entry toward the top, wrapping to the last
 // entry when at the beginning.
 func (c *ConsoleLogsPane) Up() {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		return
 	}
 	if c.cursor == 0 {
-		c.cursor = len(c.logs) - 1
+		c.cursor = c.count() - 1
 		c.scrollToEnd()
 	} else {
 		c.cursor--
@@ -334,10 +429,10 @@ func (c *ConsoleLogsPane) Up() {
 // Down moves the cursor one entry toward the bottom, wrapping to the
 // first entry when at the end.
 func (c *ConsoleLogsPane) Down() {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		return
 	}
-	if c.cursor == len(c.logs)-1 {
+	if c.cursor == c.count()-1 {
 		c.cursor = 0
 		c.top = 0
 	} else {
@@ -350,7 +445,7 @@ func (c *ConsoleLogsPane) Down() {
 // PageDown advances the viewport by one screenful, wrapping to the top
 // when past the end.
 func (c *ConsoleLogsPane) PageDown() {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		return
 	}
 	if c.lastContentLines <= 0 || c.lastValueWidth <= 0 {
@@ -359,7 +454,7 @@ func (c *ConsoleLogsPane) PageDown() {
 	}
 
 	end := c.visibleEnd(c.top, c.lastValueWidth, c.lastContentLines)
-	if end >= len(c.logs) {
+	if end >= c.count() {
 		c.cursor = 0
 		c.top = 0
 		c.updateAutoScroll()
@@ -375,7 +470,7 @@ func (c *ConsoleLogsPane) PageDown() {
 // PageUp moves the viewport back by one screenful, wrapping to the end
 // when before the start.
 func (c *ConsoleLogsPane) PageUp() {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		return
 	}
 	if c.lastContentLines <= 0 || c.lastValueWidth <= 0 {
@@ -384,7 +479,7 @@ func (c *ConsoleLogsPane) PageUp() {
 	}
 
 	if c.top == 0 {
-		c.cursor = len(c.logs) - 1
+		c.cursor = c.count() - 1
 		c.scrollToEnd()
 		c.updateAutoScroll()
 		return
@@ -394,7 +489,7 @@ func (c *ConsoleLogsPane) PageUp() {
 	used := 0
 	for newTop > 0 && used < c.lastContentLines {
 		prev := newTop - 1
-		h := wrappedLineCount(c.logs[prev].Value, c.lastValueWidth)
+		h := wrappedLineCount(c.entry(prev).Value, c.lastValueWidth)
 		if used+h > c.lastContentLines && used > 0 {
 			break
 		}
@@ -420,7 +515,7 @@ func (c *ConsoleLogsPane) ScrollToEnd() {
 func (c *ConsoleLogsPane) ScrollToStart() {
 	c.cursor = 0
 	c.top = 0
-	c.autoScroll = len(c.logs) == 0
+	c.autoScroll = c.count() == 0
 }
 
 // ---- Internal scrolling ----
@@ -428,11 +523,11 @@ func (c *ConsoleLogsPane) ScrollToStart() {
 // updateAutoScroll enables auto-scroll when the cursor is on the last
 // entry, and disables it otherwise.
 func (c *ConsoleLogsPane) updateAutoScroll() {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		c.autoScroll = true
 		return
 	}
-	if c.cursor == len(c.logs)-1 {
+	if c.cursor == c.count()-1 {
 		c.autoScroll = true
 		c.scrollToEnd()
 		return
@@ -443,14 +538,14 @@ func (c *ConsoleLogsPane) updateAutoScroll() {
 // ensureCursorVisible adjusts top so that the cursor entry is within the
 // visible window.
 func (c *ConsoleLogsPane) ensureCursorVisible() {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		c.cursor = 0
 		c.top = 0
 		return
 	}
 
-	c.cursor = clamp(c.cursor, 0, len(c.logs)-1)
-	c.top = clamp(c.top, 0, len(c.logs)-1)
+	c.cursor = clamp(c.cursor, 0, c.count()-1)
+	c.top = clamp(c.top, 0, c.count()-1)
 
 	if c.cursor < c.top {
 		c.top = c.cursor
@@ -458,19 +553,19 @@ func (c *ConsoleLogsPane) ensureCursorVisible() {
 	}
 
 	for c.cursor >= c.visibleEnd(
-		c.top, c.lastValueWidth, c.lastContentLines) && c.top < len(c.logs)-1 {
+		c.top, c.lastValueWidth, c.lastContentLines) && c.top < c.count()-1 {
 		c.top++
 	}
 }
 
 // scrollToEnd positions the viewport so the last entry is at the bottom.
 func (c *ConsoleLogsPane) scrollToEnd() {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		c.cursor = 0
 		c.top = 0
 		return
 	}
-	c.cursor = len(c.logs) - 1
+	c.cursor = c.count() - 1
 
 	if c.lastContentLines <= 0 || c.lastValueWidth <= 0 {
 		c.top = c.cursor
@@ -478,11 +573,11 @@ func (c *ConsoleLogsPane) scrollToEnd() {
 	}
 
 	top := c.cursor
-	used := min(wrappedLineCount(c.logs[top].Value, c.lastValueWidth), c.lastContentLines)
+	used := min(wrappedLineCount(c.entry(top).Value, c.lastValueWidth), c.lastContentLines)
 
 	for top > 0 && used < c.lastContentLines {
 		prev := top - 1
-		h := wrappedLineCount(c.logs[prev].Value, c.lastValueWidth)
+		h := wrappedLineCount(c.entry(prev).Value, c.lastValueWidth)
 		if used+h > c.lastContentLines {
 			break
 		}
@@ -497,16 +592,16 @@ func (c *ConsoleLogsPane) scrollToEnd() {
 // within contentLines screen rows starting from startIdx, accounting
 // for line wrapping.
 func (c *ConsoleLogsPane) visibleEnd(startIdx, maxValueWidth, contentLines int) int {
-	if len(c.logs) == 0 {
+	if c.count() == 0 {
 		return 0
 	}
-	startIdx = clamp(startIdx, 0, len(c.logs)-1)
+	startIdx = clamp(startIdx, 0, c.count()-1)
 
 	used := 0
 	i := startIdx
-	for i < len(c.logs) && used < contentLines {
+	for i < c.count() && used < contentLines {
 		remaining := contentLines - used
-		h := wrappedLineCount(c.logs[i].Value, maxValueWidth)
+		h := wrappedLineCount(c.entry(i).Value, maxValueWidth)
 		used += min(h, remaining)
 		i++
 	}

--- a/core/internal/leet/consolelogspane.go
+++ b/core/internal/leet/consolelogspane.go
@@ -2,6 +2,7 @@ package leet
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -136,12 +137,15 @@ func (c *ConsoleLogsPane) UpdateExpandedHeight(maxTerminalHeight int) {
 // SetConsoleLogs replaces the log entries and adjusts the viewport. If
 // auto-scroll is enabled, the view snaps to the tail.
 //
-// Entries are appended in place by their source, so only the new tail is
-// matched against the filter, unless the source was swapped for another
-// run's entries or shrank.
-func (c *ConsoleLogsPane) SetConsoleLogs(items []KeyValuePair) {
+// changedFrom is the first entry that may have changed. Earlier matches
+// are retained unless the source was swapped for another run or shrank.
+func (c *ConsoleLogsPane) SetConsoleLogs(items []KeyValuePair, changedFrom int) {
 	if len(items) < c.scanned || (c.scanned > 0 && &items[0] != &c.all[0]) {
 		c.scanned, c.matched = 0, c.matched[:0]
+	}
+	if changedFrom < c.scanned {
+		c.scanned = changedFrom
+		c.matched = c.matched[:sort.SearchInts(c.matched, changedFrom)]
 	}
 	c.all = items
 	c.scanFilter()

--- a/core/internal/leet/consolelogspane_test.go
+++ b/core/internal/leet/consolelogspane_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/leet"
@@ -33,6 +35,35 @@ func makeLogs(n int) []leet.KeyValuePair {
 		}
 	}
 	return logs
+}
+
+func TestConsoleLogsPane_FilterNarrowsAndFollowsNewLines(t *testing.T) {
+	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
+	expandConsoleLogsPane(t, clp, 12)
+	logs := makeLogs(10)
+	clp.SetConsoleLogs(logs)
+
+	clp.EnterFilterMode()
+	clp.HandleFilterKey(keyPressMsg('3'))
+	clp.HandleFilterKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	view := stripANSI(clp.View(120, "", ""))
+	require.Contains(t, view, "log 03")
+	require.NotContains(t, view, "log 02")
+	require.Contains(t, view, "[1-1 of 1]")
+
+	logs = append(logs,
+		leet.KeyValuePair{Key: "t11", Value: "log 13"},
+		leet.KeyValuePair{Key: "t12", Value: "log 12"})
+	clp.SetConsoleLogs(logs)
+
+	view = stripANSI(clp.View(120, "", ""))
+	require.Contains(t, view, "log 13")
+	require.NotContains(t, view, "log 12")
+	require.Contains(t, view, "[1-2 of 2]")
+
+	clp.ClearFilter()
+	require.Contains(t, stripANSI(clp.View(120, "", "")), "of 12]")
 }
 
 func TestConsoleLogsPane_AutoScrollFreezesWhenUserScrollsUp(t *testing.T) {

--- a/core/internal/leet/consolelogspane_test.go
+++ b/core/internal/leet/consolelogspane_test.go
@@ -40,8 +40,8 @@ func makeLogs(n int) []leet.KeyValuePair {
 func TestConsoleLogsPane_FilterNarrowsAndFollowsNewLines(t *testing.T) {
 	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
 	expandConsoleLogsPane(t, clp, 12)
-	logs := makeLogs(10)
-	clp.SetConsoleLogs(logs)
+	logs := append(make([]leet.KeyValuePair, 0, 12), makeLogs(10)...)
+	clp.SetConsoleLogs(logs, 0)
 
 	clp.EnterFilterMode()
 	clp.HandleFilterKey(keyPressMsg('3'))
@@ -55,11 +55,21 @@ func TestConsoleLogsPane_FilterNarrowsAndFollowsNewLines(t *testing.T) {
 	logs = append(logs,
 		leet.KeyValuePair{Key: "t11", Value: "log 13"},
 		leet.KeyValuePair{Key: "t12", Value: "log 12"})
-	clp.SetConsoleLogs(logs)
+	clp.SetConsoleLogs(logs, 10)
 
 	view = stripANSI(clp.View(120, "", ""))
 	require.Contains(t, view, "log 13")
 	require.NotContains(t, view, "log 12")
+	require.Contains(t, view, "[1-2 of 2]")
+
+	// Switching sources must scan every entry even if that source has no
+	// changes since it was last displayed.
+	other := makeLogs(12)
+	other[0].Value = "other 3"
+	clp.SetConsoleLogs(other, len(other))
+	view = stripANSI(clp.View(120, "", ""))
+	require.Contains(t, view, "other 3")
+	require.NotContains(t, view, "log 13")
 	require.Contains(t, view, "[1-2 of 2]")
 
 	clp.ClearFilter()
@@ -70,7 +80,7 @@ func TestConsoleLogsPane_AutoScrollFreezesWhenUserScrollsUp(t *testing.T) {
 	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
 	expandConsoleLogsPane(t, clp, 5) // header + padding + 3 content lines
 
-	clp.SetConsoleLogs(makeLogs(10))
+	clp.SetConsoleLogs(makeLogs(10), 0)
 	out := stripANSI(clp.View(80, "", ""))
 	require.Contains(t, out, "[8-10 of 10]", "should auto-scroll to the end initially")
 
@@ -78,7 +88,7 @@ func TestConsoleLogsPane_AutoScrollFreezesWhenUserScrollsUp(t *testing.T) {
 	clp.Up()
 
 	// New logs arrive: view should NOT jump to show the new end.
-	clp.SetConsoleLogs(makeLogs(11))
+	clp.SetConsoleLogs(makeLogs(11), 0)
 	out = stripANSI(clp.View(80, "", ""))
 	require.Contains(t, out, "[8-10 of 11]", "should not jump to end when autoScroll is disabled")
 
@@ -92,7 +102,7 @@ func TestConsoleLogsPane_ScrollToStart_JumpsToFirstAndFreezesAutoscroll(t *testi
 	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
 	expandConsoleLogsPane(t, clp, 4) // header + padding + 2 content lines
 
-	clp.SetConsoleLogs(makeLogs(5))
+	clp.SetConsoleLogs(makeLogs(5), 0)
 	out := stripANSI(clp.View(80, "", ""))
 	require.Contains(t, out, "[4-5 of 5]", "auto-scroll lands at the end initially")
 
@@ -101,7 +111,7 @@ func TestConsoleLogsPane_ScrollToStart_JumpsToFirstAndFreezesAutoscroll(t *testi
 	require.Contains(t, out, "[1-2 of 5]", "ScrollToStart should show first logs")
 
 	// New logs arriving must not jump to the end — autoscroll is off.
-	clp.SetConsoleLogs(makeLogs(8))
+	clp.SetConsoleLogs(makeLogs(8), 0)
 	out = stripANSI(clp.View(80, "", ""))
 	require.Contains(t, out, "[1-2 of 8]", "autoscroll stays disabled after ScrollToStart")
 }
@@ -110,7 +120,7 @@ func TestConsoleLogsPane_PageUpDown_WrapsAround(t *testing.T) {
 	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
 	expandConsoleLogsPane(t, clp, 4) // header + padding + 2 content lines
 
-	clp.SetConsoleLogs(makeLogs(5))
+	clp.SetConsoleLogs(makeLogs(5), 0)
 	out := stripANSI(clp.View(80, "", ""))
 	require.Contains(t, out, "[4-5 of 5]", "should start at end when auto-scroll is on")
 
@@ -223,7 +233,7 @@ func TestConsoleLogsPane_Down_CyclesAndWraps(t *testing.T) {
 	clp := leet.NewConsoleLogsPane(leet.NewAnimatedValue(false, leet.ConsoleLogsPaneMinHeight))
 	expandConsoleLogsPane(t, clp, 5) // border + header + 3 content lines
 
-	clp.SetConsoleLogs(makeLogs(5))
+	clp.SetConsoleLogs(makeLogs(5), 0)
 	out := stripANSI(clp.View(80, "", ""))
 	require.Contains(t, out, "[3-5 of 5]", "initial view should auto-scroll to end")
 
@@ -286,7 +296,7 @@ func TestConsoleLogsPane_TimestampAdaptsToAvailableWidth(t *testing.T) {
 
 			clp.SetConsoleLogs([]leet.KeyValuePair{
 				{Key: "10:11:12", Value: "hello"},
-			})
+			}, 0)
 
 			out := stripANSI(clp.View(tt.width, "", ""))
 			require.Contains(t, out, "hello", "log content should still render")

--- a/core/internal/leet/keybindings.go
+++ b/core/internal/leet/keybindings.go
@@ -134,7 +134,7 @@ func RunKeyBindings() []BindingCategory[Run] {
 				},
 				{
 					Keys:        []string{"/"},
-					Description: "Filter metrics by pattern",
+					Description: "Filter metrics by pattern (console logs when the logs pane is focused)",
 					Handler:     (*Run).handleEnterMetricsFilter,
 				},
 				{
@@ -144,7 +144,7 @@ func RunKeyBindings() []BindingCategory[Run] {
 				},
 				{
 					Keys:        []string{"ctrl+/", "ctrl+l"},
-					Description: "Clear metrics filter",
+					Description: "Clear metrics filter (console filter when the logs pane is focused)",
 					Handler:     (*Run).handleClearMetricsFilter,
 				},
 				{
@@ -361,7 +361,7 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 				},
 				{
 					Keys:        []string{"/"},
-					Description: "Filter metrics by pattern",
+					Description: "Filter metrics by pattern (console logs when the logs pane is focused)",
 					Handler:     (*Workspace).handleEnterMetricsFilter,
 				},
 				{
@@ -372,7 +372,7 @@ func WorkspaceKeyBindings() []BindingCategory[Workspace] {
 				{
 					// TODO: remove ctrl+l.
 					Keys:        []string{"ctrl+/", "ctrl+l"},
-					Description: "Clear metrics filter",
+					Description: "Clear metrics filter (console filter when the logs pane is focused)",
 					Handler:     (*Workspace).handleClearMetricsFilter,
 				},
 				{

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -552,6 +552,9 @@ func (r *Run) buildStatusText() string {
 	if r.rightSidebar.IsFilterMode() {
 		return r.buildSystemMetricsFilterStatus()
 	}
+	if r.consoleLogsPane.IsFilterMode() {
+		return r.buildConsoleFilterStatus()
+	}
 	if r.config.IsAwaitingGridConfig() {
 		return r.config.GridConfigStatus()
 	}
@@ -606,6 +609,18 @@ func (r *Run) buildSystemMetricsFilterStatus() string {
 	)
 }
 
+func (r *Run) buildConsoleFilterStatus() string {
+	shown, total := r.consoleLogsPane.FilterCounts()
+	return fmt.Sprintf(
+		"Console filter (%s): %s%s [%d/%d] (Enter to apply • Tab to toggle mode)",
+		r.consoleLogsPane.FilterMode().String(),
+		r.consoleLogsPane.FilterQuery(),
+		string(mediumShadeBlock),
+		shown,
+		total,
+	)
+}
+
 // buildLoadingStatus builds status for loading mode.
 func (r *Run) buildLoadingStatus() string {
 	if r.recordsLoaded > 0 {
@@ -644,6 +659,17 @@ func (r *Run) buildActiveStatus() string {
 			grid.FilterQuery(),
 			grid.FilteredChartCount(),
 			grid.ChartCount(),
+		))
+	}
+
+	if r.consoleLogsPane.IsFiltering() {
+		shown, total := r.consoleLogsPane.FilterCounts()
+		parts = append(parts, fmt.Sprintf(
+			"Console filter (%s): %q [%d/%d] (focus logs, / to change, ctrl+/ to clear)",
+			r.consoleLogsPane.FilterMode().String(),
+			r.consoleLogsPane.FilterQuery(),
+			shown,
+			total,
 		))
 	}
 
@@ -690,9 +716,7 @@ func (r *Run) buildActiveStatus() string {
 
 // buildHelpText builds the help text for the status bar.
 func (r *Run) buildHelpText() string {
-	if r.metricsGrid.IsFilterMode() ||
-		r.leftSidebar.IsFilterMode() ||
-		r.rightSidebar.IsFilterMode() {
+	if r.IsFiltering() {
 		return ""
 	}
 	return "h: help"
@@ -701,7 +725,8 @@ func (r *Run) buildHelpText() string {
 func (r *Run) IsFiltering() bool {
 	return r.metricsGrid.IsFilterMode() ||
 		r.leftSidebar.IsFilterMode() ||
-		r.rightSidebar.IsFilterMode()
+		r.rightSidebar.IsFilterMode() ||
+		r.consoleLogsPane.IsFilterMode()
 }
 
 func (r *Run) MediaFullscreen() bool {

--- a/core/internal/leet/run.go
+++ b/core/internal/leet/run.go
@@ -419,7 +419,7 @@ func (r *Run) renderMainView() string {
 			r.mediaPane.Park()
 		}
 		if layout.consoleLogsHeight > 0 {
-			r.consoleLogsPane.SetConsoleLogs(r.consoleLogs.Items())
+			r.consoleLogsPane.SetConsoleLogs(r.consoleLogs.takeChanges())
 			sections = append(sections, r.consoleLogsPane.View(w, "", ""))
 		}
 

--- a/core/internal/leet/runconsolelogs.go
+++ b/core/internal/leet/runconsolelogs.go
@@ -58,6 +58,9 @@ type RunConsoleLogs struct {
 	// It is updated incrementally so View does not need to reformat every line on
 	// every render.
 	items []KeyValuePair
+
+	// dirtyFrom is the first line changed since the pane took an update.
+	dirtyFrom int
 }
 
 // NewRunConsoleLogs creates an empty console log store with terminal
@@ -114,6 +117,15 @@ func (cl *RunConsoleLogs) Items() []KeyValuePair {
 	return cl.items
 }
 
+// takeChanges returns the entries and the first one that needs rematching.
+// The owning console pane is the sole consumer of these updates.
+func (cl *RunConsoleLogs) takeChanges() ([]KeyValuePair, int) {
+	items := cl.Items()
+	dirtyFrom := cl.dirtyFrom
+	cl.dirtyFrom = len(items)
+	return items, dirtyFrom
+}
+
 // appendLine is called by the line supplier when a new terminal line is
 // created. Returns the index for future PutChar callbacks.
 func (cl *RunConsoleLogs) appendLine(isStderr bool) int {
@@ -136,6 +148,7 @@ func (cl *RunConsoleLogs) onLineChanged(idx int, content []rune) {
 	}
 	value := strings.TrimRight(string(content), " \t")
 	cl.lines[idx].Content = value
+	cl.dirtyFrom = min(cl.dirtyFrom, idx)
 	if idx < len(cl.items) {
 		cl.items[idx].Value = value
 	}

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -66,7 +66,7 @@ func (r *Run) handleRecordMsg(msg tea.Msg) tea.Cmd {
 		r.consoleLogs.ProcessRaw(msg.Text, msg.IsStderr, msg.Time)
 		// Keep the pane's data (and thus focus availability) current
 		// without waiting for the next render.
-		r.consoleLogsPane.SetConsoleLogs(r.consoleLogs.Items())
+		r.consoleLogsPane.SetConsoleLogs(r.consoleLogs.takeChanges())
 
 	case FileCompleteMsg:
 		r.logger.Debug("model: processing FileCompleteMsg - file is complete!")

--- a/core/internal/leet/runhandlers.go
+++ b/core/internal/leet/runhandlers.go
@@ -353,6 +353,10 @@ func (r *Run) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		r.rightSidebar.HandleFilterKey(msg)
 		return nil
 	}
+	if r.consoleLogsPane.IsFilterMode() {
+		r.consoleLogsPane.HandleFilterKey(msg)
+		return nil
+	}
 
 	// Grid config capture takes priority.
 	if r.config.IsAwaitingGridConfig() {
@@ -561,11 +565,19 @@ func (r *Run) handleCycleChartGuides(tea.KeyPressMsg) tea.Cmd {
 }
 
 func (r *Run) handleEnterMetricsFilter(msg tea.KeyPressMsg) tea.Cmd {
+	if r.focusMgr.Current() == FocusTargetConsoleLogs {
+		r.consoleLogsPane.EnterFilterMode()
+		return nil
+	}
 	r.metricsGrid.EnterFilterMode()
 	return nil
 }
 
 func (r *Run) handleClearMetricsFilter(msg tea.KeyPressMsg) tea.Cmd {
+	if r.focusMgr.Current() == FocusTargetConsoleLogs {
+		r.consoleLogsPane.ClearFilter()
+		return nil
+	}
 	if r.metricsGrid.FilterQuery() != "" {
 		r.metricsGrid.ClearFilter()
 	}

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -186,6 +186,23 @@ func TestRun_InitialFocus_PicksFirstAvailablePane(t *testing.T) {
 		"collapsed overview should not appear focused")
 }
 
+// ---- Console filter ----
+
+func TestRun_SlashFiltersConsoleLogsWhenLogsPaneFocused(t *testing.T) {
+	r := newRunForHandlerTest(t)
+	r.TestForceExpandConsoleLogsPane(10)
+	seedConsoleLog(r)
+	r.TestSetFocusTarget(int(leet.FocusTargetConsoleLogs))
+
+	r.Update(keyPressMsg('/'))
+	require.Contains(t, stripANSI(r.View().Content), "Console filter (regex):")
+	require.True(t, r.IsFiltering())
+
+	r.Update(keyPressMsg('x'))
+	r.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.Contains(t, stripANSI(r.View().Content), `Console filter (regex): "x" [0/1]`)
+}
+
 // ---- Mouse drag-resize ----
 
 func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {

--- a/core/internal/leet/runhandlers_test.go
+++ b/core/internal/leet/runhandlers_test.go
@@ -203,6 +203,35 @@ func TestRun_SlashFiltersConsoleLogsWhenLogsPaneFocused(t *testing.T) {
 	require.Contains(t, stripANSI(r.View().Content), `Console filter (regex): "x" [0/1]`)
 }
 
+func TestRun_ConsoleFilterRematchesChangedLines(t *testing.T) {
+	for _, tt := range []struct {
+		name, initial, next string
+		wantCounts          string
+	}{
+		{"partial line becomes matching", "err", "or", "[1/1]"},
+		{"carriage return removes match", "error", "\rokay ", "[0/1]"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newRunForHandlerTest(t)
+			r.TestForceExpandConsoleLogsPane(10)
+			r.Update(leet.ConsoleLogMsg{Text: tt.initial, Time: time.Now()})
+			r.TestSetFocusTarget(int(leet.FocusTargetConsoleLogs))
+			r.Update(keyPressMsg('/'))
+			for _, ch := range "error" {
+				r.Update(keyPressMsg(ch))
+			}
+			r.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+			_ = r.View()
+
+			r.Update(leet.ConsoleLogMsg{Text: tt.next, Time: time.Now()})
+			for range 2 {
+				view := stripANSI(r.View().Content)
+				require.Contains(t, view, `Console filter (regex): "error" `+tt.wantCounts)
+			}
+		})
+	}
+}
+
 // ---- Mouse drag-resize ----
 
 func TestRun_DragResizesRightSidebarAndPersists(t *testing.T) {

--- a/core/internal/leet/testhelpers.go
+++ b/core/internal/leet/testhelpers.go
@@ -602,7 +602,7 @@ func (w *Workspace) TestSeedConsoleLogs(runKey string, lines ...string) {
 	for _, line := range lines {
 		cl.ProcessRaw(line, false, time.Now())
 	}
-	w.consoleLogsPane.SetConsoleLogs(cl.Items())
+	w.consoleLogsPane.SetConsoleLogs(cl.takeChanges())
 }
 
 // TestRunOverviewSidebarHasActiveSection reports whether the overview sidebar

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -508,14 +508,14 @@ func (w *Workspace) syncCurrentRunContext() (
 	}
 
 	if currentRunKey == "" {
-		w.consoleLogsPane.SetConsoleLogs(nil)
+		w.consoleLogsPane.SetConsoleLogs(nil, 0)
 		return runLabel, systemGrid, systemHint, mediaHint, logsHint
 	}
 
 	if cl := w.consoleLogs[currentRunKey]; cl != nil {
-		w.consoleLogsPane.SetConsoleLogs(cl.Items())
+		w.consoleLogsPane.SetConsoleLogs(cl.takeChanges())
 	} else {
-		w.consoleLogsPane.SetConsoleLogs(nil)
+		w.consoleLogsPane.SetConsoleLogs(nil, 0)
 	}
 
 	if _, selected := w.selectedRuns[currentRunKey]; !selected {

--- a/core/internal/leet/workspace.go
+++ b/core/internal/leet/workspace.go
@@ -402,6 +402,7 @@ func (w *Workspace) Cleanup() {
 func (w *Workspace) IsFiltering() bool {
 	if w.metricsGrid.IsFilterMode() ||
 		w.runOverviewSidebar.IsFilterMode() ||
+		w.consoleLogsPane.IsFilterMode() ||
 		w.filter.IsActive() {
 		return true
 	}
@@ -1229,6 +1230,9 @@ func (w *Workspace) buildStatusText() string {
 	if w.runOverviewSidebar.IsFilterMode() {
 		return w.buildOverviewFilterStatus()
 	}
+	if w.consoleLogsPane.IsFilterMode() {
+		return w.buildConsoleFilterStatus()
+	}
 
 	// Grid layout prompt (rows/cols) for metrics/system grids.
 	if w.config != nil && w.config.IsAwaitingGridConfig() {
@@ -1260,6 +1264,18 @@ func (w *Workspace) buildSystemMetricsFilterStatus(grid *SystemMetricsGrid) stri
 		string(mediumShadeBlock),
 		grid.FilteredChartCount(),
 		grid.ChartCount(),
+	)
+}
+
+func (w *Workspace) buildConsoleFilterStatus() string {
+	shown, total := w.consoleLogsPane.FilterCounts()
+	return fmt.Sprintf(
+		"Console filter (%s): %s%s [%d/%d] (Enter to apply • Tab to toggle mode)",
+		w.consoleLogsPane.FilterMode().String(),
+		w.consoleLogsPane.FilterQuery(),
+		string(mediumShadeBlock),
+		shown,
+		total,
 	)
 }
 
@@ -1341,6 +1357,17 @@ func (w *Workspace) activeFilterStatus() []string {
 			"Overview: %q [%s] (o to change, ctrl+o to clear)",
 			w.runOverviewSidebar.FilterQuery(),
 			w.runOverviewSidebar.FilterInfo(),
+		))
+	}
+
+	if w.consoleLogsPane.IsVisible() && w.consoleLogsPane.IsFiltering() {
+		shown, total := w.consoleLogsPane.FilterCounts()
+		parts = append(parts, fmt.Sprintf(
+			"Console filter (%s): %q [%d/%d] (focus logs, / to change, ctrl+/ to clear)",
+			w.consoleLogsPane.FilterMode().String(),
+			w.consoleLogsPane.FilterQuery(),
+			shown,
+			total,
 		))
 	}
 

--- a/core/internal/leet/workspacehandlers.go
+++ b/core/internal/leet/workspacehandlers.go
@@ -77,6 +77,10 @@ func (w *Workspace) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		g.handleFilterKey(msg)
 		return nil
 	}
+	if w.consoleLogsPane.IsFilterMode() {
+		w.consoleLogsPane.HandleFilterKey(msg)
+		return nil
+	}
 
 	// Grid config capture takes priority.
 	if w.config.IsAwaitingGridConfig() {
@@ -1028,6 +1032,10 @@ func (w *Workspace) handleCycleChartGuides(tea.KeyPressMsg) tea.Cmd {
 }
 
 func (w *Workspace) handleEnterMetricsFilter(msg tea.KeyPressMsg) tea.Cmd {
+	if w.focusMgr.Current() == FocusTargetConsoleLogs {
+		w.consoleLogsPane.EnterFilterMode()
+		return nil
+	}
 	w.metricsGrid.EnterFilterMode()
 	return nil
 }
@@ -1053,6 +1061,10 @@ func (w *Workspace) handleEnterSystemMetricsFilter(msg tea.KeyPressMsg) tea.Cmd 
 }
 
 func (w *Workspace) handleClearMetricsFilter(msg tea.KeyPressMsg) tea.Cmd {
+	if w.focusMgr.Current() == FocusTargetConsoleLogs {
+		w.consoleLogsPane.ClearFilter()
+		return nil
+	}
 	if w.metricsGrid.FilterQuery() != "" {
 		w.metricsGrid.ClearFilter()
 	}


### PR DESCRIPTION
Description
-----------
The console logs pane could only be scrolled. With the logs pane focused, `/` now opens a filter with the same editor as the metrics filter: the pane narrows to the matching lines while you type, `Tab` switches between regex and glob matching, `Enter` applies, `Esc` cancels and `ctrl+/` clears. The status bar shows the pattern and the shown/total line counts. With any other pane focused, `/` and `ctrl+/` keep filtering the metrics grid.

The pane keeps every entry and an index of the matches. Entries are appended in place by their source, so only the new tail is matched on each update; a filtered view follows new matching lines the same way the unfiltered one follows new output. Switching to another run's logs in the workspace rescans.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Pane test for narrowing and following new lines; run-view test that `/` targets the focused logs pane.
