### PR TITLE
chore: refresh federated identity credentials in wandb-core

### DIFF
--- a/core/internal/api/api.go
+++ b/core/internal/api/api.go
@@ -108,6 +108,9 @@ type ClientOptions struct {
 	// request for retry
 	PrepareRetry func(*http.Request) error
 
+	// Function that controls whether redirects are followed.
+	CheckRedirect func(*http.Request, []*http.Request) error
+
 	Logger *slog.Logger
 
 	// PreRetryLayers specifies additional functionality to the HTTP client
@@ -135,6 +138,7 @@ func NewClient(opts ClientOptions) RetryableClient {
 	retryableHTTP.RetryWaitMin = opts.RetryWaitMin
 	retryableHTTP.RetryWaitMax = opts.RetryWaitMax
 	retryableHTTP.HTTPClient.Timeout = opts.NonRetryTimeout
+	retryableHTTP.HTTPClient.CheckRedirect = opts.CheckRedirect
 	retryableHTTP.PrepareRetry = opts.PrepareRetry
 	retryableHTTP.CheckRetry = withRetryObservation(
 		opts.RetryPolicy,

--- a/core/internal/api/credentials.go
+++ b/core/internal/api/credentials.go
@@ -4,17 +4,23 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/rogpeppe/go-internal/lockedfile"
 
 	"github.com/wandb/wandb/core/internal/clients"
 	"github.com/wandb/wandb/core/internal/httplayers"
@@ -49,6 +55,13 @@ const (
 	// request from another process. Requests to the W&B server carry their
 	// own per-attempt deadline, which bounds the exchange instead.
 	tokenExchangeTimeout = 60 * time.Second
+
+	maxTokenResponseBytes = 1 << 20
+
+	// tokenExpiryBuffer is how far ahead of a token's actual expiration
+	// it is treated as expired, so that a request never starts with a
+	// token that expires mid-flight.
+	tokenExpiryBuffer = 5 * time.Minute
 )
 
 // CredentialProvider adds credentials to HTTP requests.
@@ -71,9 +84,7 @@ func NewCredentialProvider(
 	logger *slog.Logger,
 ) (CredentialProvider, error) {
 	if s.GetIdentityTokenFile() != "" {
-		// The exchange must not use a credential provider: supplying its
-		// credentials is what it is being used to make possible.
-		exchangeClient := NewClient(ClientOptions{
+		clientOptions := ClientOptions{
 			RetryMax:        TokenExchangeRetryMax,
 			RetryWaitMin:    tokenExchangeRetryWaitMin,
 			RetryWaitMax:    tokenExchangeRetryWaitMax,
@@ -85,15 +96,26 @@ func NewCredentialProvider(
 
 			InsecureDisableSSL: s.IsInsecureDisableSSL(),
 			Logger:             logger,
-
-			PreRetryLayers: httplayers.DefaultHeaders(s.GetExtraHTTPHeaders()),
-		})
+		}
+		// The refresh client talks to the third-party IdP: never disable
+		// TLS verification or follow redirects for it, and don't retry,
+		// since a retried refresh could consume a single-use refresh token.
+		refreshOptions := clientOptions
+		refreshOptions.RetryMax = 0
+		refreshOptions.InsecureDisableSSL = false
+		refreshOptions.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+		refreshClient := NewClient(refreshOptions)
+		clientOptions.PreRetryLayers = httplayers.DefaultHeaders(s.GetExtraHTTPHeaders())
+		exchangeClient := NewClient(clientOptions)
 
 		return NewOAuth2CredentialProvider(
 			s.GetBaseURL(),
 			s.GetIdentityTokenFile(),
 			s.GetCredentialsFile(),
 			exchangeClient,
+			refreshClient,
 			logger,
 		)
 	}
@@ -169,13 +191,18 @@ func NewOAuth2CredentialProvider(
 	identityTokenFilePath string,
 	credentialsFilePath string,
 	httpClient RetryableClient,
+	refreshHTTPClient RetryableClient,
 	logger *slog.Logger,
 ) (CredentialProvider, error) {
 	// Fail fast on misconfiguration. The token itself is re-read from the
 	// file for each exchange: identity tokens are often short-lived and
 	// re-minted to the same path, so the value read here may not stay valid
 	// for the lifetime of the provider.
-	if _, err := readIdentityToken(identityTokenFilePath); err != nil {
+	file, err := loadIdentityTokenFile(identityTokenFilePath)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := file.accountFor(baseURL); err != nil {
 		return nil, err
 	}
 	return &oauth2CredentialProvider{
@@ -183,7 +210,9 @@ func NewOAuth2CredentialProvider(
 		identityTokenFilePath: identityTokenFilePath,
 		credentialsFilePath:   credentialsFilePath,
 		httpClient:            httpClient,
+		refreshHTTPClient:     refreshHTTPClient,
 		tokenMu:               &sync.RWMutex{},
+		identityTokenMu:       lockedfile.MutexAt(identityTokenFilePath + ".lock"),
 		logger:                logger,
 	}, nil
 }
@@ -212,12 +241,77 @@ func (e *TokenExchangeError) Error() string {
 // PermanentError returns true: retrying the exchange cannot succeed.
 func (e *TokenExchangeError) PermanentError() bool { return true }
 
+// IdentityTokenExpiredError means an expired ID token cannot be refreshed.
+type IdentityTokenExpiredError struct{}
+
+func (e *IdentityTokenExpiredError) Error() string {
+	return "identity token expired and cannot be refreshed;" +
+		" provide a new identity token or run `wandb login sso`"
+}
+
+// PermanentError returns true: this cannot be resolved by retrying.
+func (e *IdentityTokenExpiredError) PermanentError() bool { return true }
+
+// IdentityTokenRefreshError is a definitive rejection of a refresh_token
+// exchange by the IdP, like a revoked or expired refresh token.
+type IdentityTokenRefreshError struct {
+	// StatusCode is the HTTP status returned by the token endpoint.
+	StatusCode int
+
+	// Detail is the OAuth error code and description.
+	Detail string
+}
+
+func (e *IdentityTokenRefreshError) Error() string {
+	detail := e.Detail
+	if e.StatusCode != 0 {
+		detail = fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Detail)
+	}
+	return "failed to refresh identity token: " + detail +
+		"; run `wandb login sso` to reauthenticate"
+}
+
+// PermanentError returns true: retrying with the same refresh token
+// cannot succeed.
+func (e *IdentityTokenRefreshError) PermanentError() bool { return true }
+
+func oauthErrorDetail(body []byte) string {
+	var response struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if json.Unmarshal(body, &response) != nil || response.Error == "" {
+		return "OAuth error response"
+	}
+	if response.ErrorDescription == "" {
+		return response.Error
+	}
+	return response.Error + ": " + response.ErrorDescription
+}
+
+func shouldRefreshIdentityToken(err *TokenExchangeError) bool {
+	if err.StatusCode != http.StatusBadRequest &&
+		err.StatusCode != http.StatusUnauthorized {
+		return false
+	}
+
+	var response struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(err.Body), &response) != nil {
+		return false
+	}
+	return response.Error == "invalid_grant" || response.Error == "invalid_token"
+}
+
 // isExchangeRejection reports whether the token endpoint's status is a
 // definitive rejection of the exchange, like an invalid or expired
 // identity token, unknown user or bad audience. 429 and 5xx responses
 // may be transient, so they are not rejections.
 func isExchangeRejection(statusCode int) bool {
 	return statusCode >= 400 && statusCode < 500 &&
+		statusCode != http.StatusRequestTimeout &&
+		statusCode != http.StatusTooEarly &&
 		statusCode != http.StatusTooManyRequests
 }
 
@@ -241,17 +335,289 @@ func TokenExchangeRetryPolicy(
 	return clients.RetryMostFailures(ctx, resp, err)
 }
 
-// readIdentityToken reads the identity token (a JWT) from the file.
-func readIdentityToken(path string) (string, error) {
-	identityToken, err := os.ReadFile(path)
+// identityTokenFileVersion is the file format version this code writes.
+const identityTokenFileVersion = 1
+
+// identityToken holds one account's credentials.
+type identityToken struct {
+	IDToken       string `json:"id_token"`
+	RefreshToken  string `json:"refresh_token,omitempty"`
+	TokenEndpoint string `json:"token_endpoint,omitempty"`
+	ClientID      string `json:"client_id,omitempty"`
+	Host          string `json:"host,omitempty"`
+	Org           string `json:"org,omitempty"`
+}
+
+// identityTokenFile is the JSON schema written by `wandb login sso`.
+//
+// Accounts are keyed by W&B server URL, or by "<url>#<org>" on
+// multi-tenant SaaS, which serves several organizations from one URL,
+// each with its own identity provider. Keeping every account in one file
+// means logging in to one W&B server does not sign the user out of
+// another.
+type identityTokenFile struct {
+	Version  int                      `json:"version"`
+	Active   string                   `json:"active,omitempty"`
+	Accounts map[string]identityToken `json:"accounts"`
+
+	// bareJWT is set for a file that holds an identity token by itself,
+	// like one minted by a workload identity provider. Such a file names
+	// no account and belongs to whoever provisioned it, so it is never
+	// rewritten.
+	bareJWT bool
+
+	// path is where the file was read from, included in error messages so
+	// that a misconfigured or stale file can be found and fixed.
+	path string
+}
+
+// identityAccount is the account selected from an identity token file.
+type identityAccount struct {
+	// key identifies the account within the file it came from.
+	key string
+
+	// cacheKey is the key under which the account's access token is
+	// cached. It is the W&B server URL for a file that holds a bare JWT,
+	// which names no account.
+	cacheKey string
+
+	token identityToken
+}
+
+// loadIdentityTokenFile reads the accounts in an identity token file,
+// accepting a file that holds a bare JWT as a single account.
+func loadIdentityTokenFile(path string) (identityTokenFile, error) {
+	contents, err := os.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("api: failed to read identity token file: %v", err)
+		return identityTokenFile{}, fmt.Errorf(
+			"api: failed to read identity token file %s: %w", path, err)
 	}
 
 	// Strip surrounding whitespace, like the trailing newline written
 	// by `echo` and most editors, which would otherwise be sent as
 	// part of the token.
-	return strings.TrimSpace(string(identityToken)), nil
+	raw := strings.TrimSpace(string(contents))
+	if raw == "" {
+		return identityTokenFile{}, fmt.Errorf(
+			"api: identity token file %s is empty", path)
+	}
+
+	if !strings.HasPrefix(raw, "{") {
+		return identityTokenFile{
+			Version:  identityTokenFileVersion,
+			Accounts: map[string]identityToken{"": {IDToken: raw}},
+			bareJWT:  true,
+			path:     path,
+		}, nil
+	}
+
+	var file identityTokenFile
+	if err := json.Unmarshal([]byte(raw), &file); err != nil {
+		return identityTokenFile{}, fmt.Errorf(
+			"api: identity token file %s is not valid JSON: %w", path, err)
+	}
+	file.path = path
+	if file.Version > identityTokenFileVersion {
+		return identityTokenFile{}, fmt.Errorf(
+			"api: identity token file %s uses file format version %d, which"+
+				" this version of wandb does not understand; upgrade wandb",
+			path, file.Version)
+	}
+	if len(file.Accounts) == 0 {
+		return identityTokenFile{}, fmt.Errorf(
+			"api: identity token file %s has no accounts; run `wandb login sso`",
+			path)
+	}
+	for key, token := range file.Accounts {
+		if token.IDToken == "" {
+			return identityTokenFile{}, fmt.Errorf(
+				"api: identity token file %s: account %q has no id_token",
+				path, key)
+		}
+		if token.RefreshToken == "" {
+			continue
+		}
+		if token.TokenEndpoint == "" {
+			return identityTokenFile{}, fmt.Errorf(
+				"api: identity token file %s: account %q has no token_endpoint",
+				path, key)
+		}
+		if err := validateTokenEndpoint(token.TokenEndpoint); err != nil {
+			return identityTokenFile{}, fmt.Errorf(
+				"api: identity token file %s: account %q: %w", path, key, err)
+		}
+	}
+
+	return file, nil
+}
+
+// accountFor selects the account to use with the given W&B server.
+//
+// An account matches when it names that server, or when it names no
+// server at all, like a bare JWT. Organizations on the same server are
+// indistinguishable here, so the file's active account breaks a tie.
+func (f identityTokenFile) accountFor(baseURL string) (identityAccount, error) {
+	base := strings.TrimRight(baseURL, "/")
+
+	var matches []string
+	for key, token := range f.Accounts {
+		if token.Host == "" || strings.TrimRight(token.Host, "/") == base {
+			matches = append(matches, key)
+		}
+	}
+	slices.Sort(matches)
+
+	switch {
+	case len(matches) == 0:
+		return identityAccount{}, fmt.Errorf(
+			"api: identity token file %s has no credentials for %s, only for"+
+				" %s; run `wandb login sso`",
+			f.path, base, strings.Join(f.hosts(), ", "))
+
+	case len(matches) > 1 && !slices.Contains(matches, f.Active):
+		return identityAccount{}, fmt.Errorf(
+			"api: identity token file %s has several accounts for %s (%s) and"+
+				" none is selected; run `wandb login sso` to choose one",
+			f.path, base, strings.Join(matches, ", "))
+
+	case len(matches) > 1:
+		return f.account(f.Active, base), nil
+
+	default:
+		return f.account(matches[0], base), nil
+	}
+}
+
+func (f identityTokenFile) account(key, baseURL string) identityAccount {
+	cacheKey := key
+	if cacheKey == "" {
+		cacheKey = baseURL
+	}
+	return identityAccount{key: key, cacheKey: cacheKey, token: f.Accounts[key]}
+}
+
+// hosts returns the W&B servers the file has accounts for.
+func (f identityTokenFile) hosts() []string {
+	var hosts []string
+	for _, token := range f.Accounts {
+		if token.Host != "" {
+			hosts = append(hosts, strings.TrimRight(token.Host, "/"))
+		}
+	}
+	slices.Sort(hosts)
+	return slices.Compact(hosts)
+}
+
+func validateTokenEndpoint(rawURL string) error {
+	endpoint, err := url.Parse(rawURL)
+	if err != nil || endpoint.Host == "" {
+		return errors.New("api: token_endpoint must be an absolute HTTP(S) URL")
+	}
+	ip := net.ParseIP(endpoint.Hostname())
+	isLoopback := endpoint.Hostname() == "localhost" || ip != nil && ip.IsLoopback()
+	if endpoint.Scheme != "https" && (endpoint.Scheme != "http" || !isLoopback) {
+		return errors.New("api: token_endpoint must use HTTPS")
+	}
+	if endpoint.User != nil || endpoint.Fragment != "" {
+		return errors.New(
+			"api: token_endpoint must not include credentials or a fragment")
+	}
+	return nil
+}
+
+// writeIdentityTokenFile atomically replaces the identity token file.
+func writeIdentityTokenFile(path string, file identityTokenFile) error {
+	file.Version = identityTokenFileVersion
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("api: failed to encode identity token: %w", err)
+	}
+
+	temp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*")
+	if err != nil {
+		return fmt.Errorf("api: failed to create identity token file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("api: failed to secure identity token file: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("api: failed to write identity token file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("api: failed to sync identity token file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("api: failed to close identity token file: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		// On Windows, renaming over a file that another process has open
+		// fails, so fall back to overwriting it in place. This is not
+		// atomic, but the alternative is being unable to persist a
+		// rotated refresh token at all.
+		if runtime.GOOS != "windows" {
+			return fmt.Errorf("api: failed to replace identity token file: %w", err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			return fmt.Errorf("api: failed to write identity token file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func readTokenResponseBody(body io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(body, maxTokenResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxTokenResponseBytes {
+		return nil, errors.New("api: token response exceeds 1 MiB")
+	}
+	return data, nil
+}
+
+// jwtExpiry returns a JWT's "exp" claim as a time, or ok=false if token
+// is not a well-formed JWT or carries no exp claim.
+//
+// This decodes only the token's payload segment, with no signature
+// verification: it is a local optimization to decide whether an
+// id_token is worth refreshing before spending a round trip on it. The
+// W&B server's response to the actual exchange remains the source of
+// truth.
+func jwtExpiry(token string) (exp time.Time, ok bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, false
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return time.Time{}, false
+	}
+
+	return time.Unix(claims.Exp, 0), true
+}
+
+// isIdentityTokenExpiring reports whether idToken's local "exp" claim is
+// at or within tokenExpiryBuffer of now. A token whose expiry cannot be
+// determined locally is treated as not expiring, so that a decoding
+// failure never blocks an exchange that the server might still accept.
+func isIdentityTokenExpiring(idToken string) bool {
+	exp, ok := jwtExpiry(idToken)
+	return ok && time.Until(exp) <= tokenExpiryBuffer
 }
 
 type oauth2CredentialProvider struct {
@@ -270,7 +636,12 @@ type oauth2CredentialProvider struct {
 	// The client used to exchange the identity token for an access token.
 	httpClient RetryableClient
 
+	// The client used with the third-party IdP.
+	refreshHTTPClient RetryableClient
+
 	tokenMu *sync.RWMutex
+
+	identityTokenMu *lockedfile.Mutex
 
 	logger *slog.Logger
 }
@@ -310,7 +681,7 @@ type accessTokenInfo struct {
 }
 
 func (c *accessTokenInfo) IsTokenExpiring() bool {
-	return time.Until(time.Time(c.ExpiresAt)) <= time.Minute*5
+	return time.Until(time.Time(c.ExpiresAt)) <= tokenExpiryBuffer
 }
 
 // CredentialsFile is used when serializing/deserializing JSON data from the
@@ -390,22 +761,34 @@ func (c *oauth2CredentialProvider) loadCredentials(ctx context.Context) error {
 		return err
 	}
 
+	// Resolve the account before consulting the cache: the account decides
+	// which cached access token belongs to it, since one W&B server can
+	// have an account per organization.
+	file, err := loadIdentityTokenFile(c.identityTokenFilePath)
+	if err != nil {
+		return err
+	}
+	account, err := file.accountFor(c.baseURL)
+	if err != nil {
+		return err
+	}
+
 	credsFile, ok := c.tryLoadCredentialsFromFile()
 	if ok {
-		accessToken, ok := credsFile.Credentials[c.baseURL]
+		accessToken, ok := credsFile.Credentials[account.cacheKey]
 		if ok && !accessToken.IsTokenExpiring() {
 			c.tokenInfo = accessToken
 			return nil
 		}
 	}
 
-	token, err := c.fetchAccessToken(ctx)
+	token, err := c.fetchAccessToken(ctx, file, account)
 	if err != nil {
 		return fmt.Errorf("api: couldn't fetch access token: %w", err)
 	}
 	c.tokenInfo = token
 
-	c.trySaveCredentialsToFile(credsFile)
+	c.trySaveCredentialsToFile(credsFile, account.cacheKey)
 
 	return nil
 }
@@ -436,11 +819,14 @@ func (c *oauth2CredentialProvider) tryLoadCredentialsFromFile() (CredentialsFile
 }
 
 // Attempts to save the access token to the credentials file.
-func (c *oauth2CredentialProvider) trySaveCredentialsToFile(credentials CredentialsFile) {
+func (c *oauth2CredentialProvider) trySaveCredentialsToFile(
+	credentials CredentialsFile,
+	cacheKey string,
+) {
 	if credentials.Credentials == nil {
 		credentials.Credentials = make(map[string]accessTokenInfo)
 	}
-	credentials.Credentials[c.baseURL] = c.tokenInfo
+	credentials.Credentials[cacheKey] = c.tokenInfo
 
 	file, err := json.MarshalIndent(credentials, "", "  ")
 	if err != nil {
@@ -453,20 +839,238 @@ func (c *oauth2CredentialProvider) trySaveCredentialsToFile(credentials Credenti
 	}
 }
 
-// Reads the identity token from a file and exchanges it for
-// an access token from the authorization server using the JWT Bearer flow defined
-// in OAuth RFC 7523. The access token is then returned with its expiration time.
+// Exchanges the account's identity token for an access token from the
+// authorization server using the JWT Bearer flow defined in OAuth RFC
+// 7523, refreshing the identity token first if it looks expired. The
+// access token is returned with its expiration time.
+//
+// The caller passes the file the account was read from so that a refresh
+// can rewrite it without discarding the other accounts in it.
 func (c *oauth2CredentialProvider) fetchAccessToken(
 	ctx context.Context,
+	file identityTokenFile,
+	account identityAccount,
 ) (accessTokenInfo, error) {
-	// Read the file for each exchange: short-lived identity tokens are
-	// re-minted to the same path, and an exchange must use the current
-	// file contents rather than the token present at startup.
-	identityToken, err := readIdentityToken(c.identityTokenFilePath)
-	if err != nil {
-		return accessTokenInfo{}, err
+	identity := account.token
+
+	var err error
+	refreshed := false
+	if isIdentityTokenExpiring(identity.IDToken) {
+		if identity.RefreshToken == "" || identity.TokenEndpoint == "" {
+			return accessTokenInfo{}, &IdentityTokenExpiredError{}
+		}
+		if identity, err = c.refreshIdentityToken(ctx, file, account); err != nil {
+			return accessTokenInfo{}, err
+		}
+		refreshed = true
 	}
 
+	token, err := c.exchangeIdentityToken(ctx, identity.IDToken, identity.Org)
+
+	var exchangeErr *TokenExchangeError
+	if err == nil ||
+		!errors.As(err, &exchangeErr) ||
+		refreshed ||
+		!shouldRefreshIdentityToken(exchangeErr) {
+		return token, err
+	}
+
+	// The identity token looked valid locally but W&B rejected it anyway
+	// (e.g. it was actually expired, revoked, or the clocks disagree). If
+	// there's a refresh token we haven't tried yet, refresh once and
+	// retry the exchange; otherwise the server's rejection is final --
+	// there's nothing to be gained by converting it to a different error.
+	if identity.RefreshToken == "" || identity.TokenEndpoint == "" {
+		return accessTokenInfo{}, err
+	}
+	if identity, err = c.refreshIdentityToken(ctx, file, account); err != nil {
+		return accessTokenInfo{}, err
+	}
+	return c.exchangeIdentityToken(ctx, identity.IDToken, identity.Org)
+}
+
+// lockIdentityTokenFile takes the cross-process lock guarding the
+// identity token file, giving up if ctx is done first.
+//
+// The underlying file lock cannot be cancelled, so an abandoned wait is
+// handed off to a goroutine that releases the lock as soon as it is
+// acquired. Otherwise a slow refresh in another process would stall this
+// one well past its request deadline.
+func (c *oauth2CredentialProvider) lockIdentityTokenFile(
+	ctx context.Context,
+) (func(), error) {
+	type acquired struct {
+		unlock func()
+		err    error
+	}
+	locked := make(chan acquired, 1)
+	go func() {
+		unlock, err := c.identityTokenMu.Lock()
+		locked <- acquired{unlock, err}
+	}()
+
+	select {
+	case result := <-locked:
+		if result.err != nil {
+			return nil, fmt.Errorf(
+				"api: failed to lock identity token file %s: %w",
+				c.identityTokenFilePath, result.err)
+		}
+		return result.unlock, nil
+
+	case <-ctx.Done():
+		go func() {
+			if result := <-locked; result.err == nil {
+				result.unlock()
+			}
+		}()
+		return nil, ctx.Err()
+	}
+}
+
+// refreshIdentityToken exchanges the account's refresh token for a new
+// id_token (and usually a new refresh_token) at the IdP's token endpoint,
+// via the OAuth2 refresh_token grant (RFC 6749 section 6), then rewrites
+// the identity token file so the new tokens are available to any process
+// reading the same file.
+//
+// The file the account was read from is passed in so that the other
+// accounts in it survive the rewrite.
+func (c *oauth2CredentialProvider) refreshIdentityToken(
+	ctx context.Context,
+	file identityTokenFile,
+	account identityAccount,
+) (identityToken, error) {
+	// A file holding a bare JWT belongs to whoever provisioned it, and
+	// carries no refresh token to use anyway.
+	if file.bareJWT {
+		return identityToken{}, &IdentityTokenExpiredError{}
+	}
+
+	unlock, err := c.lockIdentityTokenFile(ctx)
+	if err != nil {
+		return identityToken{}, err
+	}
+	defer unlock()
+
+	// Re-read under the lock: another process may have refreshed the
+	// account since it was loaded, and rotated refresh tokens are
+	// single-use.
+	file, err = loadIdentityTokenFile(c.identityTokenFilePath)
+	if err != nil {
+		return identityToken{}, err
+	}
+	latest, err := file.accountFor(c.baseURL)
+	if err != nil {
+		return identityToken{}, err
+	}
+
+	current := account.token
+	if latest.token.IDToken != current.IDToken ||
+		latest.token.RefreshToken != current.RefreshToken {
+		current = latest.token
+		if !isIdentityTokenExpiring(current.IDToken) {
+			return current, nil
+		}
+	}
+	if current.RefreshToken == "" || current.TokenEndpoint == "" {
+		return identityToken{}, &IdentityTokenExpiredError{}
+	}
+
+	// This is its own subtask for the same reason the exchange below is:
+	// it serves every request waiting on the token, not just the one
+	// whose context this is.
+	op := wboperation.Get(ctx).Subtask("refreshing identity token")
+	defer op.Finish()
+
+	ctx, cancel := context.WithTimeout(op.Context(ctx), tokenExchangeTimeout)
+	defer cancel()
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {current.RefreshToken},
+	}
+	if current.ClientID != "" {
+		form.Set("client_id", current.ClientID)
+	}
+
+	req, err := retryablehttp.NewRequestWithContext(
+		ctx, http.MethodPost, current.TokenEndpoint, []byte(form.Encode()))
+	if err != nil {
+		return identityToken{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.refreshHTTPClient.Do(req)
+	if err != nil {
+		return identityToken{}, &IdentityTokenRefreshError{
+			Detail: err.Error(),
+		}
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := readTokenResponseBody(resp.Body)
+	if err != nil {
+		return identityToken{}, &IdentityTokenRefreshError{Detail: err.Error()}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return identityToken{}, &IdentityTokenRefreshError{
+			StatusCode: resp.StatusCode,
+			Detail:     oauthErrorDetail(body),
+		}
+	}
+
+	var refreshed struct {
+		IDToken      string `json:"id_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(body, &refreshed); err != nil {
+		return identityToken{}, &IdentityTokenRefreshError{
+			Detail: "invalid response: " + err.Error(),
+		}
+	}
+	if refreshed.IDToken == "" {
+		return identityToken{}, &IdentityTokenRefreshError{
+			Detail: "response did not include an id_token",
+		}
+	}
+
+	next := identityToken{
+		IDToken:       refreshed.IDToken,
+		RefreshToken:  refreshed.RefreshToken,
+		TokenEndpoint: current.TokenEndpoint,
+		ClientID:      current.ClientID,
+		Host:          current.Host,
+		Org:           current.Org,
+	}
+	if next.RefreshToken == "" {
+		// Not every IdP rotates the refresh token on use.
+		next.RefreshToken = current.RefreshToken
+	}
+
+	file.Accounts[latest.key] = next
+	if err := writeIdentityTokenFile(c.identityTokenFilePath, file); err != nil {
+		return identityToken{}, &IdentityTokenRefreshError{
+			Detail: "failed to persist rotated credentials: " + err.Error(),
+		}
+	}
+
+	return next, nil
+}
+
+// exchangeIdentityToken exchanges idToken for an access token using the
+// JWT Bearer flow defined in OAuth RFC 7523. org, if set, tells the server
+// which organization's CLI login issuer to resolve the identity against
+// (see `wandb login sso --org`); it is omitted for on-prem/dedicated hosts,
+// which resolve their own organization.
+func (c *oauth2CredentialProvider) exchangeIdentityToken(
+	ctx context.Context,
+	idToken string,
+	org string,
+) (accessTokenInfo, error) {
 	// The exchange reports its retries on its own subtask, not as the
 	// outer request's status: it serves every request waiting on the
 	// token, not just the one whose context this is.
@@ -479,8 +1083,11 @@ func (c *oauth2CredentialProvider) fetchAccessToken(
 	tokenURL := fmt.Sprintf("%s/oidc/token", c.baseURL)
 	data := fmt.Sprintf(
 		"grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=%s",
-		url.QueryEscape(identityToken),
+		url.QueryEscape(idToken),
 	)
+	if org != "" {
+		data += "&organization=" + url.QueryEscape(org)
+	}
 	req, err := retryablehttp.NewRequestWithContext(
 		ctx, http.MethodPost, tokenURL, []byte(data))
 	if err != nil {
@@ -496,12 +1103,12 @@ func (c *oauth2CredentialProvider) fetchAccessToken(
 		_ = resp.Body.Close()
 	}()
 
-	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return accessTokenInfo{}, err
-		}
+	body, err := readTokenResponseBody(resp.Body)
+	if err != nil {
+		return accessTokenInfo{}, err
+	}
 
+	if resp.StatusCode != http.StatusOK {
 		// Repeating a rejected exchange cannot succeed, so the requests
 		// that depend on it must fail immediately instead of retrying.
 		if isExchangeRejection(resp.StatusCode) {
@@ -520,7 +1127,7 @@ func (c *oauth2CredentialProvider) fetchAccessToken(
 		AccessToken string `json:"access_token"`
 		ExpiresIn   int    `json:"expires_in"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
+	if err := json.Unmarshal(body, &tokenResponse); err != nil {
 		return accessTokenInfo{}, err
 	}
 

--- a/core/internal/api/credentials_test.go
+++ b/core/internal/api/credentials_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -481,6 +482,770 @@ func TestNewOAuth2CredentialProvider_RereadsIdentityTokenFile(t *testing.T) {
 	assert.Contains(t, string(exchanges[1].Body), "assertion=second-token")
 }
 
+func fakeJWT(t *testing.T, exp time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload, err := json.Marshal(map[string]int64{"exp": exp.Unix()})
+	require.NoError(t, err)
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func writeJSONIdentityTokenFile(
+	t *testing.T,
+	idToken, refreshToken, tokenEndpoint, clientID string,
+	hostAndOrg ...string,
+) string {
+	account := map[string]string{
+		"id_token":       idToken,
+		"refresh_token":  refreshToken,
+		"token_endpoint": tokenEndpoint,
+		"client_id":      clientID,
+	}
+	var host, org string
+	if len(hostAndOrg) > 0 {
+		host = hostAndOrg[0]
+		account["host"] = host
+	}
+	if len(hostAndOrg) > 1 {
+		org = hostAndOrg[1]
+		account["org"] = org
+	}
+
+	key := host
+	if org != "" {
+		key += "#" + org
+	}
+	return writeIdentityAccountsFile(t, key,
+		map[string]map[string]string{key: account})
+}
+
+func writeIdentityAccountsFile(
+	t *testing.T,
+	active string,
+	accounts map[string]map[string]string,
+) string {
+	path := filepath.Join(t.TempDir(), "identity_token.json")
+	data, err := json.Marshal(map[string]any{
+		"version":  1,
+		"active":   active,
+		"accounts": accounts,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func readIdentityAccounts(
+	t *testing.T,
+	path string,
+) map[string]map[string]string {
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var file struct {
+		Version  int                          `json:"version"`
+		Accounts map[string]map[string]string `json:"accounts"`
+	}
+	require.NoError(t, json.Unmarshal(data, &file))
+	assert.Equal(t, 1, file.Version)
+	return file.Accounts
+}
+
+func readIdentityAccount(t *testing.T, path string) map[string]string {
+	accounts := readIdentityAccounts(t, path)
+	require.Len(t, accounts, 1)
+	for _, account := range accounts {
+		return account
+	}
+	return nil
+}
+
+func idpRefreshHandler(idToken, refreshToken string) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id_token":      idToken,
+			"refresh_token": refreshToken,
+		})
+	}
+}
+
+func TestNewOAuth2CredentialProvider_SendsOrganizationHint(t *testing.T) {
+	token := "fake-token"
+	server := authServer(token, time.Hour)
+	defer server.Close()
+
+	idToken := fakeJWT(t, time.Now().Add(time.Hour))
+	tokenFile := writeJSONIdentityTokenFile(t,
+		idToken,
+		"refresh-token",
+		"https://idp.example.com/token",
+		"wandb-cli",
+		server.URL,
+		"acme",
+	)
+	credentialsFile := filepath.Join(t.TempDir(), "credentials.json")
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: server.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile:   &wrapperspb.StringValue{Value: credentialsFile},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	reqs, err := httplayerstest.MapRequest(t,
+		credentialProvider,
+		exampleGetRequest(t),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "Bearer "+token, reqs[0].Header.Get("Authorization"))
+
+	exchanges := server.Requests()
+	require.Len(t, exchanges, 1)
+	assert.Contains(t, string(exchanges[0].Body), "assertion="+idToken)
+	assert.Contains(t, string(exchanges[0].Body), "organization=acme")
+}
+
+func TestNewOAuth2CredentialProvider_RejectsTokenForDifferentHost(t *testing.T) {
+	tokenFile := writeJSONIdentityTokenFile(
+		t,
+		fakeJWT(t, time.Now().Add(time.Hour)),
+		"refresh-token",
+		"https://idp.example.com/token",
+		"wandb-cli",
+		"https://first.example.com",
+	)
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: "https://second.example.com"},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+
+	_, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+
+	require.ErrorContains(t, err, tokenFile)
+	require.ErrorContains(t, err,
+		"has no credentials for https://second.example.com,"+
+			" only for https://first.example.com")
+}
+
+func TestNewOAuth2CredentialProvider_SelectsAccountForHost(t *testing.T) {
+	token := "fake-token"
+	server := authServer(token, time.Hour)
+	defer server.Close()
+
+	idToken := fakeJWT(t, time.Now().Add(time.Hour))
+	tokenFile := writeIdentityAccountsFile(t,
+		"https://other.example.com",
+		map[string]map[string]string{
+			"https://other.example.com": {
+				"id_token": "other-id-token",
+				"host":     "https://other.example.com",
+			},
+			server.URL: {
+				"id_token": idToken,
+				"host":     server.URL,
+				"org":      "acme",
+			},
+		})
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: server.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t, credentialProvider, exampleGetRequest(t))
+
+	require.NoError(t, err)
+	exchanges := server.Requests()
+	require.Len(t, exchanges, 1)
+	assert.Contains(t, string(exchanges[0].Body), "assertion="+idToken)
+	assert.Contains(t, string(exchanges[0].Body), "organization=acme")
+}
+
+func TestNewOAuth2CredentialProvider_ActiveAccountBreaksTie(t *testing.T) {
+	// Multi-tenant SaaS serves several organizations from one URL, so the
+	// base URL alone cannot say which account to use.
+	token := "fake-token"
+	server := authServer(token, time.Hour)
+	defer server.Close()
+
+	idToken := fakeJWT(t, time.Now().Add(time.Hour))
+	accounts := map[string]map[string]string{
+		server.URL + "#acme": {
+			"id_token": "acme-id-token",
+			"host":     server.URL,
+			"org":      "acme",
+		},
+		server.URL + "#zeta": {
+			"id_token": idToken,
+			"host":     server.URL,
+			"org":      "zeta",
+		},
+	}
+	credentialsFile := &wrapperspb.StringValue{
+		Value: filepath.Join(t.TempDir(), "credentials.json"),
+	}
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl: &wrapperspb.StringValue{Value: server.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{
+			Value: writeIdentityAccountsFile(t, server.URL+"#zeta", accounts),
+		},
+		CredentialsFile: credentialsFile,
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t, credentialProvider, exampleGetRequest(t))
+
+	require.NoError(t, err)
+	exchanges := server.Requests()
+	require.Len(t, exchanges, 1)
+	assert.Contains(t, string(exchanges[0].Body), "assertion="+idToken)
+	assert.Contains(t, string(exchanges[0].Body), "organization=zeta")
+
+	// The access token is cached per account, not per W&B server, so that
+	// the other organization's token is never used by mistake.
+	data, err := os.ReadFile(credentialsFile.Value)
+	require.NoError(t, err)
+	var cached api.CredentialsFile
+	require.NoError(t, json.Unmarshal(data, &cached))
+	assert.Equal(t, token, cached.Credentials[server.URL+"#zeta"].AccessToken)
+}
+
+func TestNewOAuth2CredentialProvider_RejectsAmbiguousAccounts(t *testing.T) {
+	accounts := map[string]map[string]string{
+		"https://api.wandb.ai#acme": {
+			"id_token": "acme-id-token",
+			"host":     "https://api.wandb.ai",
+			"org":      "acme",
+		},
+		"https://api.wandb.ai#zeta": {
+			"id_token": "zeta-id-token",
+			"host":     "https://api.wandb.ai",
+			"org":      "zeta",
+		},
+	}
+	tokenFile := writeIdentityAccountsFile(t, "", accounts)
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: "https://api.wandb.ai"},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+
+	_, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+
+	require.ErrorContains(t, err, tokenFile)
+	require.ErrorContains(t, err,
+		"several accounts for https://api.wandb.ai"+
+			" (https://api.wandb.ai#acme, https://api.wandb.ai#zeta)")
+}
+
+func TestNewOAuth2CredentialProvider_RejectsUnsupportedFileVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity_token.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"version": 2}`), 0o600))
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: "https://api.wandb.ai"},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: path},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+
+	_, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+
+	require.ErrorContains(t, err, path)
+	require.ErrorContains(t, err, "file format version 2")
+	require.ErrorContains(t, err, "upgrade wandb")
+}
+
+func TestNewOAuth2CredentialProvider_ReportsFileLocationForMissingIDToken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity_token.json")
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"version": 1, "accounts": {"https://wandb.dedicated.test": {"host": "https://wandb.dedicated.test"}}}`,
+	), 0o600))
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: "https://wandb.dedicated.test"},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: path},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+
+	_, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+
+	require.ErrorContains(t, err, path)
+	require.ErrorContains(t, err, "has no id_token")
+}
+
+func TestNewOAuth2CredentialProvider_RejectsInsecureRefreshEndpoint(t *testing.T) {
+	tokenFile := writeJSONIdentityTokenFile(
+		t,
+		fakeJWT(t, time.Now().Add(time.Hour)),
+		"refresh-token",
+		"http://idp.example.com/token",
+		"wandb-cli",
+	)
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: "https://api.wandb.ai"},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+
+	_, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+
+	require.ErrorContains(t, err, "token_endpoint must use HTTPS")
+}
+
+func TestNewOAuth2CredentialProvider_RefreshesExpiredIdentityToken(t *testing.T) {
+	wbToken := "fake-wb-token"
+	wbServer := authServer(wbToken, time.Hour)
+	defer wbServer.Close()
+
+	newIDToken := fakeJWT(t, time.Now().Add(time.Hour))
+	idpServer := apitest.NewRecordingServer(
+		apitest.WithHandlerFunc(idpRefreshHandler(newIDToken, "new-refresh-token")))
+	defer idpServer.Close()
+
+	tokenFile := writeJSONIdentityTokenFile(t,
+		fakeJWT(t, time.Now().Add(-time.Hour)), // expired
+		"old-refresh-token",
+		idpServer.URL,
+		"wandb-cli",
+		wbServer.URL,
+		"acme",
+	)
+	require.NoError(t, os.Chmod(tokenFile, 0o644))
+	credentialsFile := filepath.Join(t.TempDir(), "credentials.json")
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: wbServer.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile:   &wrapperspb.StringValue{Value: credentialsFile},
+		XExtraHttpHeaders: &spb.MapStringKeyStringValue{
+			Value: map[string]string{"X-Wandb-Only": "secret"},
+		},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	reqs, err := httplayerstest.MapRequest(t,
+		credentialProvider,
+		exampleGetRequest(t),
+	)
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "Bearer "+wbToken, reqs[0].Header.Get("Authorization"))
+
+	idpReqs := idpServer.Requests()
+	require.Len(t, idpReqs, 1)
+	assert.Contains(t, string(idpReqs[0].Body), "grant_type=refresh_token")
+	assert.Contains(t, string(idpReqs[0].Body), "refresh_token=old-refresh-token")
+	assert.Contains(t, string(idpReqs[0].Body), "client_id=wandb-cli")
+	assert.Empty(t, idpReqs[0].Header.Get("X-Wandb-Only"))
+
+	wbReqs := wbServer.Requests()
+	require.Len(t, wbReqs, 1)
+	assert.Contains(t, string(wbReqs[0].Body), "assertion="+newIDToken)
+	assert.Equal(t, "secret", wbReqs[0].Header.Get("X-Wandb-Only"))
+
+	rewritten := readIdentityAccount(t, tokenFile)
+	assert.Equal(t, newIDToken, rewritten["id_token"])
+	assert.Equal(t, "new-refresh-token", rewritten["refresh_token"])
+	assert.Equal(t, idpServer.URL, rewritten["token_endpoint"])
+	assert.Equal(t, "wandb-cli", rewritten["client_id"])
+	assert.Equal(t, wbServer.URL, rewritten["host"])
+	assert.Equal(t, "acme", rewritten["org"])
+	info, err := os.Stat(tokenFile)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestNewOAuth2CredentialProvider_RefreshKeepsOtherAccounts(t *testing.T) {
+	wbServer := authServer("fake-wb-token", time.Hour)
+	defer wbServer.Close()
+
+	newIDToken := fakeJWT(t, time.Now().Add(time.Hour))
+	idpServer := apitest.NewRecordingServer(
+		apitest.WithHandlerFunc(idpRefreshHandler(newIDToken, "new-refresh-token")))
+	defer idpServer.Close()
+
+	tokenFile := writeIdentityAccountsFile(t, wbServer.URL,
+		map[string]map[string]string{
+			wbServer.URL: {
+				"id_token":       fakeJWT(t, time.Now().Add(-time.Hour)), // expired
+				"refresh_token":  "old-refresh-token",
+				"token_endpoint": idpServer.URL,
+				"client_id":      "wandb-cli",
+				"host":           wbServer.URL,
+			},
+			"https://other.example.com": {
+				"id_token": "other-id-token",
+				"host":     "https://other.example.com",
+			},
+		})
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: wbServer.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t, credentialProvider, exampleGetRequest(t))
+	require.NoError(t, err)
+
+	accounts := readIdentityAccounts(t, tokenFile)
+	require.Len(t, accounts, 2)
+	assert.Equal(t, newIDToken, accounts[wbServer.URL]["id_token"])
+	assert.Equal(t,
+		"other-id-token",
+		accounts["https://other.example.com"]["id_token"])
+}
+
+func TestOAuth2CredentialProvider_SerializesRefreshAcrossProviders(t *testing.T) {
+	wbServer := authServer("fake-wb-token", time.Hour)
+	defer wbServer.Close()
+
+	var refreshes atomic.Int32
+	newIDToken := fakeJWT(t, time.Now().Add(time.Hour))
+	idpServer := apitest.NewRecordingServer(apitest.WithHandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			refreshes.Add(1)
+			time.Sleep(100 * time.Millisecond)
+			idpRefreshHandler(newIDToken, "new-refresh-token")(w, req)
+		},
+	))
+	defer idpServer.Close()
+
+	tokenFile := writeJSONIdentityTokenFile(t,
+		fakeJWT(t, time.Now().Add(-time.Hour)),
+		"old-refresh-token",
+		idpServer.URL,
+		"wandb-cli",
+	)
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: wbServer.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+
+	providers := make([]api.CredentialProvider, 2)
+	for i := range providers {
+		var err error
+		providers[i], err = api.NewCredentialProvider(
+			settings,
+			observabilitytest.NewTestLogger(t).Logger,
+		)
+		require.NoError(t, err)
+	}
+
+	var group errgroup.Group
+	for _, provider := range providers {
+		group.Go(func() error {
+			_, err := httplayerstest.MapRequest(
+				t, provider, exampleGetRequest(t))
+			return err
+		})
+	}
+	require.NoError(t, group.Wait())
+	assert.Equal(t, int32(1), refreshes.Load())
+}
+
+func TestOAuth2CredentialProvider_ExpiredIdentityTokenWithoutRefreshTokenFails(t *testing.T) {
+	server := authServer("fake-token", time.Hour)
+	defer server.Close()
+
+	tokenFile := filepath.Join(t.TempDir(), "jwt.txt")
+	require.NoError(t, os.WriteFile(
+		tokenFile, []byte(fakeJWT(t, time.Now().Add(-time.Hour))), 0o600))
+	credentialsFile := filepath.Join(t.TempDir(), "credentials.json")
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: server.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile:   &wrapperspb.StringValue{Value: credentialsFile},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t, credentialProvider, exampleGetRequest(t))
+
+	var expiredErr *api.IdentityTokenExpiredError
+	require.ErrorAs(t, err, &expiredErr)
+	assert.True(t, expiredErr.PermanentError())
+	assert.Contains(t, err.Error(), "wandb login sso")
+	assert.Empty(t, server.Requests())
+}
+
+func TestOAuth2CredentialProvider_RefreshFailureIsPermanent(t *testing.T) {
+	server := authServer("fake-token", time.Hour)
+	defer server.Close()
+
+	idpServer := rejectingAuthServer(http.StatusBadRequest, `{"error":"invalid_grant"}`)
+	defer idpServer.Close()
+
+	tokenFile := writeJSONIdentityTokenFile(t,
+		fakeJWT(t, time.Now().Add(-time.Hour)), // expired
+		"refresh-token",
+		idpServer.URL,
+		"wandb-cli",
+	)
+	credentialsFile := filepath.Join(t.TempDir(), "credentials.json")
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: server.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile:   &wrapperspb.StringValue{Value: credentialsFile},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t, credentialProvider, exampleGetRequest(t))
+
+	var refreshErr *api.IdentityTokenRefreshError
+	require.ErrorAs(t, err, &refreshErr)
+	assert.Equal(t, http.StatusBadRequest, refreshErr.StatusCode)
+	assert.True(t, refreshErr.PermanentError())
+	assert.Contains(t, err.Error(), "invalid_grant")
+
+	assert.Empty(t, server.Requests())
+}
+
+func TestOAuth2CredentialProvider_RefreshRequestIsNotRetried(t *testing.T) {
+	wbServer := authServer("fake-token", time.Hour)
+	defer wbServer.Close()
+	idpServer := rejectingAuthServer(
+		http.StatusInternalServerError,
+		`{"error":"server_error"}`,
+	)
+	defer idpServer.Close()
+
+	tokenFile := writeJSONIdentityTokenFile(t,
+		fakeJWT(t, time.Now().Add(-time.Hour)),
+		"refresh-token",
+		idpServer.URL,
+		"wandb-cli",
+	)
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: wbServer.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+	provider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t, provider, exampleGetRequest(t))
+
+	var refreshErr *api.IdentityTokenRefreshError
+	require.ErrorAs(t, err, &refreshErr)
+	assert.True(t, refreshErr.PermanentError())
+	assert.Len(t, idpServer.Requests(), 1)
+	assert.Empty(t, wbServer.Requests())
+}
+
+func TestOAuth2CredentialProvider_RefreshDoesNotFollowRedirect(t *testing.T) {
+	redirectTarget := apitest.NewRecordingServer(apitest.WithHandlerFunc(
+		idpRefreshHandler("stolen-token", "stolen-refresh-token"),
+	))
+	defer redirectTarget.Close()
+	redirector := apitest.NewRecordingServer(apitest.WithHandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			http.Redirect(w, req, redirectTarget.URL, http.StatusTemporaryRedirect)
+		},
+	))
+	defer redirector.Close()
+	wbServer := authServer("fake-token", time.Hour)
+	defer wbServer.Close()
+
+	tokenFile := writeJSONIdentityTokenFile(t,
+		fakeJWT(t, time.Now().Add(-time.Hour)),
+		"refresh-token",
+		redirector.URL,
+		"wandb-cli",
+	)
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: wbServer.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile: &wrapperspb.StringValue{
+			Value: filepath.Join(t.TempDir(), "credentials.json"),
+		},
+	})
+	provider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	_, err = httplayerstest.MapRequest(t, provider, exampleGetRequest(t))
+
+	require.Error(t, err)
+	assert.Len(t, redirector.Requests(), 1)
+	assert.Empty(t, redirectTarget.Requests())
+	assert.Empty(t, wbServer.Requests())
+}
+
+func TestOAuth2CredentialProvider_RefreshesOnlyForUnrefreshedInvalidToken(
+	t *testing.T,
+) {
+	tests := []struct {
+		name          string
+		idToken       string
+		expired       bool
+		wbStatus      int
+		wbBody        string
+		wantRefreshes int
+	}{
+		{
+			name:          "refreshed token is not refreshed again",
+			expired:       true,
+			wbStatus:      http.StatusUnauthorized,
+			wbBody:        `{"error":"invalid_grant"}`,
+			wantRefreshes: 1,
+		},
+		{
+			name:          "forbidden exchange does not consume refresh token",
+			idToken:       "not-a-jwt",
+			wbStatus:      http.StatusForbidden,
+			wbBody:        `{"error":"insufficient_scope"}`,
+			wantRefreshes: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wbServer := rejectingAuthServer(test.wbStatus, test.wbBody)
+			defer wbServer.Close()
+			idpServer := apitest.NewRecordingServer(apitest.WithHandlerFunc(
+				idpRefreshHandler(fakeJWT(t, time.Now().Add(time.Hour)), ""),
+			))
+			defer idpServer.Close()
+
+			idToken := test.idToken
+			if test.expired {
+				idToken = fakeJWT(t, time.Now().Add(-time.Hour))
+			}
+			tokenFile := writeJSONIdentityTokenFile(
+				t, idToken, "refresh-token", idpServer.URL, "wandb-cli")
+			settings := wbsettings.From(&spb.Settings{
+				BaseUrl:           &wrapperspb.StringValue{Value: wbServer.URL},
+				IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+				CredentialsFile: &wrapperspb.StringValue{
+					Value: filepath.Join(t.TempDir(), "credentials.json"),
+				},
+			})
+			provider, err := api.NewCredentialProvider(
+				settings,
+				observabilitytest.NewTestLogger(t).Logger,
+			)
+			require.NoError(t, err)
+
+			_, err = httplayerstest.MapRequest(t, provider, exampleGetRequest(t))
+
+			require.Error(t, err)
+			assert.Len(t, idpServer.Requests(), test.wantRefreshes)
+			assert.Len(t, wbServer.Requests(), 1)
+		})
+	}
+}
+
+func TestOAuth2CredentialProvider_RefreshesOnServerRejectionWhenLocalCheckMissed(t *testing.T) {
+	wbServer := sequencedAuthServer(http.StatusUnauthorized, http.StatusOK)
+	defer wbServer.Close()
+
+	newIDToken := fakeJWT(t, time.Now().Add(time.Hour))
+	idpServer := apitest.NewRecordingServer(
+		apitest.WithHandlerFunc(idpRefreshHandler(newIDToken, "")))
+	defer idpServer.Close()
+
+	tokenFile := writeJSONIdentityTokenFile(t,
+		"not-a-jwt", "old-refresh-token", idpServer.URL, "wandb-cli")
+	credentialsFile := filepath.Join(t.TempDir(), "credentials.json")
+
+	settings := wbsettings.From(&spb.Settings{
+		BaseUrl:           &wrapperspb.StringValue{Value: wbServer.URL},
+		IdentityTokenFile: &wrapperspb.StringValue{Value: tokenFile},
+		CredentialsFile:   &wrapperspb.StringValue{Value: credentialsFile},
+	})
+	credentialProvider, err := api.NewCredentialProvider(
+		settings,
+		observabilitytest.NewTestLogger(t).Logger,
+	)
+	require.NoError(t, err)
+
+	reqs, err := httplayerstest.MapRequest(t, credentialProvider, exampleGetRequest(t))
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "Bearer fake-token", reqs[0].Header.Get("Authorization"))
+	assert.Len(t, wbServer.Requests(), 2)
+	assert.Len(t, idpServer.Requests(), 1)
+
+	rewritten := readIdentityAccount(t, tokenFile)
+	assert.Equal(t, "old-refresh-token", rewritten["refresh_token"])
+}
+
 // rejectingAuthServer is a token endpoint that always responds with the
 // given status code and body.
 func rejectingAuthServer(statusCode int, body string) *apitest.RecordingServer {
@@ -602,6 +1367,7 @@ func oauth2ProviderWithRetries(
 		tokenFile,
 		credentialsFile,
 		exchangeClient,
+		exchangeClient,
 		logger,
 	)
 	require.NoError(t, err)
@@ -666,6 +1432,12 @@ func sequencedAuthServer(statuses ...int) *apitest.RecordingServer {
 			authHandler("fake-token", time.Hour)(w, req)
 			return
 		}
+		if status == http.StatusBadRequest || status == http.StatusUnauthorized {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+			return
+		}
 
 		http.Error(w, "nope", status)
 	}
@@ -700,6 +1472,16 @@ func TestOAuth2CredentialProvider_ExchangeRetries(t *testing.T) {
 		{
 			name:         "a server error is retried until it succeeds",
 			statuses:     []int{http.StatusInternalServerError, http.StatusOK},
+			wantRequests: 2,
+		},
+		{
+			name:         "a request timeout is retried",
+			statuses:     []int{http.StatusRequestTimeout, http.StatusOK},
+			wantRequests: 2,
+		},
+		{
+			name:         "too early is retried",
+			statuses:     []int{http.StatusTooEarly, http.StatusOK},
 			wantRequests: 2,
 		},
 	}


### PR DESCRIPTION
## Summary
- support versioned, multi-account identity-token files while preserving bare JWT compatibility
- refresh expiring identity tokens and persist token rotation under a cross-process lock
- harden refresh requests against redirects and insecure token endpoints

The below json is how the file looks. The code is still compatible with the old version which was just a JWT.
New:
```
{
  "version": 1,
  "active": "https://api.wandb.ai#acme",
  "accounts": {
    "https://api.wandb.ai#acme": {
      "id_token": "eyJ...",
      "refresh_token": "rt_abc123",
      "token_endpoint": "https://idp.acme-corp.com/oauth2/token",
      "client_id": "wandb-cli",
      "host": "https://api.wandb.ai",
      "org": "acme"
    },
    "https://dedicated.mycompany.com": {
      "id_token": "eyJ...",
      "refresh_token": "rt_def456",
      "token_endpoint": "https://sso.mycompany.com/oauth2/token",
      "client_id": "wb-sso-cli",
      "host": "https://dedicated.mycompany.com"
    }
  }
}
```

Old:
```
eyJhbGciOi...
```

## Test plan
- [x] `cd core && go test ./internal/api`
- [x] The 4 PRs below have been tested e2e together
- [x] Tested with just this PR that the identity file is read and the refresh token is used for expired JWT & `wb_at_`
  - [x] Both the old (just JWT) and new identity token file can refresh

## Stack
1. **Core refresh foundation (this PR)**
2. [Python identity account management](https://github.com/wandb/wandb/pull/12778)
3. [PKCE SSO login](https://github.com/wandb/wandb/pull/12779)
4. [Device-code SSO login](https://github.com/wandb/wandb/pull/12780)