### PR TITLE
fix(artifacts): preserve inputs after failed uploads

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Fixed
 
+- Failed artifact uploads preserve their input files for retry, and artifact cleanup only removes files inside the supplied staging directory (@dmitryduev in https://github.com/wandb/wandb/pull/12749)
 - `wandb leet` no longer sends usage telemetry when W&B is in offline or disabled mode (`WANDB_MODE=offline` or `WANDB_MODE=disabled`), like the rest of the SDK (@dmitryduev in https://github.com/wandb/wandb/pull/12733)
 - `wandb leet` now prints an error message when it cannot start, for example when it is run without a terminal; previously it exited with status 1 and no output. Debug logs (`WANDB_DEBUG=true`) are written next to the LEET config file instead of the current directory (@dmitryduev in https://github.com/wandb/wandb/pull/12732)
 - Passing `aliases` or `tags` to `Run.log_artifact()` in the public API no longer fails with a server error (@dmitryduev in https://github.com/wandb/wandb/pull/12719)

--- a/core/pkg/artifacts/saver.go
+++ b/core/pkg/artifacts/saver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -845,12 +846,21 @@ func (as *ArtifactSaver) commitArtifact(artifactID string) error {
 }
 
 func (as *ArtifactSaver) deleteStagingFiles(manifest *Manifest) {
+	if as.stagingDir == "" {
+		return
+	}
+
 	for _, entry := range manifest.Contents {
-		if entry.LocalPath != nil && strings.HasPrefix(*entry.LocalPath, as.stagingDir) {
-			// We intentionally ignore errors below.
-			_ = os.Chmod(*entry.LocalPath, 0o600)
-			_ = os.Remove(*entry.LocalPath)
+		if entry.LocalPath == nil {
+			continue
 		}
+		rel, err := filepath.Rel(as.stagingDir, *entry.LocalPath)
+		if err != nil || !filepath.IsLocal(rel) {
+			continue
+		}
+		// We intentionally ignore errors below.
+		_ = os.Chmod(*entry.LocalPath, 0o600)
+		_ = os.Remove(*entry.LocalPath)
 	}
 }
 
@@ -860,8 +870,6 @@ func (as *ArtifactSaver) Save() (artifactID string, rerr error) {
 	if err != nil {
 		return "", err
 	}
-
-	defer as.deleteStagingFiles(&manifest)
 
 	artifactAttrs, err := as.createArtifact(&manifest)
 	if err != nil {
@@ -910,6 +918,7 @@ func (as *ArtifactSaver) Save() (artifactID string, rerr error) {
 				"Artifact %q already exists with the same content. No new version will be created.",
 				as.artifact.Name,
 			)
+		as.deleteStagingFiles(&manifest)
 		return artifactID, nil
 	}
 	// DELETED is for old servers, see https://github.com/wandb/wandb/pull/6190
@@ -984,5 +993,7 @@ func (as *ArtifactSaver) Save() (artifactID string, rerr error) {
 		}
 	}
 
+	// Keep inputs available for a later sync if the save fails.
+	as.deleteStagingFiles(&manifest)
 	return artifactID, nil
 }

--- a/core/pkg/artifacts/saver_test.go
+++ b/core/pkg/artifacts/saver_test.go
@@ -3,9 +3,11 @@ package artifacts
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/wandb/wandb/core/internal/filetransfertest"
@@ -137,4 +139,90 @@ func TestSave_CleansUpManifestFileInStagingDir(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, entries,
 		"manifest temp file should be removed, leaving the staging dir clean")
+}
+
+func TestSave_PreservesInputsOnFailure(t *testing.T) {
+	for _, hasStagingDir := range []bool{false, true} {
+		name := "without staging directory"
+		if hasStagingDir {
+			name = "with staging directory"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			input := filepath.Join(dir, "file.txt")
+			require.NoError(t, os.WriteFile(input, []byte("hello"), 0o600))
+			stagingDir := ""
+			if hasStagingDir {
+				stagingDir = dir
+			}
+
+			mockGQL := gqlmock.NewMockClient()
+			mockGQL.StubMatchWithError(gqlmock.WithOpName("CreateArtifact"), context.Canceled)
+			mockGQL.StubMatchOnce(gqlmock.WithOpName("CreateArtifact"),
+				`{"createArtifact":{"artifact":{"id":"artifact-id","state":"COMMITTED"}}}`)
+			saver := NewArtifactSaveManager(
+				observabilitytest.NewTestLogger(t), observability.NewPrinter(0), mockGQL,
+				filetransfertest.NewFakeFileTransferManager(),
+				func() bool { return true }, func() bool { return false },
+			)
+			artifact := &spb.ArtifactRecord{
+				Manifest: &spb.ArtifactManifest{Contents: []*spb.ArtifactManifestEntry{{
+					Path: "file.txt", Digest: "XUFAKrxLKna5cZ2REBfFkg==", Size: 5, LocalPath: input,
+				}}},
+			}
+
+			result := <-saver.Save(context.Background(), artifact, 0, stagingDir)
+			require.ErrorIs(t, result.Err, context.Canceled)
+			require.FileExists(t, input)
+			result = <-saver.Save(context.Background(), artifact, 0, stagingDir)
+			require.NoError(t, result.Err)
+			assert.Equal(t, "artifact-id", result.ArtifactID)
+		})
+	}
+}
+
+func TestSave_DeletesOnlyStagingFiles(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		stagingDir   string
+		inputDir     string
+		shouldDelete bool
+	}{
+		{"staging file", "staging", "staging", true},
+		{"nested staging file", "staging", "staging/nested", true},
+		{"no staging directory", "", "source", false},
+		{"sibling directory", "staging", "staging-other", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			input := filepath.Join(dir, tt.inputDir, "file.txt")
+			require.NoError(t, os.MkdirAll(filepath.Dir(input), 0o700))
+			require.NoError(t, os.WriteFile(input, []byte("hello"), 0o400))
+			stagingDir := ""
+			if tt.stagingDir != "" {
+				stagingDir = filepath.Join(dir, tt.stagingDir)
+			}
+
+			mockGQL := gqlmock.NewMockClient()
+			mockGQL.StubMatchOnce(gqlmock.WithOpName("CreateArtifact"),
+				`{"createArtifact":{"artifact":{"id":"artifact-id","state":"COMMITTED"}}}`)
+			saver := NewArtifactSaveManager(
+				observabilitytest.NewTestLogger(t), observability.NewPrinter(0), mockGQL,
+				filetransfertest.NewFakeFileTransferManager(),
+				func() bool { return true }, func() bool { return false },
+			)
+			result := <-saver.Save(context.Background(), &spb.ArtifactRecord{
+				Manifest: &spb.ArtifactManifest{Contents: []*spb.ArtifactManifestEntry{{
+					Path: "file.txt", Digest: "XUFAKrxLKna5cZ2REBfFkg==", Size: 5, LocalPath: input,
+				}}},
+			}, 0, stagingDir)
+
+			require.NoError(t, result.Err)
+			if tt.shouldDelete {
+				assert.NoFileExists(t, input)
+			} else {
+				assert.FileExists(t, input)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Description
-----------

Failed artifact saves deleted their inputs, so the next `wandb sync` could fail with missing files. Preserve those inputs on error and limit successful cleanup to the supplied staging directory.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

`go test -race ./pkg/artifacts`
