### PR TITLE
chore: list local runs from the first and last records of each log

### DIFF
--- a/core/internal/runreader/probe.go
+++ b/core/internal/runreader/probe.go
@@ -1,0 +1,100 @@
+package runreader
+
+import (
+	"errors"
+	"io"
+	"os"
+	"time"
+
+	"github.com/wandb/wandb/core/internal/observability"
+	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
+)
+
+const (
+	// blockSize is the transaction log's block size, as in core/pkg/leveldb.
+	blockSize = 32 * 1024
+
+	// probeHeadRecords bounds how far Probe reads from the start for the run
+	// record, which the SDK writes first.
+	probeHeadRecords = 64
+)
+
+// ProbeResult is what Probe learned about a run.
+type ProbeResult struct {
+	Info  Info
+	State State
+}
+
+// Probe returns a run's identity and state from the first records of its
+// log and the last complete ones, without reading what lies between, so it
+// costs the same for a run of any size. A name, tags or notes change in the
+// middle of a run is only seen by reading the run in full.
+func Probe(path string, logger *observability.CoreLogger) (ProbeResult, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return ProbeResult{}, err
+	}
+	cursor, err := OpenCursor(path, logger)
+	if err != nil {
+		return ProbeResult{}, err
+	}
+	defer cursor.Close()
+
+	var p probe
+	_, atEnd, err := p.read(cursor, probeHeadRecords)
+	if err != nil {
+		return ProbeResult{}, err
+	}
+	headEnd := cursor.Offset()
+
+	// Seek back one block at a time until a block yields a complete record:
+	// a record larger than a block ends in a later block than it starts in.
+	// The reader skips the chunks of a record that began before the seek.
+	for start := (stat.Size() - 1) / blockSize * blockSize; !atEnd; start -= blockSize {
+		start = max(start, headEnd)
+		if err := cursor.SeekRecord(start); err != nil {
+			return ProbeResult{}, err
+		}
+		n, _, err := p.read(cursor, 0)
+		if err != nil {
+			return ProbeResult{}, err
+		}
+		if n > 0 || start == headEnd {
+			break
+		}
+	}
+
+	return ProbeResult{
+		Info:  p.info,
+		State: deriveState(p.exit, p.infoSeen, stat.ModTime(), time.Now()),
+	}, nil
+}
+
+type probe struct {
+	info     Info
+	infoSeen bool
+	exit     *spb.RunExitRecord
+}
+
+// read applies up to limit records, or all remaining ones when limit is 0,
+// returning how many it read and whether it reached the end of the file.
+func (p *probe) read(cursor *Cursor, limit int) (int, bool, error) {
+	n := 0
+	for limit == 0 || n < limit {
+		record, _, err := cursor.Next()
+		if errors.Is(err, io.EOF) {
+			return n, true, nil
+		}
+		if err != nil {
+			return n, false, err
+		}
+		n++
+		if run := record.GetRun(); run != nil {
+			p.info, p.infoSeen = infoFromRecord(run), true
+		}
+		if exit := record.GetExit(); exit != nil {
+			p.exit = exit
+		}
+	}
+	return n, false, nil
+}

--- a/core/internal/wbapi/localrunhandler.go
+++ b/core/internal/wbapi/localrunhandler.go
@@ -40,8 +40,8 @@ func NewLocalRunHandler(logger *observability.CoreLogger) *LocalRunHandler {
 
 // HandleListLocalRuns lists the runs in a wandb directory, newest first.
 //
-// Runs share the cache used by detail requests, so cached runs read only
-// appended records. The first read scans the full log for metadata updates.
+// Each run's identity and state come from the first and last records of its
+// log, so the listing costs the same for runs of any size.
 func (h *LocalRunHandler) HandleListLocalRuns(
 	ctx context.Context,
 	request *spb.ListLocalRunsRequest,
@@ -50,25 +50,19 @@ func (h *LocalRunHandler) HandleListLocalRuns(
 	if err != nil {
 		return apiErrorResponse(err.Error(), 0)
 	}
-	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	response := &spb.ListLocalRunsResponse{}
 	for _, dir := range dirs {
 		if err := ctx.Err(); err != nil {
 			return apiErrorResponse(err.Error(), 0)
 		}
-		run, err := h.read(ctx, dir.WandbFile)
+		probe, err := runreader.Probe(dir.WandbFile, h.logger)
 		if err != nil {
-			if ctx.Err() != nil {
-				return apiErrorResponse(ctx.Err().Error(), 0)
-			}
 			h.logger.Debug("wbapi: skipping local run", "path", dir.WandbFile, "error", err)
 			continue
 		}
-		info := run.Info()
 		response.Runs = append(response.Runs,
-			localRunInfo(dir.WandbFile, &info, run.State()))
+			localRunInfo(dir.WandbFile, &probe.Info, probe.State))
 	}
 
 	return &spb.ApiResponse{

--- a/core/internal/wbapi/localrunhandler_test.go
+++ b/core/internal/wbapi/localrunhandler_test.go
@@ -133,7 +133,7 @@ func TestLocalRunHandler(t *testing.T) {
 	assert.NotNil(t, deleted.GetApiErrorResponse())
 }
 
-func TestLocalRunHandler_ListTracksMetadataUpdates(t *testing.T) {
+func TestLocalRunHandler_ListReadsHeadAndTail(t *testing.T) {
 	dir := t.TempDir()
 	runDir := filepath.Join(dir, "run-20260101_120000-abc")
 	require.NoError(t, os.Mkdir(runDir, 0o755))
@@ -173,19 +173,13 @@ func TestLocalRunHandler_ListTracksMetadataUpdates(t *testing.T) {
 
 	writeInfo("initial")
 	writeHistory()
+	assertInfo("initial", "running")
+
+	// The final block starts in the middle of a large row; the rename and
+	// exit after it must still be found.
 	writeInfo("renamed")
-	writeHistory()
-	assertInfo("renamed", "running")
-
-	// A later listing must read appended updates, even outside the tail blocks.
-	writeInfo("latest")
-	writeHistory()
-	assertInfo("latest", "running")
-
-	// An exit need not be in the last four blocks, either.
 	require.NoError(t, w.Write(&spb.Record{RecordType: &spb.Record_Exit{
 		Exit: &spb.RunExitRecord{ExitCode: 0},
 	}}))
-	writeHistory()
-	assertInfo("latest", "finished")
+	assertInfo("renamed", "finished")
 }

--- a/wandb/beta/local_api.py
+++ b/wandb/beta/local_api.py
@@ -74,8 +74,10 @@ class LocalApi:
     def runs(self) -> list[LocalRun]:
         """Returns the runs in the directory, newest first.
 
-        Reads each run's log to recover its latest metadata. Up to 32 runs
-        are cached; later reads of cached runs process only appended records.
+        Each run's identity and state come from the first and last records
+        of its log, so listing costs the same for runs of any size. A name,
+        tags or notes change in the middle of a run shows once the run's
+        details are read.
         """
         request = apb.ApiRequest(
             list_local_runs_request=apb.ListLocalRunsRequest(wandb_dir=self.wandb_dir)


### PR DESCRIPTION
Description
-----------
`LocalApi.runs()` read every run's log in full to report current names and states, and with more runs than the 32-run cache holds it re-read all of them on every call. On a directory of 189 runs holding 10 GB of logs, every call took 92 seconds.

The listing now probes each log instead: the first records, for the run record the SDK writes at start, and the last complete records, found by seeking back one block at a time until a block yields a record start, for the exit record and a rename made late in the run. A record larger than a block ends in a later block than it starts in, which is why the walk is needed and why the earlier fixed four-block tail missed exits. A name, tags or notes change in the middle of a long run shows once the run's details are read; `LocalRun` already loads those on first access.

The same directory now lists in 2.0 s cold and 0.55 s with the files in the OS cache, with the same 179 finished, 8 failed and 2 crashed states as before.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
Handler test where the last block starts in the middle of an 8 KB row and must still yield the rename and exit after it.
