### PR TITLE
fix(sdk): reject malformed run filters before sending requests

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,3 +26,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Changing system metrics grid rows or columns in LEET, including `wandb leet symon`, no longer crashes and takes effect immediately without waiting for new data (@dmitryduev in https://github.com/wandb/wandb/pull/12763)
+- `Api.runs()` and `Project.sweeps()` now reject malformed tag lists, logical groups, and misplaced membership operators with descriptive errors before sending a request. The `filters` argument must be a dictionary or `None`; values such as `0`, `False`, `""`, and `[]` are no longer treated as empty filters.

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -1,6 +1,8 @@
 import json
 import sys
+from copy import deepcopy
 from types import SimpleNamespace
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -152,6 +154,69 @@ def test_parse_project_path_proj():
         entity, project = Api()._parse_project_path("proj")
         assert entity == "mock_entity"
         assert project == "proj"
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+@pytest.mark.parametrize(
+    "filters,error_path",
+    [
+        (
+            {"tags": {"$all": [["sgd"], "test"], "$nin": ["test-2"]}},
+            "filters.tags.$all[0]",
+        ),
+        ({"$in": ["group-1"]}, "filters.$in"),
+    ],
+)
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_api_runs_validate_before_path_resolution_and_cache(
+    filters: dict[str, Any], error_path: str, lazy: bool
+) -> None:
+    api = Api()
+    api._service_api = MagicMock()
+    path = "entity/project"
+    cache_key = path + str(filters) + "+created_at"
+    api._runs[cache_key] = MagicMock()
+
+    with mock.patch.object(api, "_parse_project_path") as parse_project_path:
+        parse_project_path.side_effect = AssertionError(
+            "Invalid filters must be rejected before resolving the project"
+        )
+        with pytest.raises(ValueError) as exc_info:
+            api.runs(path, filters=filters, lazy=lazy)
+
+    assert error_path in str(exc_info.value)
+    parse_project_path.assert_not_called()
+    api._service_api.execute_graphql.assert_not_called()
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+@pytest.mark.parametrize(
+    "filters",
+    [None, {}, {"tags": {"$all": ("sgd", "test"), "$nin": ["test-2"]}}],
+)
+@pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
+def test_api_runs_preserve_valid_filters(
+    filters: dict[str, Any] | None, lazy: bool
+) -> None:
+    api = Api()
+    api._service_api = MagicMock()
+    api._service_api.execute_graphql.return_value = {
+        "project": {
+            "runCount": 0,
+            "runs": {"edges": [], "pageInfo": {"hasNextPage": False}},
+        }
+    }
+    original_filters = deepcopy(filters)
+
+    runs = api.runs("entity/project", filters=filters, lazy=lazy)
+
+    assert list(runs) == []
+    api._service_api.execute_graphql.assert_called_once()
+    variables = api._service_api.execute_graphql.call_args.args[1]
+    assert variables["filters"] == json.dumps(
+        {} if original_filters is None else original_filters
+    )
+    assert filters == original_filters
 
 
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")

--- a/tests/unit_tests/test_public_api/test_public_api.py
+++ b/tests/unit_tests/test_public_api/test_public_api.py
@@ -2,7 +2,6 @@ import json
 import sys
 from copy import deepcopy
 from types import SimpleNamespace
-from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -156,48 +155,27 @@ def test_parse_project_path_proj():
         assert project == "proj"
 
 
-@pytest.mark.parametrize("lazy", [True, False])
-@pytest.mark.parametrize(
-    "filters,error_path",
-    [
-        (
-            {"tags": {"$all": [["sgd"], "test"], "$nin": ["test-2"]}},
-            "filters.tags.$all[0]",
-        ),
-        ({"$in": ["group-1"]}, "filters.$in"),
-    ],
-)
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_api_runs_validate_before_path_resolution_and_cache(
-    filters: dict[str, Any], error_path: str, lazy: bool
-) -> None:
+def test_api_runs_validate_before_path_resolution_and_cache() -> None:
     api = Api()
     api._service_api = MagicMock()
+    filters = {"tags": {"$all": [["sgd"], "test"]}}
     path = "entity/project"
-    cache_key = path + str(filters) + "+created_at"
-    api._runs[cache_key] = MagicMock()
+    api._runs[path + str(filters) + "+created_at"] = MagicMock()
 
     with mock.patch.object(api, "_parse_project_path") as parse_project_path:
         parse_project_path.side_effect = AssertionError(
             "Invalid filters must be rejected before resolving the project"
         )
-        with pytest.raises(ValueError) as exc_info:
-            api.runs(path, filters=filters, lazy=lazy)
+        with pytest.raises(ValueError, match=r"filters\.tags\.\$all\[0\]"):
+            api.runs(path, filters=filters)
 
-    assert error_path in str(exc_info.value)
     parse_project_path.assert_not_called()
     api._service_api.execute_graphql.assert_not_called()
 
 
-@pytest.mark.parametrize("lazy", [True, False])
-@pytest.mark.parametrize(
-    "filters",
-    [None, {}, {"tags": {"$all": ("sgd", "test"), "$nin": ["test-2"]}}],
-)
 @pytest.mark.usefixtures("patch_apikey", "skip_verify_login")
-def test_api_runs_preserve_valid_filters(
-    filters: dict[str, Any] | None, lazy: bool
-) -> None:
+def test_api_runs_preserve_valid_filters() -> None:
     api = Api()
     api._service_api = MagicMock()
     api._service_api.execute_graphql.return_value = {
@@ -206,16 +184,14 @@ def test_api_runs_preserve_valid_filters(
             "runs": {"edges": [], "pageInfo": {"hasNextPage": False}},
         }
     }
+    filters = {"tags": {"$all": ("sgd", "test"), "$nin": ["test-2"]}}
     original_filters = deepcopy(filters)
 
-    runs = api.runs("entity/project", filters=filters, lazy=lazy)
+    runs = api.runs("entity/project", filters=filters)
 
     assert list(runs) == []
-    api._service_api.execute_graphql.assert_called_once()
     variables = api._service_api.execute_graphql.call_args.args[1]
-    assert variables["filters"] == json.dumps(
-        {} if original_filters is None else original_filters
-    )
+    assert variables["filters"] == json.dumps(original_filters)
     assert filters == original_filters
 
 

--- a/tests/unit_tests/test_public_api/test_run_filters.py
+++ b/tests/unit_tests/test_public_api/test_run_filters.py
@@ -1,96 +1,36 @@
-from typing import Any
-
 import pytest
 from wandb.apis.public.run_filters import validate_run_filters
 
 
-@pytest.mark.parametrize("invalid_leaf", [False, True])
-def test_validate_run_filters_handles_nested_groups(invalid_leaf: bool) -> None:
-    depth = 50
-    filters: dict[str, Any] = {"tags": {"$all": [["sgd"]] if invalid_leaf else ["sgd"]}}
-    for _ in range(depth):
-        filters = {"$and": [filters]}
-
-    if invalid_leaf:
-        with pytest.raises(ValueError) as exc_info:
-            validate_run_filters(filters)
-        expected_path = "filters" + ".$and[0]" * depth + ".tags.$all[0]"
-        assert str(exc_info.value) == (
-            f"{expected_path}: expected a tag string, got list"
-        )
-    else:
-        assert validate_run_filters(filters) is filters
+def test_validate_run_filters_defaults_none_to_empty() -> None:
+    assert validate_run_filters(None) == {}
 
 
-def test_validate_run_filters_handles_wide_groups() -> None:
-    filters = {"$or": [{"tags": {"$in": ["sgd"]}} for _ in range(10_000)]}
-
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"$and": [{"tags": {"$all": ["sgd"]}}]},
+        {"group": {"$in": [["group-1"]]}},
+    ],
+)
+def test_validate_run_filters_accepts_valid_filters(filters) -> None:
     assert validate_run_filters(filters) is filters
 
 
 @pytest.mark.parametrize(
-    "children,error_path",
+    "filters,error_path",
     [
+        ({"tags": {"$all": [["sgd"], "test"]}}, r"filters\.tags\.\$all\[0\]"),
         (
-            [
-                {"$or": [{"tags": {"$all": [["sgd"]]}}]},
-                {"$in": ["group-1"]},
-            ],
-            "filters.$and[0].$or[0].tags.$all[0]",
+            {"$and": [{"tags": {"$all": [["sgd"]]}}]},
+            r"filters\.\$and\[0\]\.tags\.\$all\[0\]",
         ),
-        (
-            [
-                {"$or": [{"tags": {"$all": ["sgd"]}}]},
-                {"$in": ["group-1"]},
-            ],
-            "filters.$and[1].$in",
-        ),
-        (
-            [{"$or": [{"tags": {"$all": ["sgd"]}}]}],
-            "filters.$nin",
-        ),
+        ({"tags": {"$all": "sgd"}}, r"filters\.tags\.\$all"),
+        ({"tags": [["sgd"]]}, r"filters\.tags\[0\]"),
+        ({"$in": ["group-1"]}, r"filters\.\$in"),
+        ([], r"^filters:"),
     ],
 )
-def test_validate_run_filters_reports_first_error_in_depth_first_order(
-    children: list[dict[str, Any]], error_path: str
-) -> None:
-    filters = {"$and": children, "$nin": ["group-2"]}
-
-    with pytest.raises(ValueError) as exc_info:
+def test_validate_run_filters_rejects_invalid_filters(filters, error_path) -> None:
+    with pytest.raises(ValueError, match=error_path):
         validate_run_filters(filters)
-
-    assert str(exc_info.value).startswith(f"{error_path}:")
-
-
-def test_validate_run_filters_accepts_shared_subtrees() -> None:
-    shared = {"$or": [{"tags": {"$all": ["sgd"]}}]}
-    filters = {"$and": [shared, {"$nor": [shared]}, shared]}
-
-    assert validate_run_filters(filters) is filters
-
-
-def test_validate_run_filters_reports_error_after_shared_subtree() -> None:
-    shared = {"$or": [{"tags": ["sgd"]}]}
-    filters = {"$and": [shared, shared, {"tags": [["test"]]}]}
-
-    with pytest.raises(ValueError) as exc_info:
-        validate_run_filters(filters)
-
-    assert str(exc_info.value) == (
-        "filters.$and[2].tags[0]: expected a tag string, got list"
-    )
-
-
-def test_validate_run_filters_rechecks_changed_filters() -> None:
-    shared: dict[str, Any] = {"tags": ["sgd"]}
-    filters = {"$and": [shared, shared]}
-    assert validate_run_filters(filters) is filters
-
-    shared["tags"] = [["sgd"]]
-
-    with pytest.raises(ValueError) as exc_info:
-        validate_run_filters(filters)
-
-    assert str(exc_info.value) == (
-        "filters.$and[0].tags[0]: expected a tag string, got list"
-    )

--- a/tests/unit_tests/test_public_api/test_run_filters.py
+++ b/tests/unit_tests/test_public_api/test_run_filters.py
@@ -1,0 +1,96 @@
+from typing import Any
+
+import pytest
+from wandb.apis.public.run_filters import validate_run_filters
+
+
+@pytest.mark.parametrize("invalid_leaf", [False, True])
+def test_validate_run_filters_handles_nested_groups(invalid_leaf: bool) -> None:
+    depth = 50
+    filters: dict[str, Any] = {"tags": {"$all": [["sgd"]] if invalid_leaf else ["sgd"]}}
+    for _ in range(depth):
+        filters = {"$and": [filters]}
+
+    if invalid_leaf:
+        with pytest.raises(ValueError) as exc_info:
+            validate_run_filters(filters)
+        expected_path = "filters" + ".$and[0]" * depth + ".tags.$all[0]"
+        assert str(exc_info.value) == (
+            f"{expected_path}: expected a tag string, got list"
+        )
+    else:
+        assert validate_run_filters(filters) is filters
+
+
+def test_validate_run_filters_handles_wide_groups() -> None:
+    filters = {"$or": [{"tags": {"$in": ["sgd"]}} for _ in range(10_000)]}
+
+    assert validate_run_filters(filters) is filters
+
+
+@pytest.mark.parametrize(
+    "children,error_path",
+    [
+        (
+            [
+                {"$or": [{"tags": {"$all": [["sgd"]]}}]},
+                {"$in": ["group-1"]},
+            ],
+            "filters.$and[0].$or[0].tags.$all[0]",
+        ),
+        (
+            [
+                {"$or": [{"tags": {"$all": ["sgd"]}}]},
+                {"$in": ["group-1"]},
+            ],
+            "filters.$and[1].$in",
+        ),
+        (
+            [{"$or": [{"tags": {"$all": ["sgd"]}}]}],
+            "filters.$nin",
+        ),
+    ],
+)
+def test_validate_run_filters_reports_first_error_in_depth_first_order(
+    children: list[dict[str, Any]], error_path: str
+) -> None:
+    filters = {"$and": children, "$nin": ["group-2"]}
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_run_filters(filters)
+
+    assert str(exc_info.value).startswith(f"{error_path}:")
+
+
+def test_validate_run_filters_accepts_shared_subtrees() -> None:
+    shared = {"$or": [{"tags": {"$all": ["sgd"]}}]}
+    filters = {"$and": [shared, {"$nor": [shared]}, shared]}
+
+    assert validate_run_filters(filters) is filters
+
+
+def test_validate_run_filters_reports_error_after_shared_subtree() -> None:
+    shared = {"$or": [{"tags": ["sgd"]}]}
+    filters = {"$and": [shared, shared, {"tags": [["test"]]}]}
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_run_filters(filters)
+
+    assert str(exc_info.value) == (
+        "filters.$and[2].tags[0]: expected a tag string, got list"
+    )
+
+
+def test_validate_run_filters_rechecks_changed_filters() -> None:
+    shared: dict[str, Any] = {"tags": ["sgd"]}
+    filters = {"$and": [shared, shared]}
+    assert validate_run_filters(filters) is filters
+
+    shared["tags"] = [["sgd"]]
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_run_filters(filters)
+
+    assert str(exc_info.value) == (
+        "filters.$and[0].tags[0]: expected a tag string, got list"
+    )

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -1,6 +1,5 @@
 import json
 from copy import deepcopy
-from typing import Any
 from unittest import mock
 
 import pytest
@@ -10,67 +9,19 @@ from wandb.apis.public.sweeps import Sweep
 from wandb.proto import wandb_api_pb2 as apb
 
 
-@pytest.mark.parametrize("lazy", [True, False])
-def test_runs_reject_nested_tag_list(lazy: bool) -> None:
+def test_runs_reject_nested_tag_list() -> None:
     service_api = mock.MagicMock()
-    filters = {"tags": {"$all": [["sgd"], "test"], "$nin": ["test-2"]}}
+    filters = {"tags": {"$all": [["sgd"], "test"]}}
     original_filters = deepcopy(filters)
 
     with pytest.raises(
         ValueError,
         match=r"filters\.tags\.\$all\[0\]: expected a tag string",
     ):
-        Runs(service_api, "entity", "project", filters=filters, lazy=lazy)
+        Runs(service_api, "entity", "project", filters=filters)
 
     service_api.execute_graphql.assert_not_called()
     assert filters == original_filters
-
-
-@pytest.mark.parametrize(
-    "filters,error_path",
-    [
-        ({"tags": {"$all": "sgd"}}, "filters.tags.$all"),
-        ({"tags": {"$in": None}}, "filters.tags.$in"),
-        ({"tags": {"$nin": {"tag": "sgd"}}}, "filters.tags.$nin"),
-        ({"tags": {"$all": 1}}, "filters.tags.$all"),
-        ({"tags": {"$all": [{"tag": "sgd"}]}}, "filters.tags.$all[0]"),
-        ({"tags": {"$in": [1]}}, "filters.tags.$in[0]"),
-        ({"tags": {"$nin": [None]}}, "filters.tags.$nin[0]"),
-        ({"tags": {"$in": [("sgd",)]}}, "filters.tags.$in[0]"),
-        ({"tags": {"$nin": [["sgd"]]}}, "filters.tags.$nin[0]"),
-        ({"tags": [["sgd"]]}, "filters.tags[0]"),
-        ({"tags": (("sgd",),)}, "filters.tags[0]"),
-        ({"tags": ["sgd", 1]}, "filters.tags[1]"),
-        ({"tags": [None]}, "filters.tags[0]"),
-        ({"tags": [{"tag": "sgd"}]}, "filters.tags[0]"),
-        ({"$and": {"state": "finished"}}, "filters.$and"),
-        ({"$or": "sgd"}, "filters.$or"),
-        ({"$nor": None}, "filters.$nor"),
-        ({"$and": [None]}, "filters.$and[0]"),
-        ({"$or": ["sgd"]}, "filters.$or[0]"),
-        ({"$nor": [[]]}, "filters.$nor[0]"),
-        (
-            {"$and": [{"$or": ({"$nor": [{"tags": {"$all": [["sgd"]]}}]},)}]},
-            "filters.$and[0].$or[0].$nor[0].tags.$all[0]",
-        ),
-        ({"$all": ["sgd"]}, "filters.$all"),
-        ({"$in": ["group-1"]}, "filters.$in"),
-        ({"$nin": ["group-1"]}, "filters.$nin"),
-        ({"$or": [{"$in": ["group-1"]}]}, "filters.$or[0].$in"),
-        ([], "filters"),
-        ("", "filters"),
-        (0, "filters"),
-        (False, "filters"),
-    ],
-)
-def test_runs_reject_invalid_filters(filters: Any, error_path: str) -> None:
-    service_api = mock.MagicMock()
-
-    with pytest.raises(ValueError) as exc_info:
-        Runs(service_api, "entity", "project", filters=filters)
-
-    assert error_path in str(exc_info.value)
-    service_api.execute_graphql.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -78,31 +29,10 @@ def test_runs_reject_invalid_filters(filters: Any, error_path: str) -> None:
     [
         None,
         {},
-        {"tags": "sgd"},
-        {"tags": ["sgd", "test"]},
-        {"tags": ("sgd", "test")},
-        {"tags": []},
-        {"tags": ()},
-        {"tags": {"$all": ["sgd", "test"], "$nin": ["test-2"]}},
-        {"tags": {"$in": ("sgd", "test"), "$all": (), "$nin": []}},
-        {
-            "$and": [
-                {"tags": {"$all": ["sgd"]}},
-                {"$or": ({"group": {"$in": ["group-1"]}},)},
-                {"$nor": [{"state": "failed"}]},
-            ]
-        },
-        {"$and": [], "$or": (), "$nor": []},
-        {
-            "config.options": {"tags": {"$all": [["literal"]]}},
-            "summary_metrics.values": {"$in": [[1, 2], [3, 4]]},
-            "config.query": {"$or": "literal"},
-        },
-        {"tags": {"$exists": True}, "$futureOperator": {"value": [1, 2]}},
-        {"group": {"$in": [["group-1"]]}},
+        {"tags": {"$all": ["sgd"], "$nin": ["test-2"]}},
     ],
 )
-def test_runs_preserve_valid_filters(filters: dict[str, Any] | None) -> None:
+def test_runs_preserve_valid_filters(filters: dict | None) -> None:
     service_api = mock.MagicMock()
     service_api.execute_graphql.return_value = {
         "project": {

--- a/tests/unit_tests/test_public_api/test_runs.py
+++ b/tests/unit_tests/test_public_api/test_runs.py
@@ -1,11 +1,126 @@
 import json
+from copy import deepcopy
+from typing import Any
 from unittest import mock
 
 import pytest
 import wandb
-from wandb.apis.public.runs import Run, RunNotFoundError
+from wandb.apis.public.runs import Run, RunNotFoundError, Runs
 from wandb.apis.public.sweeps import Sweep
 from wandb.proto import wandb_api_pb2 as apb
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+def test_runs_reject_nested_tag_list(lazy: bool) -> None:
+    service_api = mock.MagicMock()
+    filters = {"tags": {"$all": [["sgd"], "test"], "$nin": ["test-2"]}}
+    original_filters = deepcopy(filters)
+
+    with pytest.raises(
+        ValueError,
+        match=r"filters\.tags\.\$all\[0\]: expected a tag string",
+    ):
+        Runs(service_api, "entity", "project", filters=filters, lazy=lazy)
+
+    service_api.execute_graphql.assert_not_called()
+    assert filters == original_filters
+
+
+@pytest.mark.parametrize(
+    "filters,error_path",
+    [
+        ({"tags": {"$all": "sgd"}}, "filters.tags.$all"),
+        ({"tags": {"$in": None}}, "filters.tags.$in"),
+        ({"tags": {"$nin": {"tag": "sgd"}}}, "filters.tags.$nin"),
+        ({"tags": {"$all": 1}}, "filters.tags.$all"),
+        ({"tags": {"$all": [{"tag": "sgd"}]}}, "filters.tags.$all[0]"),
+        ({"tags": {"$in": [1]}}, "filters.tags.$in[0]"),
+        ({"tags": {"$nin": [None]}}, "filters.tags.$nin[0]"),
+        ({"tags": {"$in": [("sgd",)]}}, "filters.tags.$in[0]"),
+        ({"tags": {"$nin": [["sgd"]]}}, "filters.tags.$nin[0]"),
+        ({"tags": [["sgd"]]}, "filters.tags[0]"),
+        ({"tags": (("sgd",),)}, "filters.tags[0]"),
+        ({"tags": ["sgd", 1]}, "filters.tags[1]"),
+        ({"tags": [None]}, "filters.tags[0]"),
+        ({"tags": [{"tag": "sgd"}]}, "filters.tags[0]"),
+        ({"$and": {"state": "finished"}}, "filters.$and"),
+        ({"$or": "sgd"}, "filters.$or"),
+        ({"$nor": None}, "filters.$nor"),
+        ({"$and": [None]}, "filters.$and[0]"),
+        ({"$or": ["sgd"]}, "filters.$or[0]"),
+        ({"$nor": [[]]}, "filters.$nor[0]"),
+        (
+            {"$and": [{"$or": ({"$nor": [{"tags": {"$all": [["sgd"]]}}]},)}]},
+            "filters.$and[0].$or[0].$nor[0].tags.$all[0]",
+        ),
+        ({"$all": ["sgd"]}, "filters.$all"),
+        ({"$in": ["group-1"]}, "filters.$in"),
+        ({"$nin": ["group-1"]}, "filters.$nin"),
+        ({"$or": [{"$in": ["group-1"]}]}, "filters.$or[0].$in"),
+        ([], "filters"),
+        ("", "filters"),
+        (0, "filters"),
+        (False, "filters"),
+    ],
+)
+def test_runs_reject_invalid_filters(filters: Any, error_path: str) -> None:
+    service_api = mock.MagicMock()
+
+    with pytest.raises(ValueError) as exc_info:
+        Runs(service_api, "entity", "project", filters=filters)
+
+    assert error_path in str(exc_info.value)
+    service_api.execute_graphql.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        None,
+        {},
+        {"tags": "sgd"},
+        {"tags": ["sgd", "test"]},
+        {"tags": ("sgd", "test")},
+        {"tags": []},
+        {"tags": ()},
+        {"tags": {"$all": ["sgd", "test"], "$nin": ["test-2"]}},
+        {"tags": {"$in": ("sgd", "test"), "$all": (), "$nin": []}},
+        {
+            "$and": [
+                {"tags": {"$all": ["sgd"]}},
+                {"$or": ({"group": {"$in": ["group-1"]}},)},
+                {"$nor": [{"state": "failed"}]},
+            ]
+        },
+        {"$and": [], "$or": (), "$nor": []},
+        {
+            "config.options": {"tags": {"$all": [["literal"]]}},
+            "summary_metrics.values": {"$in": [[1, 2], [3, 4]]},
+            "config.query": {"$or": "literal"},
+        },
+        {"tags": {"$exists": True}, "$futureOperator": {"value": [1, 2]}},
+        {"group": {"$in": [["group-1"]]}},
+    ],
+)
+def test_runs_preserve_valid_filters(filters: dict[str, Any] | None) -> None:
+    service_api = mock.MagicMock()
+    service_api.execute_graphql.return_value = {
+        "project": {
+            "runCount": 0,
+            "runs": {"edges": [], "pageInfo": {"hasNextPage": False}},
+        }
+    }
+    original_filters = deepcopy(filters)
+
+    runs = Runs(service_api, "entity", "project", filters=filters)
+
+    assert list(runs) == []
+    service_api.execute_graphql.assert_called_once()
+    variables = service_api.execute_graphql.call_args.args[1]
+    assert variables["filters"] == json.dumps(
+        {} if original_filters is None else original_filters
+    )
+    assert filters == original_filters
 
 
 def _make_upload_run(mocker, *, feature_enabled: bool):

--- a/tests/unit_tests/test_public_api/test_sweeps.py
+++ b/tests/unit_tests/test_public_api/test_sweeps.py
@@ -1,5 +1,4 @@
 import json
-import re
 from copy import deepcopy
 from functools import partial
 from unittest.mock import Mock
@@ -20,42 +19,19 @@ from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 from wandb.sdk.sweeps import SweepNotFoundError
 
 
-@pytest.fixture(params=["constructor", "project"])
-def make_sweeps(request, mocker):
+@pytest.fixture
+def make_sweeps(mocker):
     service_api = mocker.Mock()
     service_api.feature_enabled.return_value = True
-    if request.param == "constructor":
-        return partial(Sweeps, service_api, "entity", "project"), service_api
-    project = Project(service_api, "entity", "project", attrs={})
-    return project.sweeps, service_api
+    return partial(Sweeps, service_api, "entity", "project"), service_api
 
 
-@pytest.mark.parametrize(
-    "filters,error",
-    [
-        (
-            {"tags": {"$all": [["sgd"], "test"], "$nin": ["test-2"]}},
-            "filters.tags.$all[0]: expected a tag string, got list",
-        ),
-        (
-            {"$in": ["group-1"]},
-            "filters.$in: $in must be nested under a field name",
-        ),
-        (
-            {"tags": [["sgd"]]},
-            "filters.tags[0]: expected a tag string, got list",
-        ),
-        (0, "filters: expected a filter dictionary"),
-        ("", "filters: expected a filter dictionary"),
-        (False, "filters: expected a filter dictionary"),
-        ([], "filters: expected a filter dictionary"),
-    ],
-)
-def test_sweeps_reject_invalid_filters_before_requests(make_sweeps, filters, error):
+def test_sweeps_reject_invalid_filters_before_requests(make_sweeps):
     create_sweeps, service_api = make_sweeps
+    filters = {"tags": {"$all": [["sgd"], "test"]}}
     original_filters = deepcopy(filters)
 
-    with pytest.raises(ValueError, match=re.escape(error)):
+    with pytest.raises(ValueError, match=r"filters\.tags\.\$all\[0\]"):
         create_sweeps(filters=filters)
 
     assert filters == original_filters
@@ -63,33 +39,15 @@ def test_sweeps_reject_invalid_filters_before_requests(make_sweeps, filters, err
     service_api.execute_graphql.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "filters",
-    [
-        None,
-        {},
-        {"tags": {"$all": ["sgd", "test"], "$nin": ["test-2"]}},
-        {"tags": ["sgd", "test"]},
-        {"tags": ("sgd", "test")},
-        {
-            "$and": [
-                {"tags": {"$in": ["sgd"]}},
-                {"summary_metrics.values": {"$in": [[1, 2], [3, 4]]}},
-                {"config.layers": {"$eq": [32, 64]}},
-            ]
-        },
-    ],
-)
-def test_sweeps_preserve_valid_filters(make_sweeps, filters):
-    create_sweeps, service_api = make_sweeps
-    original_filters = deepcopy(filters)
+def test_sweeps_preserve_valid_filters(mocker):
+    service_api = mocker.Mock()
+    service_api.feature_enabled.return_value = True
+    project = Project(service_api, "entity", "project", attrs={})
+    filters = {"tags": {"$all": ["sgd"], "$nin": ["test-2"]}}
 
-    sweeps = create_sweeps(filters=filters)
+    sweeps = project.sweeps(filters=filters)
 
-    assert filters == original_filters
-    assert sweeps.variables["filters"] == json.dumps({} if filters is None else filters)
-    service_api.feature_enabled.assert_called_once_with(pb.SWEEPS_QUERY_FILTERING)
-    service_api.execute_graphql.assert_not_called()
+    assert sweeps.variables["filters"] == json.dumps(filters)
 
 
 def test_sweeps_reject_filters_on_unsupported_server(make_sweeps):
@@ -103,12 +61,11 @@ def test_sweeps_reject_filters_on_unsupported_server(make_sweeps):
     service_api.execute_graphql.assert_not_called()
 
 
-@pytest.mark.parametrize("filters", [None, {}])
-def test_sweeps_allow_empty_filters_on_unsupported_server(make_sweeps, filters):
+def test_sweeps_allow_empty_filters_on_unsupported_server(make_sweeps):
     create_sweeps, service_api = make_sweeps
     service_api.feature_enabled.return_value = False
 
-    sweeps = create_sweeps(filters=filters)
+    sweeps = create_sweeps(filters=None)
 
     assert sweeps.variables["filters"] == "{}"
     service_api.feature_enabled.assert_called_once_with(pb.SWEEPS_QUERY_FILTERING)

--- a/tests/unit_tests/test_public_api/test_sweeps.py
+++ b/tests/unit_tests/test_public_api/test_sweeps.py
@@ -1,9 +1,14 @@
 import json
+import re
+from copy import deepcopy
+from functools import partial
 from unittest.mock import Mock
 
 import pytest
+from wandb.apis.public.projects import Project
 from wandb.apis.public.sweeps import (
     Sweep,
+    Sweeps,
     _agent_heartbeat,
     _sweep_with_runs,
     _upsert_sweep,
@@ -13,6 +18,101 @@ from wandb.proto import wandb_api_pb2 as apb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 from wandb.sdk.sweeps import SweepNotFoundError
+
+
+@pytest.fixture(params=["constructor", "project"])
+def make_sweeps(request, mocker):
+    service_api = mocker.Mock()
+    service_api.feature_enabled.return_value = True
+    if request.param == "constructor":
+        return partial(Sweeps, service_api, "entity", "project"), service_api
+    project = Project(service_api, "entity", "project", attrs={})
+    return project.sweeps, service_api
+
+
+@pytest.mark.parametrize(
+    "filters,error",
+    [
+        (
+            {"tags": {"$all": [["sgd"], "test"], "$nin": ["test-2"]}},
+            "filters.tags.$all[0]: expected a tag string, got list",
+        ),
+        (
+            {"$in": ["group-1"]},
+            "filters.$in: $in must be nested under a field name",
+        ),
+        (
+            {"tags": [["sgd"]]},
+            "filters.tags[0]: expected a tag string, got list",
+        ),
+        (0, "filters: expected a filter dictionary"),
+        ("", "filters: expected a filter dictionary"),
+        (False, "filters: expected a filter dictionary"),
+        ([], "filters: expected a filter dictionary"),
+    ],
+)
+def test_sweeps_reject_invalid_filters_before_requests(make_sweeps, filters, error):
+    create_sweeps, service_api = make_sweeps
+    original_filters = deepcopy(filters)
+
+    with pytest.raises(ValueError, match=re.escape(error)):
+        create_sweeps(filters=filters)
+
+    assert filters == original_filters
+    service_api.feature_enabled.assert_not_called()
+    service_api.execute_graphql.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        None,
+        {},
+        {"tags": {"$all": ["sgd", "test"], "$nin": ["test-2"]}},
+        {"tags": ["sgd", "test"]},
+        {"tags": ("sgd", "test")},
+        {
+            "$and": [
+                {"tags": {"$in": ["sgd"]}},
+                {"summary_metrics.values": {"$in": [[1, 2], [3, 4]]}},
+                {"config.layers": {"$eq": [32, 64]}},
+            ]
+        },
+    ],
+)
+def test_sweeps_preserve_valid_filters(make_sweeps, filters):
+    create_sweeps, service_api = make_sweeps
+    original_filters = deepcopy(filters)
+
+    sweeps = create_sweeps(filters=filters)
+
+    assert filters == original_filters
+    assert sweeps.variables["filters"] == json.dumps({} if filters is None else filters)
+    service_api.feature_enabled.assert_called_once_with(pb.SWEEPS_QUERY_FILTERING)
+    service_api.execute_graphql.assert_not_called()
+
+
+def test_sweeps_reject_filters_on_unsupported_server(make_sweeps):
+    create_sweeps, service_api = make_sweeps
+    service_api.feature_enabled.return_value = False
+
+    with pytest.raises(UnsupportedError, match="Filtering sweeps is not supported"):
+        create_sweeps(filters={"tags": {"$all": ["sgd"]}})
+
+    service_api.feature_enabled.assert_called_once_with(pb.SWEEPS_QUERY_FILTERING)
+    service_api.execute_graphql.assert_not_called()
+
+
+@pytest.mark.parametrize("filters", [None, {}])
+def test_sweeps_allow_empty_filters_on_unsupported_server(make_sweeps, filters):
+    create_sweeps, service_api = make_sweeps
+    service_api.feature_enabled.return_value = False
+
+    sweeps = create_sweeps(filters=filters)
+
+    assert sweeps.variables["filters"] == "{}"
+    service_api.feature_enabled.assert_called_once_with(pb.SWEEPS_QUERY_FILTERING)
+    service_api.execute_graphql.assert_not_called()
 
 
 def _make_sweep(

--- a/wandb/apis/public/api.py
+++ b/wandb/apis/public/api.py
@@ -31,6 +31,7 @@ from wandb._iterutils import one
 from wandb.apis import public
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.public.registries import Registries, Registry
+from wandb.apis.public.run_filters import validate_run_filters
 from wandb.apis.public.service_api import ServiceApi
 from wandb.apis.public.utils import (
     PathType,
@@ -1189,6 +1190,9 @@ class Api:
         Returns:
             A `Runs` object, which is an iterable collection of `Run` objects.
 
+        Raises:
+            ValueError: If a query or tag membership predicate is malformed.
+
         Examples:
         ```python
         import wandb
@@ -1235,8 +1239,9 @@ class Api:
         Api.runs(path="my_entity/project", order="+summary_metrics.loss")
         ```
         """
+        # Resolving the default entity can make a request, so validate first.
+        filters = validate_run_filters(filters)
         entity, project = self._parse_project_path(path)
-        filters = filters or {}
         key = (path or "") + str(filters) + str(order)
 
         # Check if we have cached results

--- a/wandb/apis/public/projects.py
+++ b/wandb/apis/public/projects.py
@@ -261,7 +261,9 @@ class Project(Attrs):
             per_page=per_page,
         )
 
-    @normalize_exceptions
+    # Intentionally not wrapped in `normalize_exceptions`: it rewrites the
+    # `ValueError` raised for a malformed filter into a `CommError`, which is
+    # the opaque error that validating filters is meant to replace.
     def sweeps(
         self,
         per_page: int = 50,
@@ -277,6 +279,9 @@ class Project(Attrs):
 
         Returns:
             A `Sweeps` object, which is an iterable collection of `Sweep` objects.
+
+        Raises:
+            ValueError: If a checked filter is malformed.
         """
         return Sweeps(
             self._service_api,

--- a/wandb/apis/public/run_filters.py
+++ b/wandb/apis/public/run_filters.py
@@ -1,0 +1,85 @@
+"""Validation for run query filters."""
+
+from __future__ import annotations
+
+from typing import Any, NoReturn
+
+_LOGICAL_OPERATORS = frozenset({"$and", "$or", "$nor"})
+_MEMBERSHIP_OPERATORS = frozenset({"$all", "$in", "$nin"})
+
+
+def validate_run_filters(filters: dict[str, Any] | None) -> dict[str, Any]:
+    """Check logical groups and tag lists in run filters.
+
+    Other fields and operators are left to the server to validate.
+
+    Args:
+        filters: Filters to check, or `None` for no filtering.
+
+    Returns:
+        The input dictionary unchanged, or an empty dictionary for `None`.
+
+    Raises:
+        ValueError: If a checked filter is malformed.
+    """
+    filters = {} if filters is None else filters
+    _validate_query(filters, [])
+    return filters
+
+
+def _validate_query(query: object, filter_path: list[str]) -> None:
+    if not isinstance(query, dict):
+        _raise_filter_error(filter_path, "", "expected a filter dictionary")
+
+    for field, condition in query.items():
+        if field in _LOGICAL_OPERATORS:
+            if not isinstance(condition, (list, tuple)):
+                _raise_filter_error(
+                    filter_path, f".{field}", "expected a list of filter dictionaries"
+                )
+            for index, child in enumerate(condition):
+                filter_path.append(f".{field}[{index}]")
+                _validate_query(child, filter_path)
+                filter_path.pop()
+        elif field in _MEMBERSHIP_OPERATORS:
+            _raise_filter_error(
+                filter_path,
+                f".{field}",
+                f"{field} must be nested under a field name; "
+                f"for example, {{'tags': {{'{field}': ['tag-1']}}}}",
+            )
+        elif field == "tags":
+            _validate_tags(condition, filter_path)
+
+
+def _validate_tags(condition: object, filter_path: list[str]) -> None:
+    """Check tag operands, which the server accepts only as strings.
+
+    Membership (`{"tags": {"$all": [...]}}`) and direct equality
+    (`{"tags": [...]}`) are both checked: a non-string in either form fails
+    server-side with an opaque error instead of a useful one.
+    """
+    if isinstance(condition, dict):
+        for operator, values in condition.items():
+            if operator not in _MEMBERSHIP_OPERATORS:
+                continue
+            _validate_tag_values(values, filter_path, f".tags.{operator}")
+    elif isinstance(condition, (list, tuple)):
+        _validate_tag_values(condition, filter_path, ".tags")
+
+
+def _validate_tag_values(values: object, filter_path: list[str], suffix: str) -> None:
+    if not isinstance(values, (list, tuple)):
+        _raise_filter_error(filter_path, suffix, "expected a list of tag strings")
+    for index, value in enumerate(values):
+        if not isinstance(value, str):
+            _raise_filter_error(
+                filter_path,
+                f"{suffix}[{index}]",
+                f"expected a tag string, got {type(value).__name__}",
+            )
+
+
+def _raise_filter_error(filter_path: list[str], suffix: str, message: str) -> NoReturn:
+    # Prefix the offending location with the public argument's name.
+    raise ValueError(f"filters{''.join(filter_path)}{suffix}: {message}")

--- a/wandb/apis/public/runs.py
+++ b/wandb/apis/public/runs.py
@@ -55,6 +55,7 @@ from wandb.apis._generated.get_agent_runs import GetAgentRuns
 from wandb.apis.attrs import Attrs
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import SizedPaginator
+from wandb.apis.public.run_filters import validate_run_filters
 from wandb.apis.public.service_api import ServiceApi
 from wandb.errors import CommError
 from wandb.proto import wandb_api_pb2 as apb
@@ -206,6 +207,9 @@ class Runs(SizedPaginator["Run"]):
             Defaults to True.
         lazy: Whether to defer loading heavy fields (config, summaryMetrics,
             systemMetrics) until they are accessed. Defaults to True.
+
+    Raises:
+        ValueError: If a query or tag membership predicate is malformed.
     """
 
     def __init__(
@@ -220,6 +224,7 @@ class Runs(SizedPaginator["Run"]):
         lazy: bool = True,
         api_key: str | None = None,
     ):
+        filters = validate_run_filters(filters)
         if not order:
             order = "+created_at"
 
@@ -228,7 +233,7 @@ class Runs(SizedPaginator["Run"]):
         self.entity = entity
         self.project = project
         self._project_internal_id = None
-        self.filters = filters or {}
+        self.filters = filters
         self.order = order
         self._sweeps: dict[str, public.Sweep] = {}
         self._include_sweeps = include_sweeps

--- a/wandb/apis/public/sweeps.py
+++ b/wandb/apis/public/sweeps.py
@@ -44,6 +44,7 @@ from wandb.apis import public
 from wandb.apis.attrs import Attrs
 from wandb.apis.normalize import normalize_exceptions
 from wandb.apis.paginator import SizedPaginator
+from wandb.apis.public.run_filters import validate_run_filters
 from wandb.errors import Error, UnsupportedError, UsageError
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.lib import ipython
@@ -102,7 +103,11 @@ class Sweeps(SizedPaginator["Sweep"]):
             per_page: The number of sweeps to fetch per request to the API.
             filters: (dict) queries for specific sweeps using the runs filters,
                 See wandb/apis/public/api.py:runs for more details.
+
+        Raises:
+            ValueError: If a checked filter is malformed.
         """
+        filters = validate_run_filters(filters)
         if self.QUERY is None:
             from wandb.apis._generated import GET_SWEEPS_GQL
 
@@ -128,7 +133,7 @@ class Sweeps(SizedPaginator["Sweep"]):
         variables = {
             "project": self.project,
             "entity": self.entity,
-            "filters": json.dumps(filters or {}),
+            "filters": json.dumps(filters),
         }
         super().__init__(service_api, variables, per_page)
 


### PR DESCRIPTION
## Description

Fixes WB-27494 and WB-27200

`Api.runs()`, `Runs`, and `Project.sweeps()` now validate run filters on the client before path resolution, cache lookup, or GraphQL.

A nested tag list used to be sent to the server and fail as `500` / `unsupported type []interface {}`. Those cases now raise `ValueError` with a path, for example `filters.tags.$all[0]: expected a tag string, got list`.

What is checked:

* `$and` / `$or` / `$nor` must be lists of filter dictionaries
* `$all` / `$in` / `$nin` must be nested under a field name
* `tags` membership lists (and bare tag lists) must be strings

Other fields and operators are left to the server. Valid filters are not rewritten; the same dict is serialized as before.

* [x] I updated CHANGELOG.unreleased.md