### PR TITLE
feat(sdk): add wandb.beta.LocalApi for reading runs from a local wandb directory

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Added
+
+- `wandb.beta.LocalApi` reads runs from a local wandb directory without a W&B server, API key or network: list the runs with their state, and read a run's config, summary, history rows and console logs, including while the run is still writing. It is experimental and may change in any release (@dmitryduev in https://github.com/wandb/wandb/pull/12745)
+
 ### Changed
 
 - Runs now write data to disk every 15 seconds, so that wandb leet updates sooner for runs that don't log a lot of data (@dmitryduev in https://github.com/wandb/wandb/pull/12742)

--- a/tests/unit_tests/test_beta_local_api.py
+++ b/tests/unit_tests/test_beta_local_api.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pathlib
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+from wandb.beta import LocalApi, LocalRun
+from wandb.proto import wandb_api_pb2 as apb
+
+RUN_DIR = "run-20260101_120000-abc"
+
+
+def _info(tmp_path: pathlib.Path, **overrides) -> apb.LocalRunInfo:
+    fields = {
+        "wandb_file": str(tmp_path / RUN_DIR / "run-abc.wandb"),
+        "run_id": "abc",
+        "project": "proj",
+        "display_name": "first",
+        "tags": ["a"],
+        "state": "finished",
+    }
+    fields.update(overrides)
+    return apb.LocalRunInfo(**fields)
+
+
+def _api(tmp_path: pathlib.Path, service_api) -> LocalApi:
+    api = LocalApi(tmp_path)
+    api._service_api = service_api
+    return api
+
+
+def test_runs_lists_the_directory(tmp_path):
+    service_api = mock.MagicMock()
+    service_api.send_api_request.return_value = apb.ApiResponse(
+        list_local_runs_response=apb.ListLocalRunsResponse(runs=[_info(tmp_path)])
+    )
+
+    (run,) = _api(tmp_path, service_api).runs()
+
+    request = service_api.send_api_request.call_args.args[0]
+    assert request.list_local_runs_request.wandb_dir == str(tmp_path.resolve())
+    assert (run.id, run.name, run.state, run.tags) == (
+        "abc",
+        "first",
+        "finished",
+        ["a"],
+    )
+    assert run.sync_dir == str(tmp_path / RUN_DIR)
+    assert run.wandb_file == str(tmp_path / RUN_DIR / "run-abc.wandb")
+    assert service_api.send_api_request.call_count == 1
+
+
+def test_run_details_are_read_once_until_refresh(tmp_path):
+    service_api = mock.MagicMock()
+    service_api.send_api_request.return_value = apb.ApiResponse(
+        read_local_run_response=apb.ReadLocalRunResponse(
+            info=_info(tmp_path, state="running"),
+            config_json='{"lr": 0.1, "_wandb": {"code_path": "train.py"}}',
+            summary_json='{"loss": 0.5}',
+            environment_json='{"os": "linux"}',
+            last_step=9,
+            history_keys=["loss"],
+        )
+    )
+    run = LocalRun(service_api, wandb_file=str(tmp_path / RUN_DIR / "run-abc.wandb"))
+
+    assert run.state == "running"
+    assert run.config == {"lr": 0.1}
+    assert run.summary == {"loss": 0.5}
+    assert run.metadata == {"os": "linux"}
+    assert run.last_step == 9
+    assert run.history_keys == ["loss"]
+    assert run.exit_code is None
+    assert run.start_time is None
+    assert service_api.send_api_request.call_count == 1
+
+    run.refresh()
+    assert run.name == "first"
+    assert service_api.send_api_request.call_count == 2
+
+
+def test_history_rows_are_decoded(tmp_path):
+    service_api = mock.MagicMock()
+    service_api.send_api_request.return_value = apb.ApiResponse(
+        read_local_run_history_response=apb.ReadLocalRunHistoryResponse(
+            rows=[
+                apb.LocalHistoryRow(
+                    step=3,
+                    items=[
+                        apb.LocalHistoryItem(key="loss", value_json="0.25"),
+                        apb.LocalHistoryItem(key="name", value_json='"x"'),
+                    ],
+                )
+            ]
+        )
+    )
+    run = LocalRun(service_api, info=_info(tmp_path))
+
+    rows = run.history(keys=["loss", "name"], last=1)
+
+    assert rows == [{"_step": 3, "loss": 0.25, "name": "x"}]
+    request = service_api.send_api_request.call_args.args[0]
+    assert list(request.read_local_run_history_request.keys) == ["loss", "name"]
+    assert request.read_local_run_history_request.last == 1
+    assert not request.read_local_run_history_request.HasField("min_step")
+
+
+def test_console_logs(tmp_path):
+    service_api = mock.MagicMock()
+    service_api.send_api_request.return_value = apb.ApiResponse(
+        read_local_run_console_logs_response=apb.ReadLocalRunConsoleLogsResponse(
+            lines=[
+                apb.RunConsoleLogLine(
+                    number=2,
+                    timestamp="2026-01-01T12:00:00Z",
+                    level="error",
+                    content="line 2",
+                )
+            ],
+            total_lines=3,
+        )
+    )
+    run = LocalRun(service_api, info=_info(tmp_path))
+
+    (line,) = run.console_logs(last=1)
+
+    assert line.number == 2
+    assert line.content == "line 2"
+    assert line.level == "error"
+    assert line.timestamp == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+    request = service_api.send_api_request.call_args.args[0]
+    assert request.read_local_run_console_logs_request.last == 1
+
+    run.console_logs()
+    request = service_api.send_api_request.call_args.args[0]
+    assert not request.read_local_run_console_logs_request.HasField("last")
+
+
+def test_run_resolves_paths_names_and_ids(tmp_path):
+    wandb_file = tmp_path / RUN_DIR / "run-abc.wandb"
+    wandb_file.parent.mkdir()
+    wandb_file.touch()
+    service_api = mock.MagicMock()
+    api = _api(tmp_path, service_api)
+
+    assert api.run(RUN_DIR).wandb_file == str(wandb_file)
+    assert api.run(wandb_file).wandb_file == str(wandb_file)
+    assert api.run(wandb_file.parent).wandb_file == str(wandb_file)
+    assert api.run("abc").wandb_file == str(wandb_file)
+    with pytest.raises(FileNotFoundError):
+        api.run("nope")
+    service_api.send_api_request.assert_not_called()

--- a/tests/unit_tests/test_beta_local_api.py
+++ b/tests/unit_tests/test_beta_local_api.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 from wandb.beta import LocalApi, LocalRun
 from wandb.proto import wandb_api_pb2 as apb
+from wandb.sdk import wandb_setup
 
 RUN_DIR = "run-20260101_120000-abc"
 
@@ -28,6 +29,24 @@ def _api(tmp_path: pathlib.Path, service_api) -> LocalApi:
     api = LocalApi(tmp_path)
     api._service_api = service_api
     return api
+
+
+def test_local_reads_do_not_require_identity_token(tmp_path, monkeypatch):
+    setup = wandb_setup.singleton()
+    token_file = str(tmp_path / "missing.jwt")
+    monkeypatch.setattr(setup.settings, "identity_token_file", token_file)
+    connection = mock.MagicMock()
+    connection.api_init_request.return_value = apb.ServerApiInitResponse(api_id="local")
+    connection.api_request.return_value = apb.ApiResponse(
+        list_local_runs_response=apb.ListLocalRunsResponse()
+    )
+
+    with mock.patch.object(setup, "ensure_service", return_value=connection):
+        assert LocalApi(tmp_path).runs() == []
+
+    settings = connection.api_init_request.call_args.args[0]
+    assert not settings.HasField("identity_token_file")
+    assert setup.settings.identity_token_file == token_file
 
 
 def test_runs_lists_the_directory(tmp_path):
@@ -90,6 +109,8 @@ def test_history_rows_are_decoded(tmp_path):
                     items=[
                         apb.LocalHistoryItem(key="loss", value_json="0.25"),
                         apb.LocalHistoryItem(key="name", value_json='"x"'),
+                        apb.LocalHistoryItem(key="a.b", value_json="1"),
+                        apb.LocalHistoryItem(key=r"a\.b", value_json="2"),
                     ],
                 )
             ]
@@ -97,11 +118,12 @@ def test_history_rows_are_decoded(tmp_path):
     )
     run = LocalRun(service_api, info=_info(tmp_path))
 
-    rows = run.history(keys=["loss", "name"], last=1)
+    keys = ["loss", "name", "a.b", r"a\.b"]
+    rows = run.history(keys=keys, last=1)
 
-    assert rows == [{"_step": 3, "loss": 0.25, "name": "x"}]
+    assert rows == [{"_step": 3, "loss": 0.25, "name": "x", "a.b": 1, r"a\.b": 2}]
     request = service_api.send_api_request.call_args.args[0]
-    assert list(request.read_local_run_history_request.keys) == ["loss", "name"]
+    assert list(request.read_local_run_history_request.keys) == keys
     assert request.read_local_run_history_request.last == 1
     assert not request.read_local_run_history_request.HasField("min_step")
 

--- a/tests/unit_tests/test_beta_local_api.py
+++ b/tests/unit_tests/test_beta_local_api.py
@@ -99,33 +99,34 @@ def test_run_details_are_read_once_until_refresh(tmp_path):
     assert service_api.send_api_request.call_count == 2
 
 
-def test_history_rows_are_decoded(tmp_path):
+def test_history_follows_pages(tmp_path):
     service_api = mock.MagicMock()
-    service_api.send_api_request.return_value = apb.ApiResponse(
-        read_local_run_history_response=apb.ReadLocalRunHistoryResponse(
-            rows=[
-                apb.LocalHistoryRow(
-                    step=3,
-                    items=[
-                        apb.LocalHistoryItem(key="loss", value_json="0.25"),
-                        apb.LocalHistoryItem(key="name", value_json='"x"'),
-                        apb.LocalHistoryItem(key="a.b", value_json="1"),
-                        apb.LocalHistoryItem(key=r"a\.b", value_json="2"),
-                    ],
-                )
-            ]
-        )
-    )
+    service_api.send_api_request.side_effect = [
+        apb.ApiResponse(
+            read_local_run_history_response=apb.ReadLocalRunHistoryResponse(
+                rows=b'{"_step":3,"loss":0.25}\n{"_step":4,"a.b":"x"}\n',
+                next_offset=512,
+            )
+        ),
+        apb.ApiResponse(
+            read_local_run_history_response=apb.ReadLocalRunHistoryResponse(
+                rows=b'{"_step":5,"loss":NaN}\n'
+            )
+        ),
+    ]
     run = LocalRun(service_api, info=_info(tmp_path))
 
-    keys = ["loss", "name", "a.b", r"a\.b"]
-    rows = run.history(keys=keys, last=1)
+    rows = list(run.history(keys=["loss", "a.b"], min_step=3))
 
-    assert rows == [{"_step": 3, "loss": 0.25, "name": "x", "a.b": 1, r"a\.b": 2}]
-    request = service_api.send_api_request.call_args.args[0]
-    assert list(request.read_local_run_history_request.keys) == keys
-    assert request.read_local_run_history_request.last == 1
-    assert not request.read_local_run_history_request.HasField("min_step")
+    assert rows[:2] == [{"_step": 3, "loss": 0.25}, {"_step": 4, "a.b": "x"}]
+    assert rows[2]["loss"] != rows[2]["loss"]
+    first, second = (
+        call.args[0].read_local_run_history_request
+        for call in service_api.send_api_request.call_args_list
+    )
+    assert (list(first.keys), first.min_step, first.offset) == (["loss", "a.b"], 3, 0)
+    assert second.offset == 512
+    assert first.limit == second.limit > 0
 
 
 def test_console_logs(tmp_path):

--- a/wandb/beta/__init__.py
+++ b/wandb/beta/__init__.py
@@ -1,0 +1,8 @@
+"""Experimental features.
+
+Anything in this package may change or be removed in any release of wandb.
+"""
+
+from wandb.beta.local_api import LocalApi, LocalRun
+
+__all__ = ["LocalApi", "LocalRun"]

--- a/wandb/beta/__init__.py
+++ b/wandb/beta/__init__.py
@@ -3,6 +3,6 @@
 Anything in this package may change or be removed in any release of wandb.
 """
 
-from wandb.beta.local_api import LocalApi, LocalRun
+from wandb.beta.local_api import LocalApi, LocalHistory, LocalRun
 
-__all__ = ["LocalApi", "LocalRun"]
+__all__ = ["LocalApi", "LocalHistory", "LocalRun"]

--- a/wandb/beta/local_api.py
+++ b/wandb/beta/local_api.py
@@ -1,0 +1,329 @@
+"""Read runs from a local wandb directory, without a W&B server.
+
+Every run writes a `.wandb` transaction log to its run directory. `LocalApi`
+reads those logs, so it works for offline runs, for runs that have not been
+synced, and for runs that are still writing. Reads go through wandb-core,
+like `wandb.Api()`, but need no API key or network.
+
+Example:
+```python
+from wandb.beta import LocalApi
+
+api = LocalApi("./wandb")
+for run in api.runs():
+    print(run.name, run.state, run.summary.get("loss"))
+
+run = api.run("abc123")
+for row in run.history(keys=["loss"], last=10):
+    print(row["_step"], row["loss"])
+for line in run.console_logs(last=20):
+    print(line.timestamp, line.content)
+```
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+from wandb.apis.normalize import normalize_exceptions
+from wandb.apis.public.console_logs import ConsoleLogLine, _parse_timestamp
+from wandb.apis.public.service_api import ServiceApi
+from wandb.errors.term import termwarn
+from wandb.proto import wandb_api_pb2 as apb
+from wandb.sdk import wandb_setup
+
+
+class LocalApi:
+    """Reads the runs in a local wandb directory.
+
+    Args:
+        wandb_dir: The wandb directory, e.g. `"./wandb"`. Defaults to the
+            directory runs are written to under the current settings.
+    """
+
+    def __init__(self, wandb_dir: str | os.PathLike[str] | None = None) -> None:
+        termwarn(
+            "wandb.beta.LocalApi is experimental and may change"
+            " or be removed in any release.",
+            repeat=False,
+        )
+        settings = wandb_setup.singleton().settings.model_copy()
+        self.wandb_dir = str(
+            pathlib.Path(wandb_dir or settings.wandb_dir).expanduser().resolve()
+        )
+        self._service_api = ServiceApi(settings=settings)
+
+    def __repr__(self) -> str:
+        return f"<LocalApi {self.wandb_dir}>"
+
+    @normalize_exceptions
+    def runs(self) -> list[LocalRun]:
+        """Returns the runs in the directory, newest first."""
+        request = apb.ApiRequest(
+            list_local_runs_request=apb.ListLocalRunsRequest(wandb_dir=self.wandb_dir)
+        )
+        response = self._service_api.send_api_request(request)
+        return [
+            LocalRun(self._service_api, info=info)
+            for info in response.list_local_runs_response.runs
+        ]
+
+    def run(self, run: str | os.PathLike[str]) -> LocalRun:
+        """Returns one run.
+
+        Args:
+            run: A run ID or run directory name inside the wandb directory,
+                or a path to a run directory or `.wandb` file.
+
+        Raises:
+            FileNotFoundError: If there is no such run.
+        """
+        for candidate in (
+            pathlib.Path(run).expanduser(),
+            pathlib.Path(self.wandb_dir, run),
+        ):
+            if candidate.is_file() and candidate.suffix == ".wandb":
+                return LocalRun(self._service_api, wandb_file=str(candidate.resolve()))
+            if candidate.is_dir():
+                files = list(candidate.glob("run-*.wandb"))
+                if len(files) == 1:
+                    return LocalRun(
+                        self._service_api, wandb_file=str(files[0].resolve())
+                    )
+
+        # Run directories are named "<offline->run-<timestamp>-<id>"; the
+        # newest of several with the same ID (a resumed run) wins.
+        files = pathlib.Path(self.wandb_dir).glob(
+            f"*run-*/run-{glob.escape(str(run))}.wandb"
+        )
+        newest = max(
+            files,
+            key=lambda file: file.parent.name.removeprefix("offline-"),
+            default=None,
+        )
+        if newest is None:
+            raise FileNotFoundError(f"no run {str(run)!r} in {self.wandb_dir}")
+        return LocalRun(self._service_api, wandb_file=str(newest.resolve()))
+
+
+class LocalRun:
+    """A run read from its local transaction log.
+
+    Attributes are read on first access and cached; call `refresh()` to read
+    a still-running run's latest data.
+    """
+
+    def __init__(
+        self,
+        service_api: ServiceApi,
+        *,
+        info: apb.LocalRunInfo | None = None,
+        wandb_file: str | None = None,
+    ) -> None:
+        if wandb_file is None:
+            if info is None:
+                raise ValueError("info or wandb_file is required")
+            wandb_file = info.wandb_file
+        self._service_api = service_api
+        self._info = info
+        self._wandb_file = wandb_file
+        self._details: apb.ReadLocalRunResponse | None = None
+
+    def __repr__(self) -> str:
+        return f"<LocalRun {os.path.basename(self.sync_dir)}>"
+
+    @property
+    def wandb_file(self) -> str:
+        """The path of the run's `.wandb` transaction log."""
+        return self._wandb_file
+
+    @property
+    def sync_dir(self) -> str:
+        """The run's directory, which holds the transaction log and its files."""
+        return os.path.dirname(self._wandb_file)
+
+    def refresh(self) -> None:
+        """Forgets cached data so the next attribute access reads the log again."""
+        self._info = None
+        self._details = None
+
+    @normalize_exceptions
+    def _load(self) -> apb.ReadLocalRunResponse:
+        if self._details is None:
+            request = apb.ApiRequest(
+                read_local_run_request=apb.ReadLocalRunRequest(
+                    wandb_file=self._wandb_file
+                )
+            )
+            response = self._service_api.send_api_request(request)
+            self._details = response.read_local_run_response
+            self._info = self._details.info
+        return self._details
+
+    def _identity(self) -> apb.LocalRunInfo:
+        return self._info if self._info is not None else self._load().info
+
+    @property
+    def id(self) -> str:
+        return self._identity().run_id
+
+    @property
+    def name(self) -> str:
+        """The run's display name."""
+        return self._identity().display_name
+
+    @property
+    def entity(self) -> str:
+        return self._identity().entity
+
+    @property
+    def project(self) -> str:
+        return self._identity().project
+
+    @property
+    def notes(self) -> str:
+        return self._identity().notes
+
+    @property
+    def tags(self) -> list[str]:
+        return list(self._identity().tags)
+
+    @property
+    def group(self) -> str:
+        return self._identity().group
+
+    @property
+    def job_type(self) -> str:
+        return self._identity().job_type
+
+    @property
+    def sweep_id(self) -> str:
+        return self._identity().sweep_id
+
+    @property
+    def host(self) -> str:
+        return self._identity().host
+
+    @property
+    def offline(self) -> bool:
+        """Whether the run was started in offline mode."""
+        return self._identity().offline
+
+    @property
+    def start_time(self) -> datetime | None:
+        info = self._identity()
+        if not info.HasField("start_time"):
+            return None
+        return info.start_time.ToDatetime(tzinfo=timezone.utc)
+
+    @property
+    def state(self) -> str:
+        """One of `pending`, `running`, `finished`, `failed` or `crashed`.
+
+        `pending` means the run's first record has not been written yet. A run
+        with no exit record whose log has not changed for 10 minutes counts as
+        crashed.
+        """
+        return self._identity().state
+
+    @property
+    def config(self) -> dict[str, Any]:
+        """The run's config, without W&B's internal `_wandb` entry."""
+        config = json.loads(self._load().config_json or "{}")
+        config.pop("_wandb", None)
+        return config
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        return json.loads(self._load().summary_json or "{}")
+
+    @property
+    def metadata(self) -> dict[str, Any] | None:
+        """The run's environment, the contents of wandb-metadata.json."""
+        environment_json = self._load().environment_json
+        return json.loads(environment_json) if environment_json else None
+
+    @property
+    def last_step(self) -> int:
+        """The highest history step logged, or -1 if there is no history."""
+        return self._load().last_step
+
+    @property
+    def history_keys(self) -> list[str]:
+        return list(self._load().history_keys)
+
+    @property
+    def exit_code(self) -> int | None:
+        """The run's exit code, or None while it has not exited."""
+        details = self._load()
+        return details.exit_code if details.HasField("exit_code") else None
+
+    @normalize_exceptions
+    def history(
+        self,
+        keys: list[str] | None = None,
+        *,
+        min_step: int | None = None,
+        max_step: int | None = None,
+        last: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Returns history rows, oldest first.
+
+        Every row has `_step`. The log has no index, so each call reads the
+        whole file.
+
+        Args:
+            keys: Return only these keys; rows with none of them are skipped.
+            min_step: Return only rows at or after this step.
+            max_step: Return only rows at or before this step.
+            last: Return only the last N matching rows.
+        """
+        request = apb.ReadLocalRunHistoryRequest(
+            wandb_file=self._wandb_file, keys=list(keys or [])
+        )
+        if min_step is not None:
+            request.min_step = min_step
+        if max_step is not None:
+            request.max_step = max_step
+        if last is not None:
+            request.last = last
+        response = self._service_api.send_api_request(
+            apb.ApiRequest(read_local_run_history_request=request)
+        )
+
+        rows: list[dict[str, Any]] = []
+        for row in response.read_local_run_history_response.rows:
+            values: dict[str, Any] = {"_step": row.step}
+            for item in row.items:
+                values[item.key] = json.loads(item.value_json)
+            rows.append(values)
+        return rows
+
+    @normalize_exceptions
+    def console_logs(self, last: int | None = None) -> list[ConsoleLogLine]:
+        """Returns the run's console output, oldest first.
+
+        Args:
+            last: Return only the last N lines.
+        """
+        request = apb.ReadLocalRunConsoleLogsRequest(wandb_file=self._wandb_file)
+        if last is not None:
+            request.last = last
+        response = self._service_api.send_api_request(
+            apb.ApiRequest(read_local_run_console_logs_request=request)
+        )
+        return [
+            ConsoleLogLine(
+                number=line.number,
+                timestamp=_parse_timestamp(line.timestamp),
+                level=line.level,
+                label=line.label,
+                content=line.content,
+            )
+            for line in response.read_local_run_console_logs_response.lines
+        ]

--- a/wandb/beta/local_api.py
+++ b/wandb/beta/local_api.py
@@ -52,7 +52,9 @@ class LocalApi:
             " or be removed in any release.",
             repeat=False,
         )
-        settings = wandb_setup.singleton().settings.model_copy()
+        settings = wandb_setup.singleton().settings.model_copy(
+            update={"identity_token_file": None}
+        )
         self.wandb_dir = str(
             pathlib.Path(wandb_dir or settings.wandb_dir).expanduser().resolve()
         )
@@ -63,7 +65,11 @@ class LocalApi:
 
     @normalize_exceptions
     def runs(self) -> list[LocalRun]:
-        """Returns the runs in the directory, newest first."""
+        """Returns the runs in the directory, newest first.
+
+        Reads each run's log to recover its latest metadata. Up to 32 runs
+        are cached; later reads of cached runs process only appended records.
+        """
         request = apb.ApiRequest(
             list_local_runs_request=apb.ListLocalRunsRequest(wandb_dir=self.wandb_dir)
         )
@@ -255,6 +261,11 @@ class LocalRun:
 
     @property
     def history_keys(self) -> list[str]:
+        """The sorted history keys, suitable for passing to `history(keys=...)`.
+
+        Dots separate nested path segments. A backslash escapes literal dots
+        and backslashes within a segment.
+        """
         return list(self._load().history_keys)
 
     @property
@@ -276,6 +287,10 @@ class LocalRun:
 
         Every row has `_step`. The log has no index, so each call reads the
         whole file.
+
+        Keys use dots to separate nested path segments, with literal dots
+        and backslashes escaped by a backslash. Use `history_keys` to find
+        the keys available for filtering.
 
         Args:
             keys: Return only these keys; rows with none of them are skipped.

--- a/wandb/beta/local_api.py
+++ b/wandb/beta/local_api.py
@@ -24,12 +24,13 @@ for line in run.console_logs(last=20):
 from __future__ import annotations
 
 import glob
-import json
 import os
 import pathlib
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from typing import Any
 
+from wandb._pydantic import from_json
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public.console_logs import ConsoleLogLine, _parse_timestamp
 from wandb.apis.public.service_api import ServiceApi
@@ -240,19 +241,19 @@ class LocalRun:
     @property
     def config(self) -> dict[str, Any]:
         """The run's config, without W&B's internal `_wandb` entry."""
-        config = json.loads(self._load().config_json or "{}")
+        config = from_json(self._load().config_json or "{}")
         config.pop("_wandb", None)
         return config
 
     @property
     def summary(self) -> dict[str, Any]:
-        return json.loads(self._load().summary_json or "{}")
+        return from_json(self._load().summary_json or "{}")
 
     @property
     def metadata(self) -> dict[str, Any] | None:
         """The run's environment, the contents of wandb-metadata.json."""
         environment_json = self._load().environment_json
-        return json.loads(environment_json) if environment_json else None
+        return from_json(environment_json) if environment_json else None
 
     @property
     def last_step(self) -> int:
@@ -274,7 +275,6 @@ class LocalRun:
         details = self._load()
         return details.exit_code if details.HasField("exit_code") else None
 
-    @normalize_exceptions
     def history(
         self,
         keys: list[str] | None = None,
@@ -282,15 +282,12 @@ class LocalRun:
         min_step: int | None = None,
         max_step: int | None = None,
         last: int | None = None,
-    ) -> list[dict[str, Any]]:
-        """Returns history rows, oldest first.
+    ) -> LocalHistory:
+        """Returns the run's history rows, oldest first.
 
-        Every row has `_step`. The log has no index, so each call reads the
-        whole file.
-
-        Keys use dots to separate nested path segments, with literal dots
-        and backslashes escaped by a backslash. Use `history_keys` to find
-        the keys available for filtering.
+        Every row is a dict with `_step` and the values logged at that step.
+        Nested keys are joined with dots, as the W&B UI names them; use
+        `history_keys` to see the keys available for filtering.
 
         Args:
             keys: Return only these keys; rows with none of them are skipped.
@@ -307,17 +304,7 @@ class LocalRun:
             request.max_step = max_step
         if last is not None:
             request.last = last
-        response = self._service_api.send_api_request(
-            apb.ApiRequest(read_local_run_history_request=request)
-        )
-
-        rows: list[dict[str, Any]] = []
-        for row in response.read_local_run_history_response.rows:
-            values: dict[str, Any] = {"_step": row.step}
-            for item in row.items:
-                values[item.key] = json.loads(item.value_json)
-            rows.append(values)
-        return rows
+        return LocalHistory(self._service_api, request)
 
     @normalize_exceptions
     def console_logs(self, last: int | None = None) -> list[ConsoleLogLine]:
@@ -342,3 +329,43 @@ class LocalRun:
             )
             for line in response.read_local_run_console_logs_response.lines
         ]
+
+
+class LocalHistory:
+    """Rows of a run's history, read from the run's log as they are iterated.
+
+    Each pass over the rows reads the log again, so iterating a second time
+    over a still-running run includes the rows written since.
+    """
+
+    _PAGE_ROWS = 10_000
+
+    def __init__(
+        self,
+        service_api: ServiceApi,
+        request: apb.ReadLocalRunHistoryRequest,
+    ) -> None:
+        self._service_api = service_api
+        self._request = request
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        request = apb.ReadLocalRunHistoryRequest()
+        request.CopyFrom(self._request)
+        request.limit = self._PAGE_ROWS
+        while True:
+            response = self._read_page(request)
+            for line in response.rows.split(b"\n"):
+                if line:
+                    yield from_json(line)
+            if not response.next_offset:
+                return
+            request.offset = response.next_offset
+
+    @normalize_exceptions
+    def _read_page(
+        self, request: apb.ReadLocalRunHistoryRequest
+    ) -> apb.ReadLocalRunHistoryResponse:
+        response = self._service_api.send_api_request(
+            apb.ApiRequest(read_local_run_history_request=request)
+        )
+        return response.read_local_run_history_response


### PR DESCRIPTION
Description
-----------
Would address https://github.com/wandb/wandb/issues/1308.

`wandb.beta.LocalApi` reads the runs in a local wandb directory through wandb-core. It covers offline runs, runs that have not synced, and runs that are still writing, which is what an agent or a script on the training machine needs.

```python
from wandb.beta import LocalApi

api = LocalApi("./wandb")
for run in api.runs():
    print(run.name, run.state, run.summary.get("loss"))

run = api.run("abc123")
run.history(keys=["loss"], last=10)
run.console_logs(last=20)
```

`LocalApi` owns a `ServiceApi` similar to `Api`. `LocalRun` uses the public `Run`'s vocabulary where the meaning is the same: `id`, `name`, `entity`, `project`, `tags`, `notes`, `state`, `config`, `summary`, `metadata`, `history()`, `console_logs()`; `sync_dir` names the run directory as `wandb.Run` does, and `wandb_file` is the path of the `.wandb` log. Identity and state come from the directory listing when the run came from `runs()`. Listing uses core's cached full-log reader; runs outside the 32-entry cache require a full scan. Config, summary and the remaining attributes are fetched from core on first access. Attributes are cached until `refresh()`; `history()` and `console_logs()` read the log on every call. `run(id)` resolves the ID from the directory names without opening any log. `history()` returns a `LocalHistory` that reads rows from wandb-core in pages as it is iterated; `console_logs()` returns a list. Values are decoded with wandb's pydantic-backed JSON parser.

The new `wandb.beta` package mirrors the CLI's `wandb beta` group as the home for features that may change in any release, and constructing a `LocalApi` prints that warning.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
