### PR TITLE
fix(sdk): stop reporting exited processes as sampling errors

### DIFF
--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/google/wire"
+	"github.com/shirou/gopsutil/v4/process"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -520,6 +521,23 @@ func (sm *SystemMonitor) sample() {
 //
 // Use to filter out expected/transient failures. Keep this intentionally small and specific.
 func ShouldCaptureSamplingError(err error) bool {
+	// A sample can combine failures from several collectors. Keep reporting it
+	// if any of those failures is unexpected, including when the join is wrapped.
+	var joined interface{ Unwrap() []error }
+	if errors.As(err, &joined) {
+		for _, cause := range joined.Unwrap() {
+			if ShouldCaptureSamplingError(cause) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The monitored process may exit before its last sample completes.
+	if errors.Is(err, process.ErrorProcessNotRunning) {
+		return false
+	}
+
 	// The caller went away, e.g. the run finished mid-sample.
 	if errors.Is(err, context.Canceled) {
 		return false

--- a/core/internal/monitor/monitor_test.go
+++ b/core/internal/monitor/monitor_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -179,6 +180,20 @@ func TestShouldCaptureSamplingErr(t *testing.T) {
 		err  error
 		want bool
 	}{
+		{"ProcessExited", process.ErrorProcessNotRunning, false},
+		{
+			"ProcessExitedWithOtherError",
+			errors.Join(process.ErrorProcessNotRunning, errors.New("disk read failed")),
+			true,
+		},
+		{
+			"ProcessExitedWithOtherExpectedError",
+			errors.Join(
+				process.ErrorProcessNotRunning,
+				status.Error(codes.Unavailable, "disconnected"),
+			),
+			false,
+		},
 		{
 			"NetstatMissing",
 			errors.New(`exec: "netstat": executable file not found in $PATH`),

--- a/core/internal/monitor/system_test.go
+++ b/core/internal/monitor/system_test.go
@@ -2,15 +2,30 @@ package monitor_test
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"reflect"
 	"testing"
 
 	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/monitor"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+func TestSystemSample_ExitedProcess(t *testing.T) {
+	child := exec.Command(os.Args[0], "-test.run=^$")
+	require.NoError(t, child.Run())
+
+	system := monitor.NewSystem(monitor.SystemParams{
+		Pid: int32(child.Process.Pid),
+	})
+	_, err := system.Sample()
+	require.ErrorIs(t, err, process.ErrorProcessNotRunning)
+	require.False(t, monitor.ShouldCaptureSamplingError(err))
+}
 
 func TestSLURMProbe(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Description
-----------

System metrics sampling can outlive the process it monitors, and the last sample then fails with `process does not exist`. That failure was captured as an SDK error even though it is expected.

The sampler now keeps it in the debug log, like a cancelled context, instead of reporting it. A sample joins failures from several collectors, so a join that also contains an unrelated failure is still reported.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

`go test -race ./internal/monitor`
