### PR TITLE
fix(launch): bump golang to 1.27.1 and chainguard image

### DIFF
--- a/tools/launch_release/build/Dockerfile
+++ b/tools/launch_release/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-central1-docker.pkg.dev/wandb-production/chainguard-pull-through/coreweave/chainguard-base@sha256:6806df87c631b7a21338afc7ed1ad82ade2e2832f25b976600136f744971e075 AS builder
+FROM us-central1-docker.pkg.dev/wandb-production/chainguard-pull-through/coreweave/chainguard-base@sha256:6ea9aff8f65c7d2bf0d3af874f2224431c7403cbe531c1193bd97edfe3490fe1 AS builder
 LABEL maintainer='Weights & Biases <support@wandb.com>'
 
 ARG TARGETARCH
@@ -6,7 +6,7 @@ ARG TARGETARCH
 RUN apk add --no-cache python3 git py3-pip gcc python3-dev curl openssl-dev pkgconf \
     && ln -sf /usr/bin/pkgconf /usr/bin/pkg-config
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.27.1
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
     curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf -; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
@@ -32,7 +32,7 @@ RUN pip3 install --upgrade pip \
     && pip3 install --no-cache-dir "wandb[launch] @ git+https://github.com/wandb/wandb.git@$REF"
 
 # --- Final image: no Go toolchain, no build tools ---
-FROM us-central1-docker.pkg.dev/wandb-production/chainguard-pull-through/coreweave/chainguard-base@sha256:6806df87c631b7a21338afc7ed1ad82ade2e2832f25b976600136f744971e075
+FROM us-central1-docker.pkg.dev/wandb-production/chainguard-pull-through/coreweave/chainguard-base@sha256:6ea9aff8f65c7d2bf0d3af874f2224431c7403cbe531c1193bd97edfe3490fe1
 LABEL maintainer='Weights & Biases <support@wandb.com>'
 
 # Suppress RequestsDependencyWarning (pip-resolved urllib3/charset_normalizer often trigger it)


### PR DESCRIPTION
Details in https://coreweave.atlassian.net/browse/WB-39687