### PR TITLE
perf(core): decode local run history on every CPU

### DIFF
--- a/core/internal/runreader/column.go
+++ b/core/internal/runreader/column.go
@@ -129,6 +129,22 @@ func (c *Chunk) dropFront(n int) {
 	c.Columns = slices.DeleteFunc(c.Columns, func(col *Column) bool { return col.len() == 0 })
 }
 
+// truncate keeps the first n rows of a finished chunk.
+func (c *Chunk) truncate(n int) {
+	for _, col := range c.Columns {
+		k := n
+		if col.RowIndex != nil {
+			k = sort.Search(len(col.RowIndex), func(i int) bool { return int(col.RowIndex[i]) >= n })
+			col.RowIndex = col.RowIndex[:k]
+		}
+		col.Ints = col.Ints[:min(k, len(col.Ints))]
+		col.Floats = col.Floats[:min(k, len(col.Floats))]
+		col.JSON = col.JSON[:min(k, len(col.JSON))]
+	}
+	c.Rows = n
+	c.Columns = slices.DeleteFunc(c.Columns, func(col *Column) bool { return col.len() == 0 })
+}
+
 func (col *Column) len() int {
 	return len(col.Ints) + len(col.Floats) + len(col.JSON)
 }

--- a/core/internal/runreader/cursor.go
+++ b/core/internal/runreader/cursor.go
@@ -38,21 +38,45 @@ func OpenCursor(path string, logger *observability.CoreLogger) (*Cursor, error) 
 // so Next can be retried after the file grows. Any other error is terminal:
 // the file is not a transaction log this version can read.
 func (c *Cursor) Next() (*spb.Record, int64, error) {
+	var record *spb.Record
+	offset, err := c.next(func() (err error) {
+		record, err = c.reader.Read()
+		return err
+	})
+	return record, offset, err
+}
+
+// NextRaw appends the next record's serialized bytes to dst and returns the
+// result with the record's offset. Errors are as for Next.
+func (c *Cursor) NextRaw(dst []byte) ([]byte, int64, error) {
+	offset, err := c.next(func() (err error) {
+		dst, err = c.reader.ReadRaw(dst)
+		return err
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	return dst, offset, nil
+}
+
+// next runs read at the cursor, skipping corrupt data, and returns the
+// offset the record was read from.
+func (c *Cursor) next(read func() error) (int64, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.reader == nil {
-		return nil, 0, ErrClosed
+		return 0, ErrClosed
 	}
 	for {
 		before := c.reader.NextRecordOffset()
-		record, err := c.reader.Read()
+		err := read()
 		switch {
 		case err == nil:
-			return record, before, nil
+			return before, nil
 		case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
-			return nil, 0, errors.Join(io.EOF, c.reader.ResetLastRead())
+			return 0, errors.Join(io.EOF, c.reader.ResetLastRead())
 		case c.reader.NextRecordOffset() <= before:
-			return nil, 0, err
+			return 0, err
 		}
 		c.skipped++
 	}

--- a/core/internal/runreader/history.go
+++ b/core/internal/runreader/history.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"errors"
 	"io"
+	"runtime"
 	"sort"
+	"sync"
+
+	"google.golang.org/protobuf/proto"
 
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
 // indexStride is the number of history records between index entries.
 const indexStride = 100
+
+// decodeBatchBytes is how many bytes of records a worker decodes at a time.
+const decodeBatchBytes = 1 << 20
 
 type indexEntry struct {
 	step   int64
@@ -89,15 +96,7 @@ func (r *Run) History(ctx context.Context, query HistoryQuery) (HistoryPage, err
 			return HistoryPage{}, err
 		}
 	}
-	chunk, next, err := scan.read(query.Limit, 0)
-	if err != nil {
-		return HistoryPage{}, err
-	}
-	page := HistoryPage{NextOffset: next}
-	if chunk.Rows > 0 {
-		page.Chunks = []*Chunk{chunk}
-	}
-	return page, nil
+	return scan.readForward(query.Limit)
 }
 
 // offsetForStep returns the offset of the last index entry at or before
@@ -117,48 +116,188 @@ type historyScan struct {
 	keys   map[string]struct{}
 }
 
+// readForward reads from the cursor to the end of the file, a step past
+// MaxStep, or limit matching rows (when positive), decoding records on
+// every CPU. Records are read in byte-bounded batches, each decoded into
+// one chunk, so a page's chunks are the batches its rows came from.
+func (s *historyScan) readForward(limit int) (HistoryPage, error) {
+	var page HistoryPage
+	workers := min(runtime.GOMAXPROCS(0), 8)
+	rows := 0
+	for {
+		// A record holds at most one row, so a page short of its limit
+		// needs at most that many more records this round.
+		wanted := 0
+		if limit > 0 {
+			wanted = limit - rows
+		}
+		batches := make([]batch, 0, workers)
+		atEnd := false
+		for len(batches) < workers && !atEnd && (limit == 0 || wanted > 0) {
+			var b batch
+			var err error
+			b, atEnd, err = s.readBatch(wanted)
+			if err != nil {
+				return HistoryPage{}, err
+			}
+			if len(b.ends) > 0 {
+				batches = append(batches, b)
+				wanted -= len(b.ends)
+			}
+		}
+
+		results := make([]decoded, len(batches))
+		var wg sync.WaitGroup
+		for i := range batches {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				results[i] = s.decodeBatch(batches[i])
+			}()
+		}
+		wg.Wait()
+
+		for _, res := range results {
+			if limit > 0 && rows == limit {
+				page.NextOffset = res.start
+				return page, nil
+			}
+			if res.chunk.Rows > 0 {
+				if limit > 0 && rows+res.chunk.Rows > limit {
+					keep := limit - rows
+					page.NextOffset = res.rowOffsets[keep]
+					res.chunk.truncate(keep)
+					page.Chunks = append(page.Chunks, res.chunk)
+					return page, nil
+				}
+				page.Chunks = append(page.Chunks, res.chunk)
+				rows += res.chunk.Rows
+			}
+			if res.stopped {
+				return page, nil
+			}
+		}
+		if atEnd {
+			return page, nil
+		}
+		if limit > 0 && rows == limit {
+			page.NextOffset = s.cursor.Offset()
+			return page, nil
+		}
+	}
+}
+
+// batch is a run of consecutive records' bytes, back to back in data and
+// ending at ends, with the file offset of each.
+type batch struct {
+	data    []byte
+	ends    []int
+	offsets []int64
+}
+
+// readBatch reads records until the batch holds decodeBatchBytes, or
+// maxRecords records when positive, or the file ends, reporting the latter.
+func (s *historyScan) readBatch(maxRecords int) (batch, bool, error) {
+	var b batch
+	for len(b.data) < decodeBatchBytes && (maxRecords <= 0 || len(b.ends) < maxRecords) {
+		if err := s.ctx.Err(); err != nil {
+			return batch{}, false, err
+		}
+		data, offset, err := s.cursor.NextRaw(b.data)
+		if errors.Is(err, io.EOF) {
+			return b, true, nil
+		}
+		if err != nil {
+			return batch{}, false, err
+		}
+		b.data = data
+		b.ends = append(b.ends, len(data))
+		b.offsets = append(b.offsets, offset)
+	}
+	return b, false, nil
+}
+
+// decoded is a batch's matching rows.
+type decoded struct {
+	chunk *Chunk
+	// start is the offset of the batch's first record; rowOffsets holds the
+	// offset of each row's record, so a page cut short can say where the
+	// next one starts.
+	start      int64
+	rowOffsets []int64
+	// stopped is true if a step past MaxStep was seen.
+	stopped bool
+}
+
+func (s *historyScan) decodeBatch(b batch) decoded {
+	res := decoded{chunk: &Chunk{}, start: b.offsets[0]}
+	start := 0
+	for i, end := range b.ends {
+		record := &spb.Record{}
+		if err := proto.Unmarshal(b.data[start:end], record); err == nil {
+			rows := res.chunk.Rows
+			if !s.addRecord(res.chunk, record) {
+				res.stopped = true
+				break
+			}
+			if res.chunk.Rows > rows {
+				res.rowOffsets = append(res.rowOffsets, b.offsets[i])
+			}
+		}
+		start = end
+	}
+	res.chunk.finish()
+	return res
+}
+
 // read decodes matching rows into a chunk until the record at offset end
-// (when positive), the end of the file, a step past MaxStep, or limit rows
-// (when positive). It returns the chunk and the offset to continue from,
-// which is 0 once the scan is complete.
-func (s *historyScan) read(limit int, end int64) (*Chunk, int64, error) {
+// (when positive), the end of the file, or a step past MaxStep.
+func (s *historyScan) read(end int64) (*Chunk, error) {
 	chunk := &Chunk{}
 	for {
 		if err := s.ctx.Err(); err != nil {
-			return nil, 0, err
+			return nil, err
 		}
-		if limit > 0 && chunk.Rows == limit || end > 0 && s.cursor.Offset() >= end {
-			chunk.finish()
-			return chunk, s.cursor.Offset(), nil
+		if end > 0 && s.cursor.Offset() >= end {
+			break
 		}
 		record, _, err := s.cursor.Next()
 		if errors.Is(err, io.EOF) {
-			chunk.finish()
-			return chunk, 0, nil
+			break
 		}
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
-		if s.query.SystemMetrics {
-			if stats := record.GetStats(); stats != nil {
-				s.addStatsRow(chunk, stats)
-			}
-			continue
+		if !s.addRecord(chunk, record) {
+			break
 		}
-		history := record.GetHistory()
-		if history == nil {
-			continue
-		}
-		step := HistoryStep(history)
-		if s.query.MinStep != nil && step < *s.query.MinStep {
-			continue
-		}
-		if s.query.MaxStep != nil && step > *s.query.MaxStep {
-			chunk.finish()
-			return chunk, 0, nil
-		}
-		s.addHistoryRow(chunk, history, step)
 	}
+	chunk.finish()
+	return chunk, nil
+}
+
+// addRecord adds the record's row to the chunk if it matches the query. It
+// returns false once a step past MaxStep is seen.
+func (s *historyScan) addRecord(chunk *Chunk, record *spb.Record) bool {
+	if s.query.SystemMetrics {
+		if stats := record.GetStats(); stats != nil {
+			s.addStatsRow(chunk, stats)
+		}
+		return true
+	}
+	history := record.GetHistory()
+	if history == nil {
+		return true
+	}
+	step := HistoryStep(history)
+	if s.query.MinStep != nil && step < *s.query.MinStep {
+		return true
+	}
+	if s.query.MaxStep != nil && step > *s.query.MaxStep {
+		return false
+	}
+	s.addHistoryRow(chunk, history, step)
+	return true
 }
 
 // addHistoryRow adds the record's items as a row, with _step from the
@@ -233,7 +372,7 @@ func (s *historyScan) last(index []indexEntry) (HistoryPage, error) {
 		if g+1 < len(index) {
 			end = index[g+1].offset
 		}
-		chunk, _, err := s.read(0, end)
+		chunk, err := s.read(end)
 		if err != nil {
 			return HistoryPage{}, err
 		}

--- a/core/internal/runreader/history_test.go
+++ b/core/internal/runreader/history_test.go
@@ -146,12 +146,56 @@ func TestRun_History(t *testing.T) {
 
 	page, err = run.History(context.Background(), runreader.HistoryQuery{Limit: 100})
 	require.NoError(t, err)
-	require.Len(t, page.Chunks, 1)
-	assert.Equal(t, 100, page.Chunks[0].Rows)
+	pageRows := 0
+	for _, chunk := range page.Chunks {
+		pageRows += chunk.Rows
+	}
+	assert.Equal(t, 100, pageRows)
 	assert.NotZero(t, page.NextOffset)
 	rows = readAll(t, run, runreader.HistoryQuery{Limit: 100, Offset: page.NextOffset})
 	assert.Equal(t, 150, len(rows))
 	assert.Equal(t, int64(100), rows[0]["_step"])
+}
+
+func TestRun_HistoryPagesAcrossDecodeBatches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run-abc.wandb")
+	writeHistoryLog(t, path, 20_000, 20)
+	run, err := runreader.Open(path, observability.NewNoOpLogger())
+	require.NoError(t, err)
+	defer run.Close()
+	require.NoError(t, run.Update(context.Background()))
+
+	var steps []int64
+	var pages, chunks int
+	query := runreader.HistoryQuery{Keys: []string{"acc"}, Limit: 700}
+	for {
+		page, err := run.History(context.Background(), query)
+		require.NoError(t, err)
+		pages++
+		chunks += len(page.Chunks)
+		for _, chunk := range page.Chunks {
+			for _, col := range chunk.Columns {
+				if col.Key == "_step" {
+					steps = append(steps, col.Ints...)
+				}
+			}
+		}
+		if page.NextOffset == 0 {
+			break
+		}
+		query.Offset = page.NextOffset
+	}
+	require.Len(t, steps, 2000)
+	for i, step := range steps {
+		require.Equal(t, int64(10*i), step)
+	}
+	assert.Equal(t, 3, pages)
+	assert.Greater(t, chunks, pages, "a page should span several decode batches")
+
+	maxStep := int64(19_005)
+	rows := readAll(t, run, runreader.HistoryQuery{MinStep: &maxStep, MaxStep: &maxStep})
+	require.Len(t, rows, 1)
+	assert.Equal(t, int64(19_005), rows[0]["_step"])
 }
 
 func BenchmarkHistory(b *testing.B) {

--- a/core/internal/transactionlog/reader.go
+++ b/core/internal/transactionlog/reader.go
@@ -117,8 +117,39 @@ func (r *Reader) NextRecordOffset() int64 {
 // position in the transaction log again. The error wraps EOF
 // or ErrUnexpectedEOF if it may be resolved by waiting for more data.
 func (r *Reader) Read() (*spb.Record, error) {
+	buf := r.bufPool.Get().(*bytes.Buffer)
+	defer func() {
+		buf.Reset()
+		r.bufPool.Put(buf)
+	}()
+
+	if err := r.readInto(buf); err != nil {
+		return nil, err
+	}
+
+	msg := &spb.Record{}
+	if err := proto.Unmarshal(buf.Bytes(), msg); err != nil {
+		return nil, fmt.Errorf("transactionlog: error unmarshaling: %v", err)
+	}
+
+	return msg, nil
+}
+
+// ReadRaw appends the next record's serialized bytes to dst and returns the
+// result, so that a caller can decode records elsewhere, such as on other
+// goroutines. Errors are as for Read.
+func (r *Reader) ReadRaw(dst []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(dst)
+	if err := r.readInto(buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// readInto appends the next record's bytes to buf.
+func (r *Reader) readInto(buf *bytes.Buffer) error {
 	if r.reader == nil {
-		return nil, errors.New("transactionlog: reader is closed")
+		return errors.New("transactionlog: reader is closed")
 	}
 
 	// Always recover after errors, skipping corrupt data.
@@ -129,33 +160,18 @@ func (r *Reader) Read() (*spb.Record, error) {
 
 	// Verify the W&B header before the first read.
 	if err := r.verifyWBHeaderBeforeFirstRead(); err != nil {
-		return nil, err
+		return err
 	}
 
 	recordReader, err := r.reader.Next()
-
 	if err != nil {
-		return nil, fmt.Errorf(
-			"transactionlog: error getting next record: %w", err)
+		return fmt.Errorf("transactionlog: error getting next record: %w", err)
 	}
 
-	buf := r.bufPool.Get().(*bytes.Buffer)
-	defer func() {
-		buf.Reset()
-		r.bufPool.Put(buf)
-	}()
-
-	_, err = io.Copy(buf, recordReader)
-	if err != nil {
-		return nil, fmt.Errorf("transactionlog: error reading: %w", err)
+	if _, err := io.Copy(buf, recordReader); err != nil {
+		return fmt.Errorf("transactionlog: error reading: %w", err)
 	}
-
-	msg := &spb.Record{}
-	if err = proto.Unmarshal(buf.Bytes(), msg); err != nil {
-		return nil, fmt.Errorf("transactionlog: error unmarshaling: %v", err)
-	}
-
-	return msg, nil
+	return nil
 }
 
 // verifyWBHeaderBeforeFirstRead verifies the W&B header if it hasn't yet been

--- a/wandb/beta/local_api.py
+++ b/wandb/beta/local_api.py
@@ -371,7 +371,7 @@ class LocalHistory:
     build their frames without touching values one at a time.
     """
 
-    _PAGE_ROWS = 10_000
+    _PAGE_ROWS = 100_000
 
     def __init__(
         self,


### PR DESCRIPTION
Description
-----------
A history scan decoded records one at a time on one goroutine, and protobuf decoding was three quarters of the cost of reading a run in full.

The transaction log reader and the cursor now hand out records' raw bytes. The forward scan reads them in 1 MB batches, and a pool of up to eight workers decodes each batch into one chunk of columns, so a page's chunks are the batches its rows came from. A row limit still cuts the page at exactly that row, with the next offset taken from the first row left out, and a round reads no more records than the page still needs, so small pages stay small. The last-N and index-granule paths, which read a few hundred records, stay sequential. Python asks for pages of 100,000 rows instead of 10,000, ten times fewer round trips for a few megabytes of columns per page.

`go test ./core/internal/runreader -bench History` on the 20k-row log: all rows 62 ms to 17 ms, one key 57 ms to 16 ms. On the million-row run through Python, against the numbers before this stack's last two PRs: a full pull as dicts 10.3 s to 3.4 s, `to_pandas()` 10.2 s to 2.0 s, `to_polars()` 11.2 s to 1.9 s, all system metrics 4.9 s to 1.8 s. Of the 2 s, about 0.7 s is decoding and the rest is moving 190 MB of columns through protobuf and the socket.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable

Testing
-------
A 20k-row test pages across decode batches under a keys filter and checks the steps are contiguous; the package runs clean under the race detector.
