### PR TITLE
fix(sdk): make tb_watcher respect settings.symlink

### DIFF
--- a/wandb/sdk/internal/tb_watcher.py
+++ b/wandb/sdk/internal/tb_watcher.py
@@ -10,6 +10,7 @@ import socket
 import sys
 import threading
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import wandb
@@ -49,12 +50,16 @@ def _link_and_save_file(
     abs_path = os.path.abspath(path)
     wandb_path = os.path.join(files_dir, file_name)
     filesystem.mkdir_exists_ok(os.path.dirname(wandb_path))
-    # We overwrite existing symlinks because namespaces can change in Tensorboard
+    # We overwrite existing links because namespaces can change in Tensorboard.
+    # link_or_copy honours settings.symlink, which defaults to False on Windows,
+    # and falls back symlink -> hardlink -> copy. Calling os.symlink directly here
+    # bypassed that and raised OSError (WinError 1314) for any Windows user without
+    # elevation or Developer Mode.
     if os.path.islink(wandb_path) and abs_path != os.readlink(wandb_path):
         os.remove(wandb_path)
-        os.symlink(abs_path, wandb_path)
+        filesystem.link_or_copy(settings, Path(abs_path), Path(wandb_path))
     elif not os.path.exists(wandb_path):
-        os.symlink(abs_path, wandb_path)
+        filesystem.link_or_copy(settings, Path(abs_path), Path(wandb_path))
     # TODO(jhr): need to figure out policy, live/throttled?
     interface.publish_files(
         dict(files=[(filesystem.GlobStr(glob.escape(file_name)), "live")])


### PR DESCRIPTION
_link_and_save_file called os.symlink() unconditionally, so wandb.init(sync_tensorboard=True) raised

    OSError: [WinError 1314] A required privilege is not held by the client

for any Windows user without elevation or Developer Mode.

wandb already handles this everywhere else. settings.symlink defaults to False on Windows (wandb_settings.py), filesystem.link_or_copy() honours that setting and falls back symlink -> hardlink -> copy, and wandb_init.py wraps its own os.symlink in try/except OSError. tb_watcher was the one path that bypassed all of it.

Use link_or_copy() here too. On Windows the file is now hardlinked (or copied across drives) instead of raising.

Description
-----------
<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

<!--
NEW: We're using a new changelog format that's more useful for users. Please
see CHANGELOG.unreleased.md for details and update on relevant changes such as feature
additions, bug fixes, or removals/deprecations.
-->
- [ ] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

<!--
Ensure PR title compliance with the conventional commits standards:
https://github.com/wandb/wandb/blob/main/CONTRIBUTING.md#conventional-commits
-->
