### PR TITLE
feat(sdk): convert local run history to pandas or polars

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Added
 
-- `wandb.beta.LocalApi` reads runs from a local wandb directory without a W&B server, API key or network: list the runs with their state, and read a run's config, summary, history rows and console logs, including while the run is still writing. It is experimental and may change in any release (@dmitryduev in https://github.com/wandb/wandb/pull/12745)
+- `wandb.beta.LocalApi` reads runs from a local wandb directory without a W&B server, API key or network: list the runs with their state, and read a run's config, summary, history rows (as dicts or a pandas or polars DataFrame) and console logs, including while the run is still writing. It is experimental and may change in any release (@dmitryduev in https://github.com/wandb/wandb/pull/12745, https://github.com/wandb/wandb/pull/12766)
 
 ### Changed
 

--- a/tests/unit_tests/test_beta_local_api.py
+++ b/tests/unit_tests/test_beta_local_api.py
@@ -129,6 +129,29 @@ def test_history_follows_pages(tmp_path):
     assert first.limit == second.limit > 0
 
 
+def test_history_dataframes(tmp_path):
+    pl = pytest.importorskip("polars")
+    service_api = mock.MagicMock()
+    service_api.send_api_request.return_value = apb.ApiResponse(
+        read_local_run_history_response=apb.ReadLocalRunHistoryResponse(
+            rows=b'{"_step":0,"loss":1.0}\n{"_step":1,"loss":NaN,"acc":0.5}\n'
+        )
+    )
+    history = LocalRun(service_api, info=_info(tmp_path)).history()
+
+    pandas_df = history.to_pandas()
+    assert list(pandas_df.columns) == ["_step", "loss", "acc"]
+    assert pandas_df["acc"].isna().tolist() == [True, False]
+
+    polars_df = history.to_polars()
+    assert polars_df.schema == {
+        "_step": pl.Int64,
+        "loss": pl.Float64,
+        "acc": pl.Float64,
+    }
+    assert polars_df["acc"].to_list() == [None, 0.5]
+
+
 def test_console_logs(tmp_path):
     service_api = mock.MagicMock()
     service_api.send_api_request.return_value = apb.ApiResponse(

--- a/wandb/beta/local_api.py
+++ b/wandb/beta/local_api.py
@@ -16,6 +16,7 @@ for run in api.runs():
 run = api.run("abc123")
 for row in run.history(keys=["loss"], last=10):
     print(row["_step"], row["loss"])
+df = run.history().to_pandas()
 for line in run.console_logs(last=20):
     print(line.timestamp, line.content)
 ```
@@ -28,7 +29,7 @@ import os
 import pathlib
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from wandb._pydantic import from_json
 from wandb.apis.normalize import normalize_exceptions
@@ -37,6 +38,10 @@ from wandb.apis.public.service_api import ServiceApi
 from wandb.errors.term import termwarn
 from wandb.proto import wandb_api_pb2 as apb
 from wandb.sdk import wandb_setup
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import polars as pl
 
 
 class LocalApi:
@@ -360,6 +365,18 @@ class LocalHistory:
             if not response.next_offset:
                 return
             request.offset = response.next_offset
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Returns the rows as a pandas DataFrame with a column per key."""
+        import pandas as pd
+
+        return pd.DataFrame(list(self))
+
+    def to_polars(self) -> pl.DataFrame:
+        """Returns the rows as a polars DataFrame with a column per key."""
+        import polars as pl
+
+        return pl.DataFrame(list(self), infer_schema_length=None)
 
     @normalize_exceptions
     def _read_page(


### PR DESCRIPTION
Description
-----------
`LocalHistory.to_pandas()` and `LocalHistory.to_polars()` read the rows and build a DataFrame with a column per logged key; a key missing from a row is null. Neither library is imported until the method is called.

On a million-row, 25-column run, `to_pandas()` takes 13.5 s and `to_polars()` 12.9 s, against 10.8 s to iterate the same rows as dicts. Most of that time is parsing JSON rows in Python (about 5 s) and reading the log in wandb-core (about 3 s). A typed columnar transfer would remove the first and is the next step if that matters.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable
