### PR TITLE
feat: index local run history while reading the run

### DIFF
--- a/core/internal/runreader/cursor.go
+++ b/core/internal/runreader/cursor.go
@@ -22,25 +22,36 @@ func OpenCursor(path string, logger *observability.CoreLogger) (*Cursor, error) 
 	return &Cursor{reader: reader}, nil
 }
 
-// Next returns the next record, skipping corrupt data.
+// Next returns the next record and its offset, skipping corrupt data.
 //
 // The error wraps io.EOF when no more data is available yet, including when
 // the last record is only partially written; the position is then unchanged
 // so Next can be retried after the file grows. Any other error is terminal:
 // the file is not a transaction log this version can read.
-func (c *Cursor) Next() (*spb.Record, error) {
+func (c *Cursor) Next() (*spb.Record, int64, error) {
 	for {
 		before := c.reader.NextRecordOffset()
 		record, err := c.reader.Read()
 		switch {
 		case err == nil:
-			return record, nil
+			return record, before, nil
 		case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
-			return nil, errors.Join(io.EOF, c.reader.ResetLastRead())
+			return nil, 0, errors.Join(io.EOF, c.reader.ResetLastRead())
 		case c.reader.NextRecordOffset() <= before:
-			return nil, err
+			return nil, 0, err
 		}
 	}
+}
+
+// Offset returns the offset of the next record to read.
+func (c *Cursor) Offset() int64 {
+	return c.reader.NextRecordOffset()
+}
+
+// SeekRecord moves the cursor to a record's offset, as returned by Next or
+// Offset.
+func (c *Cursor) SeekRecord(offset int64) error {
+	return c.reader.SeekRecord(offset)
 }
 
 func (c *Cursor) Close() {

--- a/core/internal/runreader/history.go
+++ b/core/internal/runreader/history.go
@@ -1,0 +1,239 @@
+package runreader
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sort"
+	"strconv"
+
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// indexStride is the number of history records between index entries.
+const indexStride = 100
+
+type indexEntry struct {
+	step   int64
+	offset int64
+}
+
+// HistoryQuery selects history rows.
+type HistoryQuery struct {
+	// Keys restricts each row to these keys, plus _step. Rows with none of
+	// the keys are skipped. Empty means all keys.
+	Keys []string
+
+	// MinStep and MaxStep bound the rows' steps, inclusive, when non-nil.
+	MinStep, MaxStep *int64
+
+	// Last, when positive, returns only the last N matching rows, in a
+	// single page.
+	Last int
+
+	// Offset continues a scan from a previous page's NextOffset.
+	Offset int64
+
+	// Limit, when positive, is the most rows in a page.
+	Limit int
+}
+
+// HistoryPage is one page of matching rows.
+type HistoryPage struct {
+	// Rows holds one JSON object per row, each ending in a newline. Nested
+	// keys are joined with dots; values are as logged.
+	Rows []byte
+
+	// NextOffset is the Offset for the next page, or 0 when the scan is
+	// complete.
+	NextOffset int64
+}
+
+// History scans the transaction log for rows matching the query.
+//
+// The index built by Update tells the scan where to start; rows appended
+// since the last Update are still read, as every scan runs to the end of
+// the file.
+func (r *Run) History(ctx context.Context, query HistoryQuery) (HistoryPage, error) {
+	cursor, err := OpenCursor(r.path, r.logger)
+	if err != nil {
+		return HistoryPage{}, err
+	}
+	defer cursor.Close()
+
+	scan := &historyScan{ctx: ctx, cursor: cursor, query: query}
+	if len(query.Keys) > 0 {
+		scan.keys = make(map[string]struct{}, len(query.Keys))
+		for _, key := range query.Keys {
+			scan.keys[key] = struct{}{}
+		}
+	}
+
+	if query.Last > 0 {
+		return scan.last(r.index)
+	}
+
+	start := query.Offset
+	if start == 0 && query.MinStep != nil {
+		start = r.offsetForStep(*query.MinStep)
+	}
+	if start > 0 {
+		if err := cursor.SeekRecord(start); err != nil {
+			return HistoryPage{}, err
+		}
+	}
+	rows, _, next, err := scan.read(nil, query.Limit, 0)
+	return HistoryPage{Rows: rows, NextOffset: next}, err
+}
+
+// offsetForStep returns the offset of the last index entry at or before
+// step, or 0 to scan from the start.
+func (r *Run) offsetForStep(step int64) int64 {
+	i := sort.Search(len(r.index), func(i int) bool { return r.index[i].step > step })
+	if i == 0 {
+		return 0
+	}
+	return r.index[i-1].offset
+}
+
+type historyScan struct {
+	ctx    context.Context
+	cursor *Cursor
+	query  HistoryQuery
+	keys   map[string]struct{}
+}
+
+// read appends matching rows to dst until the record at offset end (when
+// positive), the end of the file, a step past MaxStep, or limit rows (when
+// positive). It returns the rows, how many were appended, and the offset to
+// continue from, which is 0 once the scan is complete.
+func (s *historyScan) read(dst []byte, limit int, end int64) ([]byte, int, int64, error) {
+	count := 0
+	for {
+		if err := s.ctx.Err(); err != nil {
+			return dst, count, 0, err
+		}
+		if limit > 0 && count == limit || end > 0 && s.cursor.Offset() >= end {
+			return dst, count, s.cursor.Offset(), nil
+		}
+		record, _, err := s.cursor.Next()
+		if errors.Is(err, io.EOF) {
+			return dst, count, 0, nil
+		}
+		if err != nil {
+			return dst, count, 0, err
+		}
+		history := record.GetHistory()
+		if history == nil {
+			continue
+		}
+		step := historyStep(history)
+		if s.query.MinStep != nil && step < *s.query.MinStep {
+			continue
+		}
+		if s.query.MaxStep != nil && step > *s.query.MaxStep {
+			return dst, count, 0, nil
+		}
+		var ok bool
+		if dst, ok = appendRow(dst, history, s.keys); ok {
+			count++
+		}
+	}
+}
+
+// last returns the last query.Last matching rows by scanning the file
+// backwards one index granule at a time.
+func (s *historyScan) last(index []indexEntry) (HistoryPage, error) {
+	var rows []byte
+	count := 0
+	for g := len(index) - 1; g >= 0 && count < s.query.Last; g-- {
+		if err := s.cursor.SeekRecord(index[g].offset); err != nil {
+			return HistoryPage{}, err
+		}
+		var end int64
+		if g+1 < len(index) {
+			end = index[g+1].offset
+		}
+		granule, n, _, err := s.read(nil, 0, end)
+		if err != nil {
+			return HistoryPage{}, err
+		}
+		rows = append(granule, rows...)
+		count += n
+		if s.query.MinStep != nil && index[g].step < *s.query.MinStep {
+			break
+		}
+	}
+	for ; count > s.query.Last; count-- {
+		rows = rows[indexByteAfterNewline(rows):]
+	}
+	return HistoryPage{Rows: rows}, nil
+}
+
+func indexByteAfterNewline(rows []byte) int {
+	for i, c := range rows {
+		if c == '\n' {
+			return i + 1
+		}
+	}
+	return len(rows)
+}
+
+// appendRow appends the record's items as a JSON object line, with _step
+// from the record's step when it has one. When keys is non-nil, only those
+// keys and _step are included, and the row is skipped (dst is returned
+// unchanged with false) if none of the keys is present.
+func appendRow(dst []byte, history *spb.HistoryRecord, keys map[string]struct{}) ([]byte, bool) {
+	start := len(dst)
+	dst = append(dst, '{')
+	if history.Step != nil {
+		dst = append(dst, `"_step":`...)
+		dst = strconv.AppendInt(dst, history.Step.GetNum(), 10)
+	}
+	matched := keys == nil
+	for _, item := range history.GetItem() {
+		key := historyItemKey(item)
+		if key == "_step" && history.Step != nil {
+			continue
+		}
+		if keys != nil {
+			if _, wanted := keys[key]; wanted {
+				matched = true
+			} else if key != "_step" {
+				continue
+			}
+		}
+		if len(dst) > start+1 {
+			dst = append(dst, ',')
+		}
+		dst = appendJSONString(dst, key)
+		dst = append(dst, ':')
+		if value := item.GetValueJson(); value != "" {
+			dst = append(dst, value...)
+		} else {
+			dst = append(dst, "null"...)
+		}
+	}
+	if !matched {
+		return dst[:start], false
+	}
+	return append(dst, '}', '\n'), true
+}
+
+const hexDigits = "0123456789abcdef"
+
+// appendJSONString appends s as a quoted JSON string.
+func appendJSONString(dst []byte, s string) []byte {
+	dst = append(dst, '"')
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == '"' || c == '\\':
+			dst = append(dst, '\\', c)
+		case c < 0x20:
+			dst = append(dst, '\\', 'u', '0', '0', hexDigits[c>>4], hexDigits[c&0xf])
+		default:
+			dst = append(dst, c)
+		}
+	}
+	return append(dst, '"')
+}

--- a/core/internal/runreader/history_test.go
+++ b/core/internal/runreader/history_test.go
@@ -1,0 +1,133 @@
+package runreader_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wandb/wandb/core/internal/observability"
+	"github.com/wandb/wandb/core/internal/runreader"
+	"github.com/wandb/wandb/core/internal/transactionlog"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+// writeHistoryLog writes rows history records with a loss value, an acc
+// value on every tenth row and a nested val/loss value on row 7, interleaved
+// with a stats record per row.
+func writeHistoryLog(t testing.TB, path string, rows int, extraKeys int) {
+	t.Helper()
+	w, err := transactionlog.OpenWriter(path)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(runRecord("abc", nil)))
+	for step := range int64(rows) {
+		items := map[string]string{"_step": strconv.FormatInt(step, 10), "loss": fmt.Sprintf("%g", float64(step)/2)}
+		if step%10 == 0 {
+			items["acc"] = "0.9"
+		}
+		for i := range extraKeys {
+			items[fmt.Sprintf("m%d", i)] = "1.5"
+		}
+		record := historyRecord(step, items)
+		if step == 7 {
+			record.GetHistory().Item = append(record.GetHistory().Item,
+				&spb.HistoryItem{NestedKey: []string{"val", "loss"}, ValueJson: "0.25"})
+		}
+		require.NoError(t, w.Write(record))
+		require.NoError(t, w.Write(&spb.Record{RecordType: &spb.Record_Stats{Stats: &spb.StatsRecord{
+			Item: []*spb.StatsItem{{Key: "cpu", ValueJson: "1"}},
+		}}}))
+	}
+	require.NoError(t, w.Close())
+}
+
+// readAll runs the query, following pages, and returns the decoded rows.
+func readAll(t *testing.T, run *runreader.Run, query runreader.HistoryQuery) []map[string]any {
+	t.Helper()
+	var rows []map[string]any
+	for {
+		page, err := run.History(context.Background(), query)
+		require.NoError(t, err)
+		decoder := json.NewDecoder(bytes.NewReader(page.Rows))
+		for decoder.More() {
+			var row map[string]any
+			require.NoError(t, decoder.Decode(&row))
+			rows = append(rows, row)
+		}
+		if page.NextOffset == 0 {
+			return rows
+		}
+		query.Offset = page.NextOffset
+	}
+}
+
+func TestRun_History(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run-abc.wandb")
+	writeHistoryLog(t, path, 250, 0)
+	run, err := runreader.Open(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
+	defer run.Close()
+	require.NoError(t, run.Update(context.Background()))
+	steps := func(rows []map[string]any) []float64 {
+		var steps []float64
+		for _, row := range rows {
+			steps = append(steps, row["_step"].(float64))
+		}
+		return steps
+	}
+	step := func(n int64) *int64 { return &n }
+
+	rows := readAll(t, run, runreader.HistoryQuery{})
+	require.Len(t, rows, 250)
+	assert.Equal(t, map[string]any{"_step": 0.0, "loss": 0.0, "acc": 0.9}, rows[0])
+	assert.Equal(t, 0.25, rows[7]["val.loss"])
+
+	rows = readAll(t, run, runreader.HistoryQuery{Keys: []string{"acc"}})
+	require.Len(t, rows, 25)
+	assert.Equal(t, map[string]any{"_step": 240.0, "acc": 0.9}, rows[24])
+
+	rows = readAll(t, run, runreader.HistoryQuery{MinStep: step(150), MaxStep: step(152)})
+	assert.Equal(t, []float64{150, 151, 152}, steps(rows))
+
+	rows = readAll(t, run, runreader.HistoryQuery{Keys: []string{"acc"}, Last: 12})
+	assert.Equal(t, []float64{130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240}, steps(rows))
+
+	page, err := run.History(context.Background(), runreader.HistoryQuery{Limit: 100})
+	require.NoError(t, err)
+	assert.Equal(t, 100, bytes.Count(page.Rows, []byte("\n")))
+	assert.NotZero(t, page.NextOffset)
+	rows = readAll(t, run, runreader.HistoryQuery{Limit: 100, Offset: page.NextOffset})
+	assert.Equal(t, 150, len(rows))
+	assert.Equal(t, 100.0, rows[0]["_step"])
+}
+
+func BenchmarkHistory(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "run-abc.wandb")
+	writeHistoryLog(b, path, 20_000, 20)
+	run, err := runreader.Open(path, observability.NewNoOpLogger())
+	require.NoError(b, err)
+	defer run.Close()
+	require.NoError(b, run.Update(context.Background()))
+	minStep := int64(19_990)
+	for name, query := range map[string]runreader.HistoryQuery{
+		"all":     {},
+		"one_key": {Keys: []string{"acc"}},
+		"last_10": {Last: 10},
+		"tail_10": {MinStep: &minStep},
+		"page_1k": {Limit: 1000},
+	} {
+		b.Run(name, func(b *testing.B) {
+			for b.Loop() {
+				if _, err := run.History(context.Background(), query); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/core/internal/runreader/run.go
+++ b/core/internal/runreader/run.go
@@ -82,10 +82,19 @@ func infoFromRecord(rec *spb.RunRecord) Info {
 // Run is a run's state folded from its transaction log.
 //
 // Update reads the records written since the last call, so a Run kept open
-// follows a live run cheaply. History rows are not retained.
+// follows a live run cheaply. History rows are not retained; History scans
+// the file for them.
 type Run struct {
 	path   string
 	cursor *Cursor
+	logger *observability.CoreLogger
+
+	// index has one entry per indexStride history records, in file order.
+	// Steps never decrease within a log, since the SDK drops out-of-order
+	// steps, so a scan for a step or for the last rows can seek to the
+	// entry nearest its target instead of reading from the start.
+	index        []indexEntry
+	historyCount int
 
 	info        Info
 	infoSeen    bool
@@ -112,6 +121,7 @@ func Open(path string, logger *observability.CoreLogger) (*Run, error) {
 	return &Run{
 		path:        path,
 		cursor:      cursor,
+		logger:      logger,
 		config:      runconfig.New(),
 		summary:     runsummary.New(),
 		console:     NewConsole(),
@@ -129,18 +139,18 @@ func (r *Run) Update(ctx context.Context) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		record, err := r.cursor.Next()
+		record, offset, err := r.cursor.Next()
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
 			return err
 		}
-		r.apply(record)
+		r.apply(record, offset)
 	}
 }
 
-func (r *Run) apply(record *spb.Record) {
+func (r *Run) apply(record *spb.Record, offset int64) {
 	switch rec := record.RecordType.(type) {
 	case *spb.Record_Run:
 		r.info = infoFromRecord(rec.Run)
@@ -168,7 +178,12 @@ func (r *Run) apply(record *spb.Record) {
 		}
 		r.environment.ProcessRecord(rec.Environment)
 	case *spb.Record_History:
-		r.lastStep = max(r.lastStep, historyStep(rec.History))
+		step := historyStep(rec.History)
+		if r.historyCount%indexStride == 0 {
+			r.index = append(r.index, indexEntry{step: step, offset: offset})
+		}
+		r.historyCount++
+		r.lastStep = max(r.lastStep, step)
 		if r.summaryMetrics != nil {
 			r.deriveSummary(rec.History)
 		}


### PR DESCRIPTION
Description
-----------
Every history query in `runreader` read the whole transaction log, so asking for the last row of a 1 GB run cost as much as reading all of it: about 3.5 seconds for a million rows.

`Run.Update` now records the step and file offset of every 100th history record. `Run.History` seeks to the entry nearest a query's minimum step, and for the last N rows walks the entries backwards one granule at a time, so both take a few hundred microseconds whatever the file size. The index lives in memory, 16 bytes per 100 rows, and is built during the read the run needs anyway.

Rows come back as newline-delimited JSON, one object per row, with nested keys joined by dots and values as logged. A page holds up to a requested number of rows and names the file offset to continue from, so a client streams a long history without wandb-core holding any state. A keys filter keeps `_step` in every row and skips rows that have none of the keys.

`go test ./core/internal/runreader -bench History` on a 20k-row, 23-key log:

| query | time |
|---|---|
| all rows | 50 ms |
| one key | 52 ms |
| last 10 rows | 0.38 ms |
| rows from step 19990 | 0.33 ms |
| first page of 1000 rows | 2.8 ms |

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Unit test over a 250-row log that spans three index granules.
