### PR TITLE
Manage federated identity accounts in Python

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,6 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Changed
 
+- Setting both `WANDB_API_KEY` and `WANDB_IDENTITY_TOKEN_FILE` is no longer an error. Federated identity credentials take precedence and W&B warns that the API key is being ignored.
 - Runs now write data to disk every 15 seconds, so that wandb leet updates sooner for runs that don't log a lot of data (@dmitryduev in https://github.com/wandb/wandb/pull/12742)
 
 ### Fixed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,9 @@ def filesystem_isolate(tmp_path, monkeypatch):
     print(f"Setting COVERAGE_FILE to {new_covfile}", file=sys.stderr)
     monkeypatch.setenv("COVERAGE_FILE", new_covfile)
 
+    # Keep developer settings out of tests, like the isolated netrc fixture.
+    monkeypatch.setenv("WANDB_CONFIG_DIR", str(tmp_path / "wandb-config"))
+
     with CliRunner().isolated_filesystem(temp_dir=tmp_path):
         yield
 

--- a/tests/unit_tests/test_lib/test_auth.py
+++ b/tests/unit_tests/test_lib/test_auth.py
@@ -3,21 +3,48 @@ import textwrap
 from unittest.mock import MagicMock
 
 import pytest
+from wandb import env
 from wandb.errors import AuthenticationError, UsageError
 from wandb.sdk import wandb_setup
 from wandb.sdk.lib import wbauth
 from wandb.sdk.lib.wbauth import (
     AuthApiKey,
     AuthIdentityTokenFile,
+    HostUrl,
     authenticate_session,
+    identity_token_file,
     session_credentials,
     use_explicit_auth,
     validation,
 )
+from wandb.sdk.lib.wbauth.authenticate import _try_settings_file_auth
 
 from tests.fixtures.mock_wandb_log import MockWandbLog
 
 pytestmark = pytest.mark.usefixtures("skip_verify_login")
+
+
+def _write_sso_account(path: pathlib.Path, host: str) -> None:
+    """Saves credentials for a host, as `wandb login sso` does."""
+    accounts = identity_token_file.Accounts()
+    accounts.add(
+        identity_token_file.Account(
+            id_token="id-token",
+            refresh_token="refresh-token",
+            token_endpoint="https://idp.example.com/token",
+            client_id="wandb-cli",
+            host=host,
+        )
+    )
+    accounts.save(path)
+
+
+def _write_system_settings(contents: str) -> None:
+    settings = wandb_setup.singleton().settings
+    path = pathlib.Path(settings.settings_system)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(contents))
+    settings.update_from_system_settings()
 
 
 def test_auth_repr_no_secrets():
@@ -58,17 +85,21 @@ def test_warns_if_changing_auth(mock_wandb_log: MockWandbLog):
     )
 
 
-def test_error_if_multiple_credentials_in_env(
+def test_identity_token_environment_variable_takes_priority_over_api_key(
+    mock_wandb_log: MockWandbLog,
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("WANDB_API_KEY", "from_env" * 5)
     monkeypatch.setenv("WANDB_IDENTITY_TOKEN_FILE", "file.jwt")
 
-    with pytest.raises(
-        AuthenticationError,
-        match="Both WANDB_API_KEY and WANDB_IDENTITY_TOKEN_FILE are set",
-    ):
-        authenticate_session(host="https://fake-url", source="test")
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthIdentityTokenFile)
+    assert result.path == pathlib.Path("file.jwt").absolute()
+    mock_wandb_log.assert_warned(
+        "Ignoring WANDB_API_KEY because federated identity credentials are"
+        + " configured from WANDB_IDENTITY_TOKEN_FILE."
+    )
 
 
 def test_loads_api_key_from_environment_variable(
@@ -165,6 +196,171 @@ def test_loads_oidc_from_environment_variable(
         "[test] Loaded credentials for https://fake-url from"
         + " WANDB_IDENTITY_TOKEN_FILE."
     )
+
+
+def test_loads_identity_token_from_settings_file(
+    mock_wandb_log: MockWandbLog,
+    local_settings,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    monkeypatch.delenv("WANDB_IDENTITY_TOKEN_FILE", raising=False)
+
+    token_path = tmp_path / "identity_token.json"
+    _write_sso_account(token_path, "https://fake-url")
+    _write_system_settings(
+        f"""\
+            [default]
+            base_url = https://fake-url
+            identity_token_file = {token_path}
+        """
+    )
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthIdentityTokenFile)
+    assert result.host.is_same_url("https://fake-url")
+    assert result.path == token_path.absolute()
+    mock_wandb_log.assert_logged(
+        "[test] Loaded credentials for https://fake-url from"
+        + " your saved SSO credentials."
+    )
+
+
+def test_identity_token_setting_takes_priority_over_api_key(
+    mock_wandb_log: MockWandbLog,
+    local_settings,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    token_path = tmp_path / "identity_token.json"
+    _write_sso_account(token_path, "https://fake-url")
+    _write_system_settings(
+        f"""\
+            [default]
+            base_url = https://fake-url
+            identity_token_file = {token_path}
+        """
+    )
+    monkeypatch.setenv("WANDB_API_KEY", "from_env" * 5)
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthIdentityTokenFile)
+    mock_wandb_log.assert_warned(
+        "Ignoring WANDB_API_KEY because federated identity credentials are"
+        + " configured from your saved SSO credentials."
+    )
+
+
+def test_loads_identity_token_from_default_path(
+    mock_wandb_log: MockWandbLog,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv(env.API_KEY, raising=False)
+    monkeypatch.delenv(env.IDENTITY_TOKEN_FILE, raising=False)
+    monkeypatch.setenv(env.CONFIG_DIR, str(tmp_path))
+    token_path = identity_token_file.default_path()
+    token_path.parent.mkdir(exist_ok=True)
+    _write_sso_account(token_path, "https://fake-url")
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthIdentityTokenFile)
+    assert result.path == token_path.absolute()
+    mock_wandb_log.assert_logged(
+        "[test] Loaded credentials for https://fake-url from"
+        + " your saved SSO credentials."
+    )
+
+
+def test_default_identity_token_file_takes_priority_over_api_key(
+    mock_wandb_log: MockWandbLog,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(env.API_KEY, "from_env" * 5)
+    monkeypatch.delenv(env.IDENTITY_TOKEN_FILE, raising=False)
+    monkeypatch.setenv(env.CONFIG_DIR, str(tmp_path))
+    token_path = identity_token_file.default_path()
+    token_path.parent.mkdir(exist_ok=True)
+    _write_sso_account(token_path, "https://fake-url")
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthIdentityTokenFile)
+    mock_wandb_log.assert_warned(
+        "Ignoring WANDB_API_KEY because federated identity credentials are"
+        + " configured from your saved SSO credentials."
+    )
+
+
+def test_falls_back_when_the_default_token_file_is_ambiguous(
+    mock_wandb_log: MockWandbLog,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(env.API_KEY, "from_env" * 5)
+    monkeypatch.delenv(env.IDENTITY_TOKEN_FILE, raising=False)
+    monkeypatch.setenv(env.CONFIG_DIR, str(tmp_path))
+    token_path = identity_token_file.default_path()
+    token_path.parent.mkdir(exist_ok=True)
+    accounts = identity_token_file.Accounts()
+    for org in ("acme", "globex"):
+        accounts.add(
+            identity_token_file.Account(
+                id_token="id-token",
+                refresh_token="refresh-token",
+                token_endpoint="https://idp.example.com/token",
+                client_id="wandb-cli",
+                host="https://fake-url",
+                org=org,
+            )
+        )
+    accounts.active = None
+    accounts.save(token_path)
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthApiKey)
+    mock_wandb_log.assert_warned("Several accounts are saved for https://fake-url")
+
+
+def test_ignores_default_identity_token_file_for_different_host(
+    mock_wandb_log: MockWandbLog,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(env.API_KEY, "from_env" * 5)
+    monkeypatch.delenv(env.IDENTITY_TOKEN_FILE, raising=False)
+    monkeypatch.setenv(env.CONFIG_DIR, str(tmp_path))
+    token_path = identity_token_file.default_path()
+    token_path.parent.mkdir(exist_ok=True)
+    _write_sso_account(token_path, "https://other-fake-url")
+
+    result = authenticate_session(host="https://fake-url", source="test")
+
+    assert isinstance(result, AuthApiKey)
+    mock_wandb_log.assert_logged(
+        "[test] Loaded credentials for https://fake-url from WANDB_API_KEY."
+    )
+
+
+def test_ignores_identity_token_setting_for_different_host(
+    local_settings,
+    tmp_path: pathlib.Path,
+):
+    _write_system_settings(
+        f"""\
+            [default]
+            base_url = https://first.example.com
+            identity_token_file = {tmp_path / "identity_token.json"}
+        """
+    )
+
+    assert _try_settings_file_auth(host=HostUrl("https://second.example.com")) is None
 
 
 def test_reads_netrc(

--- a/tests/unit_tests/test_lib/test_auth_identity_token_file.py
+++ b/tests/unit_tests/test_lib/test_auth_identity_token_file.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from wandb.sdk.lib.wbauth import identity_token_file
+from wandb.sdk.lib.wbauth.host_url import HostUrl
+
+
+def _account(host: str, org: str | None = None) -> identity_token_file.Account:
+    return identity_token_file.Account(
+        id_token=f"{org or host}-id-token",
+        refresh_token="refresh-token",
+        token_endpoint="https://idp.example.com/token",
+        client_id="wandb-cli",
+        host=host,
+        org=org,
+    )
+
+
+def test_default_path_uses_config_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("WANDB_CONFIG_DIR", str(tmp_path))
+
+    assert identity_token_file.default_path() == tmp_path / "identity_token.json"
+
+
+def test_save_is_private_and_atomic(tmp_path: pathlib.Path):
+    accounts = identity_token_file.Accounts()
+    accounts.add(_account("https://api.wandb.ai", "acme"))
+    path = tmp_path / "nested" / "identity_token.json"
+
+    accounts.save(path)
+
+    assert (path.stat().st_mode & 0o777) == 0o600
+    assert json.loads(path.read_text()) == {
+        "version": 1,
+        "active": "https://api.wandb.ai#acme",
+        "accounts": {
+            "https://api.wandb.ai#acme": {
+                "id_token": "acme-id-token",
+                "refresh_token": "refresh-token",
+                "token_endpoint": "https://idp.example.com/token",
+                "client_id": "wandb-cli",
+                "host": "https://api.wandb.ai",
+                "org": "acme",
+            }
+        },
+    }
+
+
+def test_add_keeps_accounts_for_other_hosts(tmp_path: pathlib.Path):
+    path = tmp_path / "identity_token.json"
+    accounts = identity_token_file.Accounts()
+    accounts.add(_account("https://wandb.corp.example.com"))
+    accounts.save(path)
+
+    reloaded = identity_token_file.load(path)
+    reloaded.add(_account("https://api.wandb.ai", "acme"))
+    reloaded.save(path)
+
+    saved = identity_token_file.load(path)
+    assert set(saved.accounts) == {
+        "https://wandb.corp.example.com",
+        "https://api.wandb.ai#acme",
+    }
+    assert saved.active == "https://api.wandb.ai#acme"
+
+
+def test_for_host_selects_matching_account():
+    accounts = identity_token_file.Accounts()
+    accounts.add(_account("https://api.wandb.ai", "acme"))
+    accounts.add(_account("https://wandb.corp.example.com"))
+
+    account = accounts.for_host(HostUrl("https://wandb.corp.example.com/"))
+
+    assert account is not None
+    assert account.id_token == "https://wandb.corp.example.com-id-token"
+
+
+def test_for_host_prefers_active_account():
+    accounts = identity_token_file.Accounts()
+    accounts.add(_account("https://api.wandb.ai", "acme"))
+    accounts.add(_account("https://api.wandb.ai", "zeta"))
+
+    account = accounts.for_host(HostUrl("https://api.wandb.ai"))
+
+    assert account is not None
+    assert account.org == "zeta"
+
+
+def test_for_host_rejects_ambiguous_accounts():
+    accounts = identity_token_file.Accounts()
+    accounts.add(_account("https://api.wandb.ai", "acme"))
+    accounts.add(_account("https://api.wandb.ai", "zeta"))
+    accounts.active = None
+
+    with pytest.raises(identity_token_file.AmbiguousAccountError, match="acme, zeta"):
+        accounts.for_host(HostUrl("https://api.wandb.ai"))
+
+
+def test_load_rejects_bare_jwt(tmp_path: pathlib.Path):
+    path = tmp_path / "identity_token.json"
+    path.write_text("header.payload.signature")
+
+    with pytest.raises(identity_token_file.InvalidIdentityTokenFileError):
+        identity_token_file.load(path)
+
+
+def test_load_rejects_newer_file_format(tmp_path: pathlib.Path):
+    path = tmp_path / "identity_token.json"
+    path.write_text(json.dumps({"version": 2, "accounts": {}}))
+
+    with pytest.raises(
+        identity_token_file.InvalidIdentityTokenFileError,
+        match="Upgrade wandb",
+    ):
+        identity_token_file.load(path)
+
+
+def test_load_rejects_account_without_id_token(tmp_path: pathlib.Path):
+    path = tmp_path / "identity_token.json"
+    path.write_text(
+        json.dumps({"version": 1, "accounts": {"https://api.wandb.ai": {}}})
+    )
+
+    with pytest.raises(
+        identity_token_file.InvalidIdentityTokenFileError,
+        match="id_token",
+    ):
+        identity_token_file.load(path)
+
+
+def test_load_or_empty_warns_about_unreadable_file(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture,
+):
+    path = tmp_path / "identity_token.json"
+    path.write_text("not json")
+
+    accounts = identity_token_file.load_or_empty(path)
+
+    assert accounts.accounts == {}
+    assert "Replacing unreadable saved credentials" in capsys.readouterr().err
+
+
+def test_load_or_empty_is_quiet_for_missing_file(
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture,
+):
+    accounts = identity_token_file.load_or_empty(tmp_path / "missing.json")
+
+    assert accounts.accounts == {}
+    assert capsys.readouterr().err == ""

--- a/tests/unit_tests/test_wandb_login.py
+++ b/tests/unit_tests/test_wandb_login.py
@@ -5,6 +5,7 @@ import wandb
 from wandb.errors import UsageError
 from wandb.sdk import wandb_login, wandb_setup
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.lib.wbauth import identity_token_file
 
 
 @pytest.fixture(autouse=True)
@@ -109,6 +110,42 @@ def test_login_key(emulated_terminal):
 
     assert "Appending key" in "\n".join(emulated_terminal.read_stderr())
     assert wandb.api.api_key == "A" * 40
+
+
+@pytest.mark.usefixtures("local_settings", "skip_verify_login")
+def test_login_key_clears_persisted_identity_token():
+    settings = wandb_setup.singleton().settings
+    system_settings = settings.read_system_settings()
+    system_settings.set("identity_token_file", "/tmp/identity.json", globally=True)
+    system_settings.save()
+
+    wandb.login(key="A" * 40)
+
+    assert "identity_token_file" not in settings.read_system_settings().all()
+
+
+@pytest.mark.usefixtures("local_settings", "skip_verify_login")
+def test_login_key_forgets_saved_sso_credentials_for_the_host(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("WANDB_CONFIG_DIR", str(tmp_path))
+    accounts = identity_token_file.Accounts()
+    for host in ("https://api.wandb.ai", "https://other.example.com"):
+        accounts.add(
+            identity_token_file.Account(
+                id_token="id-token",
+                refresh_token="refresh-token",
+                token_endpoint="https://idp.example.com/token",
+                client_id="wandb-cli",
+                host=host,
+            )
+        )
+    accounts.save(identity_token_file.default_path())
+
+    wandb.login(key="A" * 40, host="https://api.wandb.ai")
+
+    saved = identity_token_file.load(identity_token_file.default_path())
+    assert set(saved.accounts) == {"https://other.example.com"}
 
 
 def test_login(test_settings):

--- a/wandb/sdk/lib/wbauth/auth.py
+++ b/wandb/sdk/lib/wbauth/auth.py
@@ -90,7 +90,7 @@ class AuthApiKey(Auth):
 
 @final
 class AuthIdentityTokenFile(Auth):
-    """A path to a file storing a JWT with OIDC credentials."""
+    """A file containing OIDC identity credentials."""
 
     @override
     def __init__(
@@ -104,7 +104,7 @@ class AuthIdentityTokenFile(Auth):
 
         Args:
             host: The W&B server URL.
-            path: Path to the identity token file containing a JWT.
+            path: Path to the identity token file.
             credentials_file: Path to the credentials file for caching access tokens.
         """
         super().__init__(host=host)
@@ -143,4 +143,4 @@ class AuthWithSource:
     auth: Auth
 
     source: str
-    """A file path or environment variable."""
+    """A file path, environment variable, or setting name."""

--- a/wandb/sdk/lib/wbauth/authenticate.py
+++ b/wandb/sdk/lib/wbauth/authenticate.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import os
+import pathlib
 import threading
 
 from wandb import env
 from wandb.errors import AuthenticationError, UsageError, term
 from wandb.sdk import wandb_setup
 
-from . import prompt, wbnetrc
+from . import identity_token_file, prompt, wbnetrc
 from .auth import Auth, AuthApiKey, AuthIdentityTokenFile, AuthWithSource
 from .host_url import HostUrl
 from .settings import set_auth_settings
@@ -170,7 +171,11 @@ def _use_system_auth(
 ) -> Auth | None:
     """Load (or reload) session credentials from external sources.
 
-    Loads credentials from environment variables, .netrc, or global settings.
+    Loads federated-identity credentials from the identity-token environment
+    variable, persisted setting, or default token path. When an API-key
+    environment variable is also configured, federated identity takes
+    precedence and a warning is printed. If no identity token is configured,
+    it loads an API key from the environment, .netrc, or global settings.
     If no credentials are found, the session credentials are unchanged.
 
     Args:
@@ -186,8 +191,17 @@ def _use_system_auth(
     Returns:
         The new credentials, if any.
     """
+    identity_token_auth = _try_identity_token_auth(host=host)
+    api_key = os.getenv(env.API_KEY)
+    if api_key and identity_token_auth:
+        term.termwarn(
+            f"Ignoring {env.API_KEY} because federated identity credentials"
+            + f" are configured from {identity_token_auth.source}."
+        )
+
     auth = (
-        _try_env_auth(host=host)  #
+        identity_token_auth
+        or _try_env_api_key_auth(host=host)
         or wbnetrc.read_netrc_auth_with_source(host=host)
     )
     if auth is None:
@@ -212,41 +226,95 @@ def _use_system_auth(
         return _session_auth
 
 
-def _try_env_auth(*, host: HostUrl) -> AuthWithSource | None:
-    """Returns credentials from environment variables, if set.
+def _try_identity_token_auth(*, host: HostUrl) -> AuthWithSource | None:
+    """Returns identity-token credentials from their configured sources.
 
-    Raises an authentication error if an invalid combination of environment
-    variables is set.
+    The identity-token environment variable takes precedence over the persisted
+    setting, which takes precedence over the standard config-directory path.
+    The latter lets a preceding ``wandb login sso`` be used without setting an
+    environment variable explicitly.
     """
-    api_key = os.getenv(env.API_KEY)
-    identity_token_file = os.getenv(env.IDENTITY_TOKEN_FILE)
+    if path := os.getenv(env.IDENTITY_TOKEN_FILE):
+        return _identity_token_auth(path, host=host, source=env.IDENTITY_TOKEN_FILE)
 
-    if api_key and identity_token_file:
-        raise AuthenticationError(
-            f"Both {env.API_KEY} and {env.IDENTITY_TOKEN_FILE} are set,"
-            + " which is not allowed."
-        )
+    if auth := _try_settings_file_auth(host=host):
+        return auth
 
-    if api_key:
-        try:
-            return AuthWithSource(
-                auth=AuthApiKey(host=host, api_key=api_key),
-                source=env.API_KEY,
-            )
-        except AuthenticationError as e:
-            raise AuthenticationError(f"{env.API_KEY} invalid: {e}") from None
-
-    elif identity_token_file:
-        return AuthWithSource(
-            auth=AuthIdentityTokenFile(
-                host=host,
-                path=identity_token_file,
-                credentials_file=wandb_setup.singleton().settings.credentials_file,
-            ),
-            source=env.IDENTITY_TOKEN_FILE,
-        )
+    default_path = identity_token_file.default_path()
+    if _has_sso_account(default_path, host=host):
+        return _identity_token_auth(default_path, host=host, source=_SSO_SOURCE)
 
     return None
+
+
+_SSO_SOURCE = "your saved SSO credentials"
+
+
+def _identity_token_auth(
+    path: str | pathlib.Path,
+    *,
+    host: HostUrl,
+    source: str,
+) -> AuthWithSource:
+    return AuthWithSource(
+        auth=AuthIdentityTokenFile(
+            host=host,
+            path=str(path),
+            credentials_file=wandb_setup.singleton().settings.credentials_file,
+        ),
+        source=source,
+    )
+
+
+def _has_sso_account(path: pathlib.Path, *, host: HostUrl) -> bool:
+    """Returns whether ``path`` holds `wandb login sso` credentials for ``host``."""
+    try:
+        return identity_token_file.load(path).for_host(host) is not None
+    except identity_token_file.AmbiguousAccountError as e:
+        # Let another configured credential source work instead of blocking
+        # every request until the saved accounts are sorted out.
+        term.termwarn(str(e))
+        return False
+    except identity_token_file.InvalidIdentityTokenFileError:
+        # This may be a bare JWT provisioned outside `wandb login sso`,
+        # which has no host to match automatically.
+        return False
+
+
+def _try_env_api_key_auth(*, host: HostUrl) -> AuthWithSource | None:
+    """Returns API-key credentials from the environment, if set."""
+    api_key = os.getenv(env.API_KEY)
+    if not api_key:
+        return None
+
+    try:
+        return AuthWithSource(
+            auth=AuthApiKey(host=host, api_key=api_key),
+            source=env.API_KEY,
+        )
+    except AuthenticationError as e:
+        raise AuthenticationError(f"{env.API_KEY} invalid: {e}") from None
+
+
+def _try_settings_file_auth(*, host: HostUrl) -> AuthWithSource | None:
+    """Returns identity-token credentials persisted for this host, if any."""
+    settings = wandb_setup.singleton().settings
+
+    if not settings.identity_token_file:
+        return None
+    if not HostUrl(settings.base_url).is_same_url(host):
+        return None
+
+    path = pathlib.Path(settings.identity_token_file)
+    return _identity_token_auth(
+        path,
+        host=host,
+        source=(
+            _SSO_SOURCE
+            if _has_sso_account(path, host=host)
+            else f"an identity token file configured in your settings ({path})"
+        ),
+    )
 
 
 def _use_prompted_auth(

--- a/wandb/sdk/lib/wbauth/identity_token_file.py
+++ b/wandb/sdk/lib/wbauth/identity_token_file.py
@@ -1,0 +1,249 @@
+"""The file that stores federated identity credentials.
+
+`wandb login sso` saves the credentials it obtains here, one entry per
+account, so that logging in to one W&B server does not sign the user out
+of another. wandb-core reads the file to exchange an identity token for
+an access token.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import pathlib
+import tempfile
+from typing import Any
+
+from wandb import env
+from wandb.errors import AuthenticationError, term
+
+from .host_url import HostUrl
+
+VERSION = 1
+
+
+class InvalidIdentityTokenFileError(AuthenticationError):
+    """An identity token file is missing or cannot be understood."""
+
+
+class AmbiguousAccountError(AuthenticationError):
+    """An identity token file has several accounts for one W&B server."""
+
+
+def default_path() -> pathlib.Path:
+    """Returns the identity-token path in the configured W&B config directory."""
+    config_dir = os.getenv(env.CONFIG_DIR, "~/.config/wandb")
+    return pathlib.Path(config_dir).expanduser() / "identity_token.json"
+
+
+@dataclasses.dataclass(frozen=True)
+class Account:
+    """Credentials and metadata needed to refresh an OIDC ID token."""
+
+    id_token: str
+    refresh_token: str
+    token_endpoint: str
+    client_id: str
+    host: str = ""
+    org: str | None = None
+
+    @property
+    def key(self) -> str:
+        """The key under which the account is saved."""
+        host = self.host.rstrip("/")
+        return f"{host}#{self.org}" if self.org else host
+
+    def to_json(self) -> dict[str, str]:
+        """Returns the account as a JSON-serializable object."""
+        contents = {
+            "id_token": self.id_token,
+            "refresh_token": self.refresh_token,
+            "token_endpoint": self.token_endpoint,
+            "client_id": self.client_id,
+        }
+        if self.host:
+            contents["host"] = self.host
+        if self.org:
+            contents["org"] = self.org
+        return contents
+
+    @classmethod
+    def from_json(cls, data: Any) -> Account:
+        """Reads one account from parsed JSON.
+
+        Raises:
+            InvalidIdentityTokenFileError: If the account is malformed.
+        """
+        if not isinstance(data, dict):
+            raise InvalidIdentityTokenFileError("Each account must be an object.")
+
+        values: dict[str, str] = {}
+        for name in (
+            "id_token",
+            "refresh_token",
+            "token_endpoint",
+            "client_id",
+            "host",
+            "org",
+        ):
+            if (value := data.get(name)) is None:
+                continue
+            if not isinstance(value, str):
+                raise InvalidIdentityTokenFileError(
+                    f"The account field {name!r} must be a string."
+                )
+            values[name] = value
+
+        if not values.get("id_token"):
+            raise InvalidIdentityTokenFileError("Each account must have an id_token.")
+
+        return cls(
+            id_token=values["id_token"],
+            refresh_token=values.get("refresh_token", ""),
+            token_endpoint=values.get("token_endpoint", ""),
+            client_id=values.get("client_id", ""),
+            host=values.get("host", ""),
+            org=values.get("org"),
+        )
+
+
+@dataclasses.dataclass
+class Accounts:
+    """Accounts saved by `wandb login sso`.
+
+    Bare JWT files are handled only by wandb-core because they name no W&B
+    server to match here.
+    """
+
+    accounts: dict[str, Account] = dataclasses.field(default_factory=dict)
+
+    active: str | None = None
+    """The key of the account to prefer when several match a W&B server."""
+
+    def for_host(self, host: str | HostUrl) -> Account | None:
+        """Returns the account to use with a W&B server, if any."""
+        if not isinstance(host, HostUrl):
+            host = HostUrl(host)
+
+        matches = {
+            key: account
+            for key, account in self.accounts.items()
+            if account.host and host.is_same_url(account.host)
+        }
+
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return next(iter(matches.values()))
+        if self.active in matches:
+            return matches[self.active]
+
+        orgs = ", ".join(sorted(account.org or "?" for account in matches.values()))
+        raise AmbiguousAccountError(
+            f"Several accounts are saved for {host} ({orgs}), and none of them"
+            + " is selected. Run `wandb login sso` to choose one."
+        )
+
+    def add(self, account: Account) -> None:
+        """Saves an account and selects it for its W&B server."""
+        self.accounts[account.key] = account
+        self.active = account.key
+
+    def remove_host(self, host: str | HostUrl) -> bool:
+        """Forgets every account for a W&B server, reporting whether any went.
+
+        Accounts for other servers are left alone, so signing out of one
+        does not sign the user out of the rest.
+        """
+        if not isinstance(host, HostUrl):
+            host = HostUrl(host)
+
+        removed = [
+            key
+            for key, account in self.accounts.items()
+            if account.host and host.is_same_url(account.host)
+        ]
+        for key in removed:
+            del self.accounts[key]
+        if self.active in removed:
+            self.active = None
+        return bool(removed)
+
+    def save(self, path: str | os.PathLike[str]) -> None:
+        """Atomically writes the accounts to a user-only file."""
+        resolved = pathlib.Path(path).expanduser()
+        resolved.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        contents: dict[str, Any] = {"version": VERSION}
+        if self.active:
+            contents["active"] = self.active
+        contents["accounts"] = {
+            key: account.to_json() for key, account in self.accounts.items()
+        }
+        data = json.dumps(contents, indent=2)
+
+        fd, temp_path = tempfile.mkstemp(
+            dir=resolved.parent, prefix=f".{resolved.name}."
+        )
+        try:
+            with os.fdopen(fd, "w") as file:
+                file.write(data)
+            os.chmod(temp_path, 0o600)
+            os.replace(temp_path, resolved)
+        finally:
+            pathlib.Path(temp_path).unlink(missing_ok=True)
+
+
+def load(path: str | os.PathLike[str]) -> Accounts:
+    """Reads the accounts saved in an identity token file.
+
+    Raises:
+        InvalidIdentityTokenFileError: If the file is missing, or is not an
+            identity token file written by `wandb login sso`.
+    """
+    try:
+        data = json.loads(pathlib.Path(path).read_text())
+    except OSError as e:
+        raise InvalidIdentityTokenFileError(f"Could not read {path}: {e}") from None
+    except json.JSONDecodeError as e:
+        raise InvalidIdentityTokenFileError(f"{path} is not valid JSON: {e}") from None
+
+    if not isinstance(data, dict):
+        raise InvalidIdentityTokenFileError(f"{path} must contain a JSON object.")
+
+    version = data.get("version", VERSION)
+    if not isinstance(version, int) or version > VERSION:
+        raise InvalidIdentityTokenFileError(
+            f"{path} uses file format version {version}, which this version of"
+            + " wandb does not understand. Upgrade wandb to use it."
+        )
+
+    accounts = data.get("accounts")
+    if not isinstance(accounts, dict):
+        raise InvalidIdentityTokenFileError(f"{path} has no accounts object.")
+
+    active = data.get("active")
+    if active is not None and not isinstance(active, str):
+        raise InvalidIdentityTokenFileError(f"{path} has an invalid active account.")
+
+    try:
+        parsed = {key: Account.from_json(value) for key, value in accounts.items()}
+    except InvalidIdentityTokenFileError as e:
+        raise InvalidIdentityTokenFileError(f"{path} is malformed. {e}") from None
+
+    return Accounts(accounts=parsed, active=active)
+
+
+def load_or_empty(path: str | os.PathLike[str]) -> Accounts:
+    """Reads the accounts saved in an identity token file, tolerating problems.
+
+    Warns and returns no accounts if the file exists but cannot be read, so
+    that a login is never blocked by the credentials it is about to replace.
+    """
+    try:
+        return load(path)
+    except InvalidIdentityTokenFileError as e:
+        if pathlib.Path(path).exists():
+            term.termwarn(f"Replacing unreadable saved credentials. {e}")
+        return Accounts()

--- a/wandb/sdk/wandb_login.py
+++ b/wandb/sdk/wandb_login.py
@@ -15,6 +15,7 @@ from wandb.sdk import wandb_setup
 from wandb.sdk.lib import settings_file, wbauth
 from wandb.sdk.lib.deprecation import UNSET, DoNotSet
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.lib.wbauth import identity_token_file
 
 
 def login(
@@ -37,9 +38,12 @@ def login(
     This updates global credentials for the session (affecting all wandb usage
     in the current Python process after this call) and possibly the .netrc file.
 
-    If an identity token file is configured, like through the
-    WANDB_IDENTITY_TOKEN_FILE environment variable, then it is used for the
-    session (federated identity) and no API key is read or saved.
+    If an identity token file is configured through the
+    WANDB_IDENTITY_TOKEN_FILE environment variable or settings file, it is
+    used for the session (federated identity). When neither is configured,
+    W&B uses ``identity_token.json`` from its config directory (usually
+    ``~/.config/wandb``) if it exists. If WANDB_API_KEY is also configured,
+    federated identity is used and W&B prints a warning.
 
     Otherwise, if an explicit API key is provided, it is used and written to
     the system .netrc file. If no key is provided, but the session is already
@@ -102,7 +106,7 @@ def login(
     if host:
         host = host.rstrip("/")
 
-    logged_in, _ = _login(
+    logged_in, api_key = _login(
         key=key,
         relogin=relogin,
         host=host,
@@ -115,22 +119,49 @@ def login(
 
     if not logged_in and not prompt:
         return False
+    if api_key is not None:
+        _forget_sso_credentials(host or global_settings.base_url)
 
     _update_system_settings(
         global_settings.read_system_settings(),
         host=host,
+        clear_identity_token=api_key is not None,
     )
     return logged_in
+
+
+def _forget_sso_credentials(host: str) -> None:
+    """Drops saved SSO credentials for a host after an API-key login.
+
+    Saved SSO credentials outrank an API key, so leaving them in place
+    would silently override the key the user just logged in with.
+    """
+    path = identity_token_file.default_path()
+    try:
+        accounts = identity_token_file.load(path)
+        if not accounts.remove_host(host):
+            return
+        accounts.save(path)
+    except identity_token_file.InvalidIdentityTokenFileError:
+        return
+    except (OSError, ValueError) as e:
+        term.termwarn(f"Failed to remove saved SSO credentials from {path}: {e}")
+        return
+
+    term.termlog(f"Removed the saved SSO credentials for {host}.")
 
 
 def _update_system_settings(
     system_settings: settings_file.SettingsFiles,
     *,
     host: str | None,
+    clear_identity_token: bool,
 ) -> None:
     """Update the user's system settings files."""
     # 'anonymous' is deprecated; we clear it automatically for now.
     system_settings.clear("anonymous", globally=True)
+    if clear_identity_token:
+        system_settings.clear("identity_token_file", globally=True)
 
     if host:
         if host == "https://api.wandb.ai":


### PR DESCRIPTION
## Summary
- add atomic persistence for refreshable federated identity accounts
- resolve saved accounts by host and make identity credentials participate in auth precedence
- remove saved SSO credentials when an explicit API-key login would otherwise be overridden

## Test plan
- [x] `./.venv/bin/python -m pytest tests/unit_tests/test_lib/test_auth.py tests/unit_tests/test_lib/test_auth_identity_token_file.py tests/unit_tests/test_wandb_login.py -q`

## Stack
1. [Core refresh foundation](https://github.com/wandb/wandb/pull/12777)
2. **Python identity account management (this PR)**
3. [PKCE SSO login](https://github.com/wandb/wandb/pull/12779)
4. [Device-code SSO login](https://github.com/wandb/wandb/pull/12780)