### PR TITLE
fix(sdk): skip final uploads for uninitialized runs

### DIFF
--- a/core/internal/monitor/monitor.go
+++ b/core/internal/monitor/monitor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/google/wire"
+	"github.com/shirou/gopsutil/v4/process"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -520,6 +521,23 @@ func (sm *SystemMonitor) sample() {
 //
 // Use to filter out expected/transient failures. Keep this intentionally small and specific.
 func ShouldCaptureSamplingError(err error) bool {
+	// A sample can combine failures from several collectors. Keep reporting it
+	// if any of those failures is unexpected, including when the join is wrapped.
+	var joined interface{ Unwrap() []error }
+	if errors.As(err, &joined) {
+		for _, cause := range joined.Unwrap() {
+			if ShouldCaptureSamplingError(cause) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The monitored process may exit before its last sample completes.
+	if errors.Is(err, process.ErrorProcessNotRunning) {
+		return false
+	}
+
 	// The caller went away, e.g. the run finished mid-sample.
 	if errors.Is(err, context.Canceled) {
 		return false

--- a/core/internal/monitor/monitor_test.go
+++ b/core/internal/monitor/monitor_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -179,6 +180,20 @@ func TestShouldCaptureSamplingErr(t *testing.T) {
 		err  error
 		want bool
 	}{
+		{"ProcessExited", process.ErrorProcessNotRunning, false},
+		{
+			"ProcessExitedWithOtherError",
+			errors.Join(process.ErrorProcessNotRunning, errors.New("disk read failed")),
+			true,
+		},
+		{
+			"ProcessExitedWithOtherExpectedError",
+			errors.Join(
+				process.ErrorProcessNotRunning,
+				status.Error(codes.Unavailable, "disconnected"),
+			),
+			false,
+		},
 		{
 			"NetstatMissing",
 			errors.New(`exec: "netstat": executable file not found in $PATH`),

--- a/core/internal/monitor/system_test.go
+++ b/core/internal/monitor/system_test.go
@@ -2,15 +2,30 @@ package monitor_test
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"reflect"
 	"testing"
 
 	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wandb/wandb/core/internal/monitor"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
+
+func TestSystemSample_ExitedProcess(t *testing.T) {
+	child := exec.Command(os.Args[0], "-test.run=^$")
+	require.NoError(t, child.Run())
+
+	system := monitor.NewSystem(monitor.SystemParams{
+		Pid: int32(child.Process.Pid),
+	})
+	_, err := system.Sample()
+	require.ErrorIs(t, err, process.ErrorProcessNotRunning)
+	require.False(t, monitor.ShouldCaptureSamplingError(err))
+}
 
 func TestSLURMProbe(t *testing.T) {
 	tests := []struct {

--- a/core/internal/runfiles/upload_batcher.go
+++ b/core/internal/runfiles/upload_batcher.go
@@ -49,6 +49,9 @@ func newUploadBatcher(
 
 // Add adds files to the next upload batch, scheduling one if necessary.
 func (b *uploadBatcher) Add(runPaths []paths.RelativePath) {
+	if len(runPaths) == 0 {
+		return
+	}
 	if b.delay == 0 {
 		b.upload(runPaths)
 		return

--- a/core/internal/stream/sender.go
+++ b/core/internal/stream/sender.go
@@ -614,13 +614,13 @@ func (s *Sender) finishRunSync(
 
 	// Upload the run's finalized summary and config.
 	s.mu.Lock()
-	s.uploadSummaryFile()
-
+	// Sync can stop before receiving a run record, for example on an empty file.
 	upserter, _ := s.runHandle.Upserter()
 	if upserter != nil {
+		s.uploadSummaryFile()
 		upserter.Finish()
+		s.uploadConfigFile()
 	}
-	s.uploadConfigFile()
 	s.mu.Unlock()
 
 	// Wait for artifacts operations to complete here to detect
@@ -628,7 +628,9 @@ func (s *Sender) finishRunSync(
 	s.artifactWG.Wait()
 
 	s.mu.Lock()
-	s.sendJobFlush()
+	if upserter != nil {
+		s.sendJobFlush()
+	}
 	s.mu.Unlock()
 
 	// Finish uploading non-artifact files.

--- a/core/internal/stream/sender_test.go
+++ b/core/internal/stream/sender_test.go
@@ -1,11 +1,15 @@
 package stream_test
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -35,16 +39,19 @@ type testFixtures struct {
 	RunHandle *runhandle.RunHandle
 	Settings  *wbsettings.Settings
 	Logger    *observability.CoreLogger
+	Logs      *bytes.Buffer
 }
 
 func makeSender(t *testing.T, client graphql.Client) testFixtures {
 	t.Helper()
 	runWork := runworktest.New()
-	logger := observabilitytest.NewTestLogger(t)
+	logger, logs := observabilitytest.NewRecordingTestLogger(t)
 	settings := wbsettings.From(&spb.Settings{
-		RunId:   &wrapperspb.StringValue{Value: "run1"},
-		Console: &wrapperspb.StringValue{Value: "off"},
-		ApiKey:  &wrapperspb.StringValue{Value: "test-api-key"},
+		RunId:    &wrapperspb.StringValue{Value: "run1"},
+		Console:  &wrapperspb.StringValue{Value: "off"},
+		ApiKey:   &wrapperspb.StringValue{Value: "test-api-key"},
+		SyncDir:  wrapperspb.String(t.TempDir()),
+		XPrimary: wrapperspb.Bool(true),
 	})
 	baseURL := stream.BaseURLFromSettings(logger, settings)
 	credentialProvider := stream.CredentialsFromSettings(logger, settings)
@@ -60,22 +67,27 @@ func makeSender(t *testing.T, client graphql.Client) testFixtures {
 		logger,
 		settings,
 	)
+	runHandle := runhandle.New()
+	fileWatcher := watchertest.NewFakeWatcher()
 	runfilesUploaderFactory := &runfiles.UploaderFactory{
 		FileTransfer: fileTransferManager,
-		FileWatcher:  watchertest.NewFakeWatcher(),
+		FileWatcher:  fileWatcher,
 		GraphQL:      client,
 		Logger:       logger,
 		Settings:     settings,
+		RunHandle:    runHandle,
 	}
-	runHandle := runhandle.New()
 
 	senderFactory := stream.SenderFactory{
 		BaseURL:                 baseURL,
 		CredentialProvider:      credentialProvider,
 		Logger:                  logger,
+		Printer:                 observability.NewPrinter(0),
 		Settings:                settings,
 		FileStreamFactory:       fileStreamFactory,
 		FileTransferManager:     fileTransferManager,
+		FileTransferStats:       filetransfer.NewFileTransferStats(),
+		FileWatcher:             fileWatcher,
 		RunfilesUploaderFactory: runfilesUploaderFactory,
 		Mailbox:                 mailbox.New(),
 		GraphqlClient:           client,
@@ -87,6 +99,32 @@ func makeSender(t *testing.T, client graphql.Client) testFixtures {
 		RunHandle: runHandle,
 		Settings:  settings,
 		Logger:    logger,
+		Logs:      logs,
+	}
+}
+
+func TestSendExitBeforeRunInitialization(t *testing.T) {
+	client := gqlmock.NewMockClient()
+	x := makeSender(t, client)
+	require.NoError(t, os.MkdirAll(x.Settings.GetFilesDir(), 0o700))
+	request, responses := runworktest.SimpleRequest(t, "exit")
+	x.Sender.SendRecord(&spb.Record{
+		RecordType: &spb.Record_Exit{Exit: &spb.RunExitRecord{}},
+	}, request)
+
+	select {
+	case response := <-responses:
+		require.NotNil(t, response.GetResultCommunicate().GetExitResult())
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown did not finish")
+	}
+
+	assert.Empty(t, client.AllRequests())
+	files, err := os.ReadDir(x.Settings.GetFilesDir())
+	require.NoError(t, err)
+	assert.Empty(t, files)
+	for _, entry := range observabilitytest.ExtractLogs(t, x.Logs) {
+		assert.NotEqual(t, "ERROR", entry["level"], entry["msg"])
 	}
 }
 


### PR DESCRIPTION
Description
-----------

When a run was never initialized, for example because a sync failed to create it on the server, shutdown still tried to upload the summary, config, and job artifact and logged `run not yet initialized` for each. The runfiles uploader also pushed empty file batches through the same run lookup.

Shutdown now skips those uploads when there is no run, and the upload batcher ignores empty batches.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------

`go test -race ./internal/stream ./internal/runfiles`
