### PR TITLE
fix: explain incomplete .wandb files in wandb sync

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,6 +41,7 @@ Legacy `wandb sync` options have been removed. See `wandb sync --help`.
 
 ### Fixed
 
+- `wandb sync` explains that a `.wandb` file ends with an incomplete record and how to retry, instead of reporting an internal error (@dmitryduev in https://github.com/wandb/wandb/pull/12751)
 - Syncing an already uploaded MD5 artifact no longer fails when its staged files have been removed. This was a regression in 0.29.0 (@dmitryduev in https://github.com/wandb/wandb/pull/12750)
 - Failed artifact uploads preserve their input files for retry, and artifact cleanup only removes files inside the supplied staging directory (@dmitryduev in https://github.com/wandb/wandb/pull/12749)
 - `wandb leet` no longer sends usage telemetry when W&B is in offline or disabled mode (`WANDB_MODE=offline` or `WANDB_MODE=disabled`), like the rest of the SDK (@dmitryduev in https://github.com/wandb/wandb/pull/12733)

--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -85,6 +85,10 @@ func (r *RunReader) ExtractRunInfo(ctx context.Context) (*RunInfo, error) {
 
 		record, err := r.nextUpdatedRecord(ctx, reader, true /*retryEOF*/)
 
+		if _, ok := err.(*SyncError); ok {
+			return nil, err
+		}
+
 		if err != nil {
 			return nil, &SyncError{
 				Err:      err,
@@ -270,6 +274,18 @@ func (r *RunReader) nextUpdatedRecord(
 			case <-time.After(time.Second):
 			}
 			record, err = reader.Read()
+		}
+	}
+
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, &SyncError{
+			Err:     err,
+			Message: "runsync: incomplete transaction log",
+			UserText: fmt.Sprintf(
+				"Failed to sync all data from %q: the file ends with"+
+					" an incomplete record. If the run is still running,"+
+					" retry after it finishes or use `wandb beta sync --live`.",
+				r.displayPath),
 		}
 	}
 

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -3,6 +3,7 @@ package runsync_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -380,6 +381,25 @@ func Test_FilePermissionError(t *testing.T) {
 			x.TransactionLog),
 		syncErr.UserText,
 	)
+}
+
+func Test_IncompleteRecordError(t *testing.T) {
+	x := setup(t)
+	wandbFileWithRecords(t, x.TransactionLog, &spb.Record{Num: 1})
+	x.FakeRunWork.QueueResponse(&spb.ServerResponse{}) // for the exit record
+	x.MockRecordParser.EXPECT().Parse(isExitRecord(1)).Return(&testWork{})
+
+	// Cut off the end of the only record.
+	info, err := os.Stat(x.TransactionLog)
+	require.NoError(t, err)
+	require.NoError(t, os.Truncate(x.TransactionLog, info.Size()-1))
+
+	err = x.RunReader.ProcessTransactionLog(t.Context())
+
+	var syncErr *runsync.SyncError
+	require.ErrorAs(t, err, &syncErr)
+	assert.ErrorIs(t, syncErr.Err, io.ErrUnexpectedEOF)
+	assert.Contains(t, syncErr.UserText, x.TransactionLog)
 }
 
 func Test_CorruptFileError(t *testing.T) {


### PR DESCRIPTION
Description
-----------

`wandb sync` reported an internal error ("unexpected EOF") when a `.wandb` file ended midway through a record. That happens while the run is still writing, or after it was killed mid-write. The error was also captured as an unexpected SDK exception.

The sync now stops with a message that names the file, says it ends with an incomplete record, and suggests retrying after the run finishes or using `wandb beta sync --live`. Checksum mismatches and other corruption still show up as internal errors.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

Truncated a real `.wandb` file mid-record, then ran `wandb sync` and `wandb beta sync --live` on it.
