### PR TITLE
fix(artifacts): bound auto-generated artifact names to 128 characters

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -20,4 +20,5 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Fixed
 
+- Auto-generated artifact names (e.g. run tables, incremental tables, and file logs) are now safely bounded to 128 characters with middle ellipsis truncation and CRC32 uniqueness preservation, preventing unexpected client-side validation errors (@somuai in https://github.com/wandb/wandb/issues/11212)
 - Changing system metrics grid rows or columns in LEET, including `wandb leet symon`, no longer crashes and takes effect immediately without waiting for new data (@dmitryduev in https://github.com/wandb/wandb/pull/12763)

--- a/tests/unit_tests/test_artifacts/test_internal_artifact.py
+++ b/tests/unit_tests/test_artifacts/test_internal_artifact.py
@@ -1,0 +1,83 @@
+from pytest import mark
+from wandb.sdk.artifacts._internal_artifact import (
+    InternalArtifact,
+    sanitize_artifact_name,
+)
+from wandb.sdk.artifacts._validators import NAME_MAXLEN, validate_artifact_name
+
+
+@mark.parametrize(
+    "name",
+    [
+        "my-artifact",
+        "dataset_2026.table",
+        "run-12345-loss",
+        "a" * 128,
+    ],
+)
+def test_sanitize_artifact_name_preserves_valid(name: str):
+    """Already valid artifact names within 128 chars should be returned unchanged."""
+    assert sanitize_artifact_name(name) == name
+
+
+@mark.parametrize(
+    "name",
+    [
+        "run 12345:metric/table",
+        "nested/path/to/artifact",
+        "special!@#$%^&*()_+chars",
+    ],
+)
+def test_sanitize_artifact_name_sanitizes_invalid_chars(name: str):
+    """Names with invalid characters should be stripped and suffixed with CRC32."""
+    sanitized = sanitize_artifact_name(name)
+    assert len(sanitized) <= NAME_MAXLEN
+    validate_artifact_name(sanitized)
+    assert "-" in sanitized
+
+
+@mark.parametrize(
+    "length",
+    [129, 150, 200, 300, 500],
+)
+def test_sanitize_artifact_name_truncates_long_names(length: int):
+    """Auto-generated or user-provided names longer than 128 characters must be safely bounded."""
+    raw_name = "run-abcdef123456-table-metric-" + "x" * length
+    sanitized = sanitize_artifact_name(raw_name)
+    assert len(sanitized) <= NAME_MAXLEN
+    validate_artifact_name(sanitized)
+    assert sanitized.startswith("run-abcdef123456-table-metric-")
+
+
+def test_sanitize_artifact_name_idempotent():
+    """Sanitizing an already sanitized name should return the identical string."""
+    names = [
+        "already-valid-name",
+        "run-12345/special table name",
+        "x" * 250,
+        "run-" + "a" * 150 + "-incr-table",
+    ]
+    for name in names:
+        first = sanitize_artifact_name(name)
+        second = sanitize_artifact_name(first)
+        assert first == second
+
+
+def test_sanitize_artifact_name_uniqueness_on_long_names():
+    """Two long names differing only in the middle or end produce different sanitized outputs."""
+    name_a = "prefix-" + "a" * 200 + "-suffix-one"
+    name_b = "prefix-" + "a" * 200 + "-suffix-two"
+    sanitized_a = sanitize_artifact_name(name_a)
+    sanitized_b = sanitize_artifact_name(name_b)
+    assert sanitized_a != sanitized_b
+    assert len(sanitized_a) <= NAME_MAXLEN
+    assert len(sanitized_b) <= NAME_MAXLEN
+
+
+def test_internal_artifact_with_long_auto_generated_name():
+    """InternalArtifact initialization succeeds even when the generated name exceeds 128 chars."""
+    long_key = "very_long_metric_evaluation_dataset_key_" + "z" * 150
+    artifact_name = f"run-xyz789-{long_key}"
+    artifact = InternalArtifact(artifact_name, "run_table")
+    assert len(artifact.name) <= NAME_MAXLEN
+    validate_artifact_name(artifact.name)

--- a/tests/unit_tests/test_artifacts/test_validators.py
+++ b/tests/unit_tests/test_artifacts/test_validators.py
@@ -5,6 +5,7 @@ from wandb.sdk.artifacts._validators import (
     REGISTRY_PREFIX,
     RESERVED_ARTIFACT_TYPE_PREFIX,
     ArtifactPath,
+    validate_artifact_name,
     validate_artifact_path,
     validate_artifact_root_name,
     validate_artifact_type,
@@ -226,3 +227,31 @@ def test_artifact_path_roundtrip_from_str(path_str: str):
 def test_artifact_path_roundtrip_from_instance(path_obj: ArtifactPath):
     """Check that the roundtrip conversion ArtifactPath -> str -> ArtifactPath preserves the original."""
     assert ArtifactPath.from_str(path_obj.to_str()) == path_obj
+
+
+@mark.parametrize(
+    "name",
+    [
+        "my-artifact",
+        "model.v1",
+        "dataset_2026",
+        "a" * 128,
+    ],
+)
+def test_validate_artifact_name_valid(name: str):
+    assert validate_artifact_name(name) == name
+
+
+@mark.parametrize(
+    "name, expected_err",
+    [
+        ("a" * 129, "Artifact name is longer than 128 characters"),
+        (
+            "invalid/name",
+            "Artifact names must not contain any of the following characters: '/'",
+        ),
+    ],
+)
+def test_validate_artifact_name_invalid(name: str, expected_err: str):
+    with raises(ValueError, match=expected_err):
+        validate_artifact_name(name)

--- a/wandb/sdk/artifacts/_internal_artifact.py
+++ b/wandb/sdk/artifacts/_internal_artifact.py
@@ -5,6 +5,7 @@ from base64 import urlsafe_b64encode
 from typing import Any, Final, Literal
 from zlib import crc32
 
+from wandb.sdk.artifacts._validators import NAME_MAXLEN
 from wandb.sdk.artifacts.artifact import Artifact
 
 PLACEHOLDER: Final[str] = "PLACEHOLDER"
@@ -12,9 +13,17 @@ PLACEHOLDER: Final[str] = "PLACEHOLDER"
 
 def sanitize_artifact_name(name: str) -> str:
     """Sanitize the string to satisfy constraints on artifact names."""
-    # If the name is already sanitized, don't change it.
-    if (sanitized := re.sub(r"[^a-zA-Z0-9_\-.]+", "", name)) == name:
+    # If the name is already sanitized and fits within NAME_MAXLEN, don't change it.
+    if (
+        name
+        and len(name) <= NAME_MAXLEN
+        and (sanitized := re.sub(r"[^a-zA-Z0-9_\-.]+", "", name)) == name
+    ):
         return name
+
+    sanitized = re.sub(r"[^a-zA-Z0-9_\-.]+", "", name)
+    if not sanitized:
+        sanitized = "artifact"
 
     # Append a short alphanumeric suffix to maintain uniqueness.
     # Yes, CRC is meant for checksums and not as a general hash function, but
@@ -26,8 +35,15 @@ def sanitize_artifact_name(name: str) -> str:
     crc: int = crc32(name.encode("utf-8")) & 0xFFFFFFFF  # Ensure it's unsigned
     crc_bytes = crc.to_bytes(4, byteorder="big")
     suffix = urlsafe_b64encode(crc_bytes).rstrip(b"=").decode("ascii")
+    full_suffix = f"-{suffix}"
 
-    return f"{sanitized}-{suffix}"
+    max_prefix_len = NAME_MAXLEN - len(full_suffix)
+    if len(sanitized) > max_prefix_len:
+        head = (max_prefix_len - 2) // 2
+        tail = max_prefix_len - 2 - head
+        sanitized = f"{sanitized[:head]}..{sanitized[-tail:]}"
+
+    return f"{sanitized}{full_suffix}"
 
 
 class InternalArtifact(Artifact):

--- a/wandb/sdk/wandb_run.py
+++ b/wandb/sdk/wandb_run.py
@@ -3444,10 +3444,10 @@ class Run:
         from wandb.sdk.artifacts.artifact import Artifact
 
         if isinstance(artifact_or_path, (str, os.PathLike)):
-            name = (
-                name
-                or f"run-{self._settings.run_id}-{os.path.basename(artifact_or_path)}"
-            )
+            if not name:
+                name = wandb.util.make_artifact_name_safe(
+                    f"run-{self._settings.run_id}-{os.path.basename(artifact_or_path)}"
+                )
             artifact = Artifact(name, type or "unspecified")
             if os.path.isfile(artifact_or_path):
                 artifact.add_file(str(artifact_or_path))


### PR DESCRIPTION
Description
-----------
- Fixes #11212

When client-side artifact name validation was added in #9594, `validate_artifact_name(name)` strictly enforces `len(name) <= 128`. However, internal auto-generated artifact names (such as run tables created via `InternalArtifact(f"run-{run.id}-{key}", "run_table")`, incremental tables created via `_get_artifact_name(run, key)`, or default names generated when logging files via `log_artifact`) could exceed 128 characters when table keys or filenames are long. This caused unpredictable `ValueError: Artifact name is longer than 128 characters` errors on valid user workflows.

### Changes
1. Updated `sanitize_artifact_name(name: str) -> str` in `wandb/sdk/artifacts/_internal_artifact.py` to enforce `NAME_MAXLEN = 128`. Names longer than 128 characters (or with characters sanitized) are safely truncated using middle ellipsis while preserving the 6-character CRC32 suffix to prevent collection name collisions.
2. Handled edge case where `sanitized` prefix is empty (e.g. input composed purely of stripped characters) by defaulting to `"artifact"`.
3. Ensured default artifact names auto-generated in `Run.log_artifact()` (`wandb/sdk/wandb_run.py`) are passed through `wandb.util.make_artifact_name_safe` when `name` is omitted.
4. Added comprehensive test coverage in `tests/unit_tests/test_artifacts/test_internal_artifact.py` covering preservation of valid names, character sanitization, length bounding, idempotency, uniqueness, and `InternalArtifact` initialization with long keys.
5. Added unit test cases for `validate_artifact_name` in `tests/unit_tests/test_artifacts/test_validators.py`.
6. Updated `CHANGELOG.unreleased.md`.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
- Executed unit tests with `pytest`:
  - `tests/unit_tests/test_artifacts/test_internal_artifact.py` (15 passed)
  - `tests/unit_tests/test_artifacts/test_validators.py` (89 passed)
- Verified idempotency and character constraints across edge cases (`len=129`, `len=200`, `len=500`).
- Checked code formatting and linting via `ruff check` and `ruff format`.