### PR TITLE
chore(sweeps): fix test_agent_basic timeout

### DIFF
--- a/tests/unit_tests/test_wandb_agent/conftest.py
+++ b/tests/unit_tests/test_wandb_agent/conftest.py
@@ -91,16 +91,20 @@ class WandbAgentTestEnv:
         return api
 
     def patch_sweep_helpers(self, module: str, api: mock.MagicMock) -> None:
-        """Route the module's sweep API helpers to the mock API's methods."""
+        """Route sweep helpers to the calling agent's mock API."""
         self.monkeypatch.setattr(wandb, "Api", lambda *args, **kwargs: api)
         for helper, method in [
-            ("_sweep_with_runs", api.sweep),
-            ("_register_agent", api.register_agent),
-            ("_agent_heartbeat", api.agent_heartbeat),
+            ("_sweep_with_runs", "sweep"),
+            ("_register_agent", "register_agent"),
+            ("_agent_heartbeat", "agent_heartbeat"),
         ]:
+            # A previous agent's heartbeat may still be exiting when another
+            # mock API is created. Keep its requests on its own API instance.
             self.monkeypatch.setattr(
                 f"{module}.{helper}",
-                lambda _api, *args, _method=method, **kwargs: _method(*args, **kwargs),
+                lambda _api, *args, _method=method, **kwargs: getattr(_api, _method)(
+                    *args, **kwargs
+                ),
                 raising=False,
             )
 


### PR DESCRIPTION
Description
-----------
Fix `test_agent_basic` intermittently [timing out in CI](https://app.circleci.com/pipelines/github/wandb/wandb/69801/workflows/85605cca-972e-47ac-819f-b119e9aa2013/jobs/1752374/tests). A heartbeat from the previous agent could consume the next agent's mocked job because the sweep helpers always called the latest mock API. Route calls through the API passed by each agent.
