### PR TITLE
fix(artifacts): reuse MD5 digests when syncing artifacts

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -38,6 +38,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Fixed
 
+- Syncing an already uploaded MD5 artifact no longer fails when its staged files have been removed. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12750)
 - Failed artifact uploads preserve their input files for retry, and artifact cleanup only removes files inside the supplied staging directory (@dmitryduev in https://github.com/wandb/wandb/pull/12749)
 - `wandb leet` no longer sends usage telemetry when W&B is in offline or disabled mode (`WANDB_MODE=offline` or `WANDB_MODE=disabled`), like the rest of the SDK (@dmitryduev in https://github.com/wandb/wandb/pull/12733)
 - `wandb leet` now prints an error message when it cannot start, for example when it is run without a terminal; previously it exited with status 1 and no output. Debug logs (`WANDB_DEBUG=true`) are written next to the LEET config file instead of the current directory (@dmitryduev in https://github.com/wandb/wandb/pull/12732)

--- a/core/pkg/artifacts/manifest.go
+++ b/core/pkg/artifacts/manifest.go
@@ -214,7 +214,7 @@ func (m *Manifest) GetManifestEntryFromArtifactFilePath(path string) (ManifestEn
 	return manifestEntry, nil
 }
 
-// HashContentsWithMd5 hashes the contents of the manifest with MD5.
+// HashContentsWithMd5 converts local XXH128 entries to MD5.
 func (m *Manifest) HashContentsWithMd5(ctx context.Context) error {
 	var mu sync.Mutex
 
@@ -222,6 +222,10 @@ func (m *Manifest) HashContentsWithMd5(ctx context.Context) error {
 	g.SetLimit(maxSimultaneousHashes)
 	for path, entry := range maps.Clone(m.Contents) {
 		if entry.LocalPath == nil || entry.Ref != nil {
+			continue
+		}
+		// Untagged entries already have MD5 digests. Their staged files may be gone.
+		if entry.Extra[digestAlgorithmExtraKey] != "XXH128" {
 			continue
 		}
 		g.Go(func() error {

--- a/core/pkg/artifacts/manifest_test.go
+++ b/core/pkg/artifacts/manifest_test.go
@@ -264,14 +264,8 @@ func TestManifest_HashContentsWithMd5_Xxh128_Entry_Is_Updated(t *testing.T) {
 
 func TestManifest_HashContentsWithMd5_Md5_And_Ref_Entries_Are_Not_Updated(t *testing.T) {
 	ctx := context.Background()
-
-	localPath2, err := os.CreateTemp("", "file2.txt")
-	assert.NoError(t, err)
-	defer func() {
-		_ = os.Remove(localPath2.Name())
-	}()
-	_, err = localPath2.WriteString("test")
-	assert.NoError(t, err)
+	// An existing MD5 digest remains usable after its staged file is removed.
+	localPath2 := filepath.Join(t.TempDir(), "removed-file.txt")
 
 	proto := &spb.ArtifactManifest{
 		Version:       1,
@@ -281,7 +275,7 @@ func TestManifest_HashContentsWithMd5_Md5_And_Ref_Entries_Are_Not_Updated(t *tes
 				Path:      "file2.txt",
 				Digest:    "CY9rzUYh03PK3k6DJie09g==",
 				Size:      int64(4),
-				LocalPath: localPath2.Name(),
+				LocalPath: localPath2,
 			},
 			{
 				Path:   "path4",
@@ -300,13 +294,29 @@ func TestManifest_HashContentsWithMd5_Md5_And_Ref_Entries_Are_Not_Updated(t *tes
 
 	// file2.txt digest should not change, and it stays untagged.
 	assert.Equal(t, "CY9rzUYh03PK3k6DJie09g==", manifest.Contents["file2.txt"].Digest)
-	assert.Equal(t, localPath2.Name(), *manifest.Contents["file2.txt"].LocalPath)
+	assert.Equal(t, localPath2, *manifest.Contents["file2.txt"].LocalPath)
 	assert.NotContains(t, manifest.Contents["file2.txt"].Extra, digestAlgorithmExtraKey)
 
 	// path4 reference file should not be rehashed
 	assert.Equal(t, "digest4", manifest.Contents["path4"].Digest)
 	assert.Equal(t, "local/path4", *manifest.Contents["path4"].Ref)
 	assert.Nil(t, manifest.Contents["path4"].LocalPath)
+}
+
+func TestManifest_HashContentsWithMd5_MissingXxh128File(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "missing-file.txt")
+	manifest := Manifest{Contents: map[string]ManifestEntry{
+		"file.txt": {
+			Digest: "xxh128-digest", LocalPath: &localPath,
+			Extra: map[string]any{digestAlgorithmExtraKey: "XXH128"},
+		},
+	}}
+
+	err := manifest.HashContentsWithMd5(context.Background())
+
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.Equal(t, "xxh128-digest", manifest.Contents["file.txt"].Digest)
+	assert.Equal(t, "XXH128", manifest.Contents["file.txt"].Extra[digestAlgorithmExtraKey])
 }
 
 func TestManifest_HashContentsWithMd5_Xxh128_Subdir_Entry_Is_Updated(t *testing.T) {

--- a/core/pkg/artifacts/saver_test.go
+++ b/core/pkg/artifacts/saver_test.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -222,6 +223,47 @@ func TestSave_DeletesOnlyStagingFiles(t *testing.T) {
 				assert.NoFileExists(t, input)
 			} else {
 				assert.FileExists(t, input)
+			}
+		})
+	}
+}
+
+func TestSave_MissingMD5File(t *testing.T) {
+	for _, state := range []string{"COMMITTED", "PENDING"} {
+		t.Run(state, func(t *testing.T) {
+			mockGQL := gqlmock.NewMockClient()
+			mockGQL.StubMatchOnce(
+				gqlmock.WithOpName("CreateArtifact"),
+				fmt.Sprintf(
+					`{"createArtifact":{"artifact":{"id":"artifact-id","state":%q}}}`,
+					state,
+				),
+			)
+			if state == "PENDING" {
+				mockGQL.StubMatchOnce(gqlmock.WithOpName("CreateArtifactManifest"),
+					`{"createArtifactManifest":{}}`)
+			}
+			saver := NewArtifactSaveManager(
+				observabilitytest.NewTestLogger(t), observability.NewPrinter(0), mockGQL,
+				filetransfertest.NewFakeFileTransferManager(),
+				func() bool { return true }, func() bool { return false },
+			)
+			result := <-saver.Save(context.Background(), &spb.ArtifactRecord{
+				Manifest: &spb.ArtifactManifest{Contents: []*spb.ArtifactManifestEntry{{
+					Path: "file.txt", Digest: "XUFAKrxLKna5cZ2REBfFkg==", Size: 5,
+					LocalPath: filepath.Join(t.TempDir(), "removed-staging-file"),
+				}}},
+			}, 0, "")
+
+			if state == "PENDING" {
+				require.ErrorContains(
+					t,
+					result.Err,
+					"ArtifactSaver.uploadFiles: failed to get file size",
+				)
+			} else {
+				require.NoError(t, result.Err)
+				assert.Equal(t, "artifact-id", result.ArtifactID)
 			}
 		})
 	}


### PR DESCRIPTION
Description
-----------

Since 0.29.0, MD5 artifacts were rehashed before the server could deduplicate them. Reuse their stored digests so syncing an already uploaded artifact works after its staged files are removed.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
