### PR TITLE
Add PKCE SSO login to the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ uv.lock
 .nox/
 .nox-wandb/
 
+# CLI debug logs.
+wandb/debug-cli.*.log
+
 # Unit test / coverage reports / linting.
 test-results/
 .pytest_cache/

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -14,6 +14,10 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ## Unreleased
 
+### Added
+
+- `wandb login sso` logs in through your organization's identity provider in a browser, instead of an API key. On multi-tenant SaaS, pass `--org` together with `--issuer` and `--client-id`, which are checked against the identity provider that organization registered before anything is sent to it. Pass `--host` for a dedicated or self-hosted instance, which serves a single organization and resolves it automatically. The resulting credentials are saved to `identity_token.json` in the W&B config directory, one entry per account, and wandb-core refreshes them as they expire.
+
 ### Changed
 
 - Setting both `WANDB_API_KEY` and `WANDB_IDENTITY_TOKEN_FILE` is no longer an error. Federated identity credentials take precedence and W&B warns that the API key is being ignored.

--- a/tests/unit_tests/test_cli_login_sso.py
+++ b/tests/unit_tests/test_cli_login_sso.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import configparser
+import json
+import pathlib
+
+import pytest
+from wandb.apis.public.service_api import AuthenticateResponse, ServiceApi
+from wandb.cli import cli
+from wandb.sdk.lib.wbauth import identity_token_file
+
+
+@pytest.fixture
+def fake_pkce_login(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    calls: list[dict] = []
+
+    def fake_login_with_pkce(host, *, org=None, expected=None):
+        calls.append({"host": host, "org": org, "expected": expected})
+        return identity_token_file.Account(
+            id_token="fake-id-token",
+            refresh_token="fake-refresh-token",
+            token_endpoint="https://idp.example.com/token",
+            client_id="wandb-cli",
+            host=host.url,
+            org=org,
+        )
+
+    monkeypatch.setattr(cli.sso_login, "login_with_pkce", fake_login_with_pkce)
+    monkeypatch.setattr(
+        ServiceApi,
+        "authenticate",
+        lambda self: AuthenticateResponse(),
+    )
+    return calls
+
+
+@pytest.fixture
+def saas_base_url(local_settings):
+    """Points the CLI at multi-tenant SaaS, as a fresh install would be."""
+    system_settings = cli.wandb_setup.singleton().settings.read_system_settings()
+    system_settings.set("base_url", "https://api.wandb.ai", globally=True)
+    system_settings.save()
+    cli.wandb_setup.singleton().settings.update_from_system_settings()
+
+
+def _read_system_settings(path: pathlib.Path) -> dict[str, str]:
+    parser = configparser.ConfigParser()
+    parser.read(path)
+    return dict(parser.items(section="default"))
+
+
+def test_sso_login_help(runner):
+    result = runner.invoke(cli.cli, ["login", "sso", "--help"])
+
+    assert result.exit_code == 0
+    assert "identity provider" in result.output
+    assert "--host" in result.output
+    assert "--org" in result.output
+    assert "--issuer" in result.output
+    assert "--client-id" in result.output
+
+
+def test_login_help_keeps_api_key_options(runner):
+    result = runner.invoke(cli.cli, ["login", "--help"])
+
+    assert result.exit_code == 0
+    assert "--host" in result.output
+    assert "--verify" in result.output
+    assert "--relogin" in result.output
+
+
+def test_sso_login_writes_identity_token_file(
+    runner,
+    local_settings,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+):
+    token_path = tmp_path / "identity_token.json"
+    system_settings = cli.wandb_setup.singleton().settings.read_system_settings()
+    system_settings.set("api_key", "old-api-key", globally=True)
+    system_settings.save()
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--host",
+            "https://my-wandb.example.com",
+            "--identity-token-file",
+            str(token_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(fake_pkce_login) == 1
+    assert fake_pkce_login[0]["host"].is_same_url("https://my-wandb.example.com")
+    assert fake_pkce_login[0]["org"] is None
+
+    assert token_path.exists()
+    assert json.loads(token_path.read_text()) == {
+        "version": 1,
+        "active": "https://my-wandb.example.com",
+        "accounts": {
+            "https://my-wandb.example.com": {
+                "id_token": "fake-id-token",
+                "refresh_token": "fake-refresh-token",
+                "token_endpoint": "https://idp.example.com/token",
+                "client_id": "wandb-cli",
+                "host": "https://my-wandb.example.com",
+            }
+        },
+    }
+
+    system_settings_path = pathlib.Path(
+        cli.wandb_setup.singleton().settings.settings_system
+    )
+    settings = _read_system_settings(system_settings_path)
+    assert "api_key" not in settings
+    assert settings["identity_token_file"] == str(token_path)
+    assert settings["base_url"] == "https://my-wandb.example.com"
+
+
+def test_sso_login_host_names_saas_explicitly(
+    runner,
+    local_settings,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+):
+    # A prior `wandb login sso --host` pinned base_url to a dedicated
+    # instance. --host https://api.wandb.ai is the only way to reach SaaS
+    # from here: it overrides what's configured rather than naming some
+    # third, unrelated deployment kind.
+    system_settings = cli.wandb_setup.singleton().settings.read_system_settings()
+    system_settings.set("base_url", "https://my-wandb.example.com", globally=True)
+    system_settings.save()
+    cli.wandb_setup.singleton().settings.update_from_system_settings()
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--host",
+            "https://api.wandb.ai",
+            "--org",
+            "acme",
+            "--issuer",
+            "https://idp.example.com",
+            "--client-id",
+            "wandb-cli",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(fake_pkce_login) == 1
+    assert fake_pkce_login[0]["host"].is_same_url("https://api.wandb.ai")
+    assert fake_pkce_login[0]["org"] == "acme"
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--org", "acme"],
+        ["--issuer", "https://idp.example.com"],
+        ["--client-id", "wandb-cli"],
+    ],
+)
+def test_sso_login_rejects_host_with_org_flags(runner, local_settings, extra):
+    result = runner.invoke(
+        cli.cli,
+        ["login", "sso", "--host", "https://my-wandb.example.com", *extra],
+    )
+
+    assert result.exit_code == 2
+    assert "resolves its own identity provider" in result.output
+
+
+@pytest.mark.parametrize(
+    ("flags", "missing"),
+    [
+        ([], "--org, --issuer, --client-id"),
+        (["--org", "acme"], "--issuer, --client-id"),
+        (["--org", "acme", "--issuer", "https://idp.example.com"], "--client-id"),
+        (["--org", "acme", "--client-id", "wandb-cli"], "--issuer"),
+        (["--issuer", "https://idp.example.com", "--client-id", "wandb-cli"], "--org"),
+    ],
+)
+def test_sso_login_org_requires_its_identity_provider(
+    runner,
+    saas_base_url,
+    fake_pkce_login: list[dict],
+    flags,
+    missing,
+):
+    result = runner.invoke(cli.cli, ["login", "sso", *flags])
+
+    assert result.exit_code == 2
+    assert f"Pass {missing}" in result.output
+    assert fake_pkce_login == []
+
+
+@pytest.mark.parametrize("pass_host", [False, True])
+def test_sso_login_with_explicit_org_checks_the_named_provider(
+    runner,
+    saas_base_url,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+    pass_host: bool,
+):
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            *(["--host", "https://api.wandb.ai"] if pass_host else []),
+            "--org",
+            "acme",
+            "--issuer",
+            "https://idp.example.com",
+            "--client-id",
+            "wandb-cli",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(fake_pkce_login) == 1
+    assert fake_pkce_login[0]["host"].is_same_url("https://api.wandb.ai")
+    assert fake_pkce_login[0]["org"] == "acme"
+    assert fake_pkce_login[0]["expected"] == cli.sso_login.ExpectedIdp(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+    )
+
+    # The default host is left implicit rather than pinned in the settings.
+    system_settings_path = pathlib.Path(
+        cli.wandb_setup.singleton().settings.settings_system
+    )
+    assert "base_url" not in _read_system_settings(system_settings_path)
+
+
+def test_sso_login_without_flags_skips_org_checks_on_a_dedicated_instance(
+    runner,
+    local_settings,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+):
+    system_settings = cli.wandb_setup.singleton().settings.read_system_settings()
+    system_settings.set("base_url", "https://my-wandb.example.com", globally=True)
+    system_settings.save()
+    cli.wandb_setup.singleton().settings.update_from_system_settings()
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(fake_pkce_login) == 1
+    assert fake_pkce_login[0]["org"] is None
+
+
+def test_sso_login_replaces_unreadable_credentials(
+    runner,
+    local_settings,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+):
+    token_path = tmp_path / "identity_token.json"
+    token_path.write_text("header.payload.signature")
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--host",
+            "https://my-wandb.example.com",
+            "--identity-token-file",
+            str(token_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Replacing unreadable saved credentials" in result.output
+    assert set(json.loads(token_path.read_text())["accounts"]) == {
+        "https://my-wandb.example.com"
+    }
+
+
+def test_sso_login_preserves_existing_file_if_verification_fails(
+    runner,
+    local_settings,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fail_verification(self):
+        raise RuntimeError("verification failed")
+
+    monkeypatch.setattr(ServiceApi, "authenticate", fail_verification)
+    token_path = tmp_path / "identity_token.json"
+    token_path.write_text("existing credentials")
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--host",
+            "https://my-wandb.example.com",
+            "--identity-token-file",
+            str(token_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert token_path.read_text() == "existing credentials"
+
+
+def test_sso_login_fails_if_settings_cannot_be_saved(
+    runner,
+    local_settings,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fail_save(_self):
+        raise cli.settings_file.SaveSettingsError("read-only")
+
+    monkeypatch.setattr(cli.settings_file.SettingsFiles, "save", fail_save)
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--host",
+            "https://my-wandb.example.com",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Logged in to" not in result.output

--- a/tests/unit_tests/test_lib/test_auth_sso_login.py
+++ b/tests/unit_tests/test_lib/test_auth_sso_login.py
@@ -1,0 +1,806 @@
+import base64
+import hashlib
+import http.client
+import json
+import re
+import threading
+import urllib.parse
+import urllib.request
+
+import pytest
+from responses import RequestsMock
+from wandb.errors import AuthenticationError
+from wandb.sdk.lib.wbauth import sso_login
+from wandb.sdk.lib.wbauth.host_url import HostUrl
+from wandb.sdk.lib.wbauth.identity_token_file import Account
+
+
+@pytest.fixture
+def mock_responses():
+    with RequestsMock() as rsps:
+        yield rsps
+
+
+@pytest.fixture(autouse=True)
+def headless(monkeypatch: pytest.MonkeyPatch):
+    """Stands in for a machine with no browser, unless a test says otherwise."""
+    monkeypatch.setattr(sso_login.webbrowser, "open", lambda url: False)
+
+
+def _fake_id_token(**claims: str) -> str:
+    """Builds an unsigned JWT, which is all the login flow reads."""
+
+    def segment(value: dict) -> str:
+        raw = base64.urlsafe_b64encode(json.dumps(value).encode())
+        return raw.rstrip(b"=").decode()
+
+    return f"{segment({'alg': 'none'})}.{segment(claims)}.signature"
+
+
+def test_fetch_idp_config(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com/realms/acme",
+            "client_id": "wandb-cli",
+            "scopes": ["openid", "offline_access"],
+            "auth_methods": ["pkce"],
+        },
+    )
+
+    result = sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+    assert result == sso_login.IdpConfig(
+        issuer="https://idp.example.com/realms/acme",
+        client_id="wandb-cli",
+        scopes=("openid", "offline_access"),
+        auth_methods=("pkce",),
+    )
+
+
+def test_fetch_idp_config_reads_legacy_singular_auth_method(
+    mock_responses: RequestsMock,
+):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com",
+            "client_id": "wandb-cli",
+            "auth_method": "pkce",
+        },
+    )
+
+    result = sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+    assert result.auth_methods == ("pkce",)
+
+
+def test_fetch_idp_config_without_auth_methods(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={"issuer": "https://idp.example.com", "client_id": "wandb-cli"},
+    )
+
+    result = sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+    assert result.auth_methods is None
+
+
+def test_fetch_idp_config_rejects_malformed_auth_methods(
+    mock_responses: RequestsMock,
+):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com",
+            "client_id": "wandb-cli",
+            "auth_methods": "pkce",
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="auth_methods"):
+        sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+
+def test_fetch_idp_config_passes_org(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={"issuer": "https://idp.example.com", "client_id": "wandb-cli"},
+    )
+
+    sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"), org="acme")
+
+    request_url = mock_responses.calls[0].request.url
+    assert urllib.parse.parse_qs(urllib.parse.urlparse(request_url).query) == {
+        "organization": ["acme"]
+    }
+
+
+def test_fetch_idp_config_defaults_scopes(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={"issuer": "https://idp.example.com", "client_id": "wandb-cli"},
+    )
+
+    result = sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+    assert result.scopes == sso_login._DEFAULT_SCOPES
+
+
+def test_fetch_idp_config_not_found(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        status=404,
+    )
+
+    with pytest.raises(AuthenticationError, match="no CLI SSO login configured"):
+        sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"), org="acme")
+
+
+def test_fetch_idp_config_server_error(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        status=500,
+        body="internal error",
+    )
+
+    with pytest.raises(AuthenticationError, match="HTTP 500"):
+        sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+
+def test_fetch_idp_config_invalid_json(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={"issuer": "https://idp.example.com"},  # missing client_id
+    )
+
+    with pytest.raises(AuthenticationError, match="invalid SSO configuration"):
+        sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+
+def test_fetch_idp_config_rejects_insecure_issuer(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={"issuer": "http://idp.example.com", "client_id": "wandb-cli"},
+    )
+
+    with pytest.raises(AuthenticationError, match="must use HTTPS"):
+        sso_login.fetch_idp_config(HostUrl("https://my-wandb.example.com"))
+
+
+@pytest.mark.parametrize(
+    ("url", "allowed"),
+    [
+        ("http://127.0.0.1:8080/token", True),
+        ("http://127.0.0.2:8080/token", True),
+        ("http://localhost:8080/token", True),
+        ("http://[::1]:8080/token", True),
+        ("http://10.0.0.1:8080/token", False),
+        ("http://idp.example.com/token", False),
+    ],
+)
+def test_secure_url_allows_plain_http_only_on_loopback(url: str, allowed: bool):
+    if allowed:
+        assert sso_login._secure_url(url, name="token_endpoint") == url
+    else:
+        with pytest.raises(ValueError, match="must use HTTPS"):
+            sso_login._secure_url(url, name="token_endpoint")
+
+
+def test_login_with_pkce_requires_server_support(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com",
+            "client_id": "wandb-cli",
+            "auth_methods": ["unsupported"],
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="does not offer browser login"):
+        sso_login.login_with_pkce(HostUrl("https://my-wandb.example.com"))
+
+
+def _add_cli_config(mock_responses: RequestsMock, **overrides: object) -> None:
+    mock_responses.add(
+        "GET",
+        "https://api.wandb.ai/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com",
+            "client_id": "wandb-cli",
+            **overrides,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("registered", "named", "message"),
+    [
+        (
+            {"issuer": "https://idp.example.com"},
+            {"issuer": "https://acme-login.example"},
+            "its issuer is 'https://idp.example.com'",
+        ),
+        (
+            {"client_id": "wandb-cli"},
+            {"client_id": "attacker-cli"},
+            "its client ID is 'wandb-cli'",
+        ),
+    ],
+)
+def test_login_with_pkce_aborts_on_a_provider_the_org_did_not_register(
+    mock_responses: RequestsMock,
+    registered: dict,
+    named: dict,
+    message: str,
+):
+    _add_cli_config(mock_responses, **registered)
+    expected = sso_login.ExpectedIdp(
+        **{"issuer": "https://idp.example.com", "client_id": "wandb-cli", **named}
+    )
+
+    with pytest.raises(AuthenticationError, match=re.escape(message)):
+        sso_login.login_with_pkce(
+            HostUrl("https://api.wandb.ai"),
+            org="acme",
+            expected=expected,
+        )
+
+    # Nothing beyond the W&B discovery call was attempted.
+    assert len(mock_responses.calls) == 1
+
+
+def test_check_expected_idp_ignores_a_trailing_slash():
+    sso_login.check_expected_idp(
+        sso_login.IdpConfig(
+            issuer="https://idp.example.com/",
+            client_id="wandb-cli",
+            scopes=("openid",),
+        ),
+        sso_login.ExpectedIdp(
+            issuer="https://idp.example.com",
+            client_id="wandb-cli",
+        ),
+        org="acme",
+    )
+
+
+def test_check_expected_idp_names_both_mismatched_fields():
+    with pytest.raises(AuthenticationError) as excinfo:
+        sso_login.check_expected_idp(
+            sso_login.IdpConfig(
+                issuer="https://idp.example.com",
+                client_id="wandb-cli",
+                scopes=("openid",),
+            ),
+            sso_login.ExpectedIdp(
+                issuer="https://acme-login.example",
+                client_id="attacker-cli",
+            ),
+            org="acme",
+        )
+
+    assert "issuer" in str(excinfo.value)
+    assert "client ID" in str(excinfo.value)
+
+
+def test_discover_oidc(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+        },
+    )
+
+    result = sso_login.discover_oidc("https://idp.example.com")
+
+    assert result == sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+
+def test_discover_oidc_missing_endpoint(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="invalid OIDC discovery document"):
+        sso_login.discover_oidc("https://idp.example.com")
+
+
+def test_discover_oidc_rejects_issuer_mismatch(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://attacker.example.com",
+            "authorization_endpoint": "https://attacker.example.com/authorize",
+            "token_endpoint": "https://attacker.example.com/token",
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="does not match"):
+        sso_login.discover_oidc("https://idp.example.com")
+
+
+def test_discover_oidc_reads_iss_parameter_support(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "authorization_response_iss_parameter_supported": True,
+        },
+    )
+
+    result = sso_login.discover_oidc("https://idp.example.com")
+
+    assert result.iss_parameter_supported
+
+
+def test_discover_oidc_rejects_malformed_iss_parameter_support(
+    mock_responses: RequestsMock,
+):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "authorization_response_iss_parameter_supported": "yes",
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="must be a boolean"):
+        sso_login.discover_oidc("https://idp.example.com")
+
+
+def test_authorization_code_accepts_matching_iss():
+    code = sso_login._authorization_code(
+        {"state": ["s"], "code": ["c"], "iss": ["https://idp.example.com/"]},
+        expected_state="s",
+        expected_issuer="https://idp.example.com",
+    )
+
+    assert code == "c"
+
+
+def test_authorization_code_rejects_foreign_iss():
+    with pytest.raises(AuthenticationError, match="attacker.example.com"):
+        sso_login._authorization_code(
+            {"state": ["s"], "code": ["c"], "iss": ["https://attacker.example.com"]},
+            expected_state="s",
+            expected_issuer="https://idp.example.com",
+        )
+
+
+def test_authorization_code_tolerates_missing_iss():
+    code = sso_login._authorization_code(
+        {"state": ["s"], "code": ["c"]},
+        expected_state="s",
+        expected_issuer="https://idp.example.com",
+    )
+
+    assert code == "c"
+
+
+def test_authorization_code_requires_iss_when_advertised():
+    with pytest.raises(AuthenticationError, match="did not"):
+        sso_login._authorization_code(
+            {"state": ["s"], "code": ["c"]},
+            expected_state="s",
+            expected_issuer="https://idp.example.com",
+            require_issuer=True,
+        )
+
+
+def test_authorization_code_surfaces_idp_error_before_checking_iss():
+    with pytest.raises(AuthenticationError, match="Consent required"):
+        sso_login._authorization_code(
+            {
+                "error": ["access_denied"],
+                "error_description": ["Consent required"],
+                "iss": ["https://attacker.example.com"],
+            },
+            expected_state="s",
+            expected_issuer="https://idp.example.com",
+        )
+
+
+def test_pkce_login_rejects_response_from_another_issuer(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_hitting_callback(
+        monkeypatch,
+        extra_params={"iss": "https://attacker.example.com"},
+    )
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+    with pytest.raises(AuthenticationError, match="attacker.example.com"):
+        sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    # The code never reached the token endpoint.
+    assert len(mock_responses.calls) == 0
+
+
+def test_pkce_login_accepts_response_carrying_its_own_issuer(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_hitting_callback(
+        monkeypatch,
+        extra_params={"iss": "https://idp.example.com"},
+    )
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+        iss_parameter_supported=True,
+    )
+
+    result = sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    assert result.id_token == "fake-id-token"
+
+
+def test_pkce_login_requires_iss_from_an_idp_that_advertises_it(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_hitting_callback(monkeypatch)
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+        iss_parameter_supported=True,
+    )
+
+    with pytest.raises(AuthenticationError, match="identifies itself"):
+        sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    assert len(mock_responses.calls) == 0
+
+
+def test_exchange_code_requires_refresh_token(mock_responses: RequestsMock):
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "id-token"},
+    )
+
+    with pytest.raises(AuthenticationError, match="refresh token"):
+        sso_login._exchange_code(
+            "https://idp.example.com/token",
+            client_id="wandb-cli",
+            code="code",
+            redirect_uri="http://127.0.0.1/callback",
+            code_verifier="verifier",
+            nonce="test-nonce",
+        )
+
+
+def test_exchange_code_does_not_follow_redirect(mock_responses: RequestsMock):
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        status=307,
+        headers={"Location": "https://attacker.example.com/token"},
+    )
+
+    with pytest.raises(AuthenticationError, match="HTTP 307"):
+        sso_login._exchange_code(
+            "https://idp.example.com/token",
+            client_id="wandb-cli",
+            code="code",
+            redirect_uri="http://127.0.0.1/callback",
+            code_verifier="verifier",
+            nonce="test-nonce",
+        )
+
+    assert len(mock_responses.calls) == 1
+
+
+def test_exchange_code_rejects_mismatched_nonce(mock_responses: RequestsMock):
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={
+            "id_token": _fake_id_token(nonce="someone-elses-nonce"),
+            "refresh_token": "refresh-token",
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="a different login request"):
+        sso_login._exchange_code(
+            "https://idp.example.com/token",
+            client_id="wandb-cli",
+            code="code",
+            redirect_uri="http://127.0.0.1/callback",
+            code_verifier="verifier",
+            nonce="test-nonce",
+        )
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        pytest.param({"nonce": "test-nonce"}, id="matching nonce"),
+        # Omitting the claim is out of spec, but common enough that
+        # failing the login over it would do more harm than good.
+        pytest.param({}, id="no nonce"),
+    ],
+)
+def test_exchange_code_accepts_id_token(
+    mock_responses: RequestsMock,
+    claims: dict,
+):
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": _fake_id_token(**claims), "refresh_token": "refresh-token"},
+    )
+
+    account = sso_login._exchange_code(
+        "https://idp.example.com/token",
+        client_id="wandb-cli",
+        code="code",
+        redirect_uri="http://127.0.0.1/callback",
+        code_verifier="verifier",
+        nonce="test-nonce",
+    )
+
+    assert account.refresh_token == "refresh-token"
+
+
+def test_authorization_url_contains_pkce_params():
+    url = sso_login._authorization_url(
+        "https://idp.example.com/authorize",
+        client_id="wandb-cli",
+        redirect_uri="http://127.0.0.1:12345/callback",
+        scopes=("openid", "offline_access"),
+        state="test-state",
+        nonce="test-nonce",
+        code_challenge="test-challenge",
+    )
+
+    parsed = urllib.parse.urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "idp.example.com"
+    assert parsed.path == "/authorize"
+    query = urllib.parse.parse_qs(parsed.query)
+    assert query["response_type"] == ["code"]
+    assert query["client_id"] == ["wandb-cli"]
+    assert query["redirect_uri"] == ["http://127.0.0.1:12345/callback"]
+    assert query["scope"] == ["openid offline_access"]
+    assert query["state"] == ["test-state"]
+    assert query["nonce"] == ["test-nonce"]
+    assert query["code_challenge"] == ["test-challenge"]
+    assert query["code_challenge_method"] == ["S256"]
+
+
+def test_authorization_code_surfaces_idp_error():
+    with pytest.raises(AuthenticationError, match="Consent required"):
+        sso_login._authorization_code(
+            {"error": ["access_denied"], "error_description": ["Consent required"]},
+            expected_state="s",
+        )
+
+
+def test_authorization_code_requires_code():
+    with pytest.raises(
+        AuthenticationError, match="did not include an authorization code"
+    ):
+        sso_login._authorization_code({"state": ["s"]}, expected_state="s")
+
+
+def _simulate_browser_hitting_callback(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    code: str = "fake-auth-code",
+    omit_state: bool = False,
+    extra_params: dict[str, str] | None = None,
+) -> list[str]:
+    """Makes webbrowser.open() redirect to the loopback callback."""
+    opened_urls: list[str] = []
+
+    def fake_open(auth_url: str) -> bool:
+        opened_urls.append(auth_url)
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(auth_url).query)
+        redirect_uri = query["redirect_uri"][0]
+        params = {"code": code, **(extra_params or {})}
+        if not omit_state:
+            params["state"] = query["state"][0]
+
+        def hit_callback() -> None:
+            url = f"{redirect_uri}?{urllib.parse.urlencode(params)}"
+            urllib.request.urlopen(url, timeout=5)
+
+        threading.Thread(target=hit_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(sso_login.webbrowser, "open", fake_open)
+    return opened_urls
+
+
+def test_pkce_login_full_flow(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    opened_urls = _simulate_browser_hitting_callback(monkeypatch, code="fake-auth-code")
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid", "offline_access"),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+    result = sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    assert result == Account(
+        id_token="fake-id-token",
+        refresh_token="fake-refresh-token",
+        token_endpoint="https://idp.example.com/token",
+        client_id="wandb-cli",
+    )
+
+    exchange_body = urllib.parse.parse_qs(mock_responses.calls[0].request.body)
+    assert exchange_body["grant_type"] == ["authorization_code"]
+    assert exchange_body["code"] == ["fake-auth-code"]
+    assert exchange_body["client_id"] == ["wandb-cli"]
+    verifier = exchange_body["code_verifier"][0]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    auth_query = urllib.parse.parse_qs(urllib.parse.urlparse(opened_urls[0]).query)
+    assert auth_query["code_challenge"] == [challenge]
+    assert auth_query["nonce"]
+    redirect_uri = exchange_body["redirect_uri"][0]
+    assert redirect_uri.startswith("http://localhost:")
+
+
+def test_pkce_login_redirects_browser_to_success_page(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    callback_responses: list[http.client.HTTPResponse] = []
+
+    def fake_open(auth_url: str) -> bool:
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(auth_url).query)
+        parsed = urllib.parse.urlsplit(query["redirect_uri"][0])
+        params = {"code": "fake-auth-code", "state": query["state"][0]}
+
+        def hit_callback() -> None:
+            # http.client does not follow redirects, unlike urllib.request.
+            conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=5)
+            conn.request("GET", f"{parsed.path}?{urllib.parse.urlencode(params)}")
+            callback_responses.append(conn.getresponse())
+            conn.close()
+
+        threading.Thread(target=hit_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(sso_login.webbrowser, "open", fake_open)
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid", "offline_access"),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+    result = sso_login.pkce_login(
+        idp_config,
+        discovery,
+        timeout=10,
+        success_redirect_url="https://my-wandb.example.com/cli-login-success",
+    )
+
+    assert result.id_token == "fake-id-token"
+    (response,) = callback_responses
+    assert response.status == 302
+    assert response.getheader("Location") == (
+        "https://my-wandb.example.com/cli-login-success"
+    )
+    # The URL being left carries the authorization code.
+    assert response.getheader("Referrer-Policy") == "no-referrer"
+
+
+def test_pkce_login_rejects_mismatched_state(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_hitting_callback(monkeypatch, omit_state=True)
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+    with pytest.raises(AuthenticationError, match="state did not match"):
+        sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    assert len(mock_responses.calls) == 0
+
+
+def test_pkce_login_times_out_without_a_callback():
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+    with pytest.raises(TimeoutError):
+        sso_login.pkce_login(idp_config, discovery, timeout=0.2)

--- a/wandb/cli/_click_utils.py
+++ b/wandb/cli/_click_utils.py
@@ -1,0 +1,65 @@
+"""Shared click.Group helpers for the wandb CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+
+class DefaultCommandGroup(click.Group):
+    """A group that passes non-command arguments to a default command."""
+
+    def __init__(
+        self,
+        *args: Any,
+        default_cmd: str,
+        usage: str,
+        show_default_options: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.default_cmd = default_cmd
+        self._usage = usage
+        self._show_default_options = show_default_options
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if args and args[0] in ctx.help_option_names:
+            return super().parse_args(ctx, args)
+        if not args or args[0] not in self.commands:
+            args = [self.default_cmd, *args]
+        return super().parse_args(ctx, args)
+
+    def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        formatter.write_usage(ctx.command_path, self._usage)
+
+    def format_options(
+        self,
+        ctx: click.Context,
+        formatter: click.HelpFormatter,
+    ) -> None:
+        if not self._show_default_options:
+            super().format_options(ctx, formatter)
+            return
+
+        options: list[tuple[str, str]] = []
+        seen: set[str] = set()
+
+        def add_records(
+            command: click.Command,
+            command_ctx: click.Context,
+        ) -> None:
+            for param in command.get_params(command_ctx):
+                record = param.get_help_record(command_ctx)
+                if record is not None and record[0] not in seen:
+                    seen.add(record[0])
+                    options.append(record)
+
+        add_records(self, ctx)
+        if command := self.get_command(ctx, self.default_cmd):
+            add_records(command, click.Context(command, parent=ctx))
+
+        if options:
+            with formatter.section("Options"):
+                formatter.write_dl(options)
+        self.format_commands(ctx, formatter)

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -43,8 +43,10 @@ from wandb.sdk.lib import config_util, filesystem, settings_file, wbauth
 from wandb.sdk.lib.filenames import DIFF_FNAME
 from wandb.sdk.lib.hashutil import md5_file_b64
 from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from wandb.sdk.lib.wbauth import identity_token_file, saas, sso_login
 from wandb.sdk.sweeps import SweepNotFoundError
 
+from ._click_utils import DefaultCommandGroup
 from .beta import beta
 from .clean import clean
 from .leet import leet
@@ -274,51 +276,17 @@ def projects(entity, display=True):
     return projects
 
 
-@cli.command(context_settings=CONTEXT)
-@click.argument("key", nargs=-1)
-@click.option(
-    "--cloud",
-    is_flag=True,
-    help="""Log in to the W&B public cloud
-    (https://api.wandb.ai).
-    Mutually exclusive with --host.""",
+@cli.group(
+    cls=DefaultCommandGroup,
+    default_cmd="key",
+    usage="[KEY] | COMMAND [ARGS]...",
+    show_default_options=True,
+    context_settings=CONTEXT,
 )
-@click.option(
-    "--host",
-    "--base-url",
-    default=None,
-    help="""Log in to a specific W&B server
-    instance by URL
-    (e.g. https://my-wandb.example.com).
-    Mutually exclusive with --cloud.""",
-)
-@click.option(
-    "--relogin",
-    default=None,
-    is_flag=True,
-    help="Force a new login prompt, ignoring any existing credentials.",
-)
-@click.option(
-    "--anonymously",
-    default=False,
-    hidden=True,
-    is_flag=True,
-    help="Deprecated. Has no effect and will be removed in a future version.",
-)
-@click.option(
-    "--verify/--no-verify",
-    default=True,
-    is_flag=True,
-    help="""Verify the API key with W&B after storing it. If verification
-    is successful, display the source of the credentials and the
-    default team.""",
-)
-@display_error
-def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):
+def login() -> None:
     """Authenticate your machine with W&B.
 
     Store an API key locally for authenticating with W&B services.
-    By default, credentials are stored without server-side verification.
 
     If no API key is provided as an argument, the command looks for
     credentials in the following order:
@@ -358,7 +326,56 @@ def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):
     To force a new login prompt even if already authenticated:
 
         $ wandb login --relogin
+
+    To log in via your organization's identity provider (SSO) instead of an
+    API key:
+
+        $ wandb login sso
     """
+
+
+@login.command(name="key", context_settings=CONTEXT, hidden=True)
+@click.argument("key", nargs=-1)
+@click.option(
+    "--cloud",
+    is_flag=True,
+    help="""Log in to the W&B public cloud
+    (https://api.wandb.ai).
+    Mutually exclusive with --host.""",
+)
+@click.option(
+    "--host",
+    "--base-url",
+    default=None,
+    help="""Log in to a specific W&B server
+    instance by URL
+    (e.g. https://my-wandb.example.com).
+    Mutually exclusive with --cloud.""",
+)
+@click.option(
+    "--relogin",
+    default=None,
+    is_flag=True,
+    help="Force a new login prompt, ignoring any existing credentials.",
+)
+@click.option(
+    "--anonymously",
+    default=False,
+    hidden=True,
+    is_flag=True,
+    help="Deprecated. Has no effect and will be removed in a future version.",
+)
+@click.option(
+    "--verify/--no-verify",
+    default=True,
+    is_flag=True,
+    help="""Verify the API key with W&B after storing it. If verification
+    is successful, display the source of the credentials and the
+    default team.""",
+)
+@display_error
+def _login_with_key(key, host, cloud, relogin, anonymously, verify, no_offline=False):
+    """Authenticate your machine with W&B using an API key."""
     # TODO: handle no_offline
     if anonymously:
         wandb.termwarn(
@@ -374,8 +391,7 @@ def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):
     if cloud:
         host = "https://api.wandb.ai"
 
-    # A change in click or the test harness means key can be none...
-    key = key[0] if key is not None and len(key) > 0 else None
+    key = key[0] if key else None
     relogin = True if key or relogin else False
 
     global_settings = wandb_setup.singleton().settings
@@ -390,6 +406,150 @@ def login(key, host, cloud, relogin, anonymously, verify, no_offline=False):
         verify=verify,
         referrer="models",
     )
+
+
+@login.command(name="sso", context_settings=CONTEXT)
+@click.option(
+    "--host",
+    default=None,
+    help="""Log in to a specific W&B instance by URL. For a dedicated or
+    self-hosted instance (e.g. https://my-wandb.example.com), this serves a
+    single organization and resolves its own identity provider, so it
+    cannot be combined with --org, --issuer or --client-id. Pass the
+    multi-tenant SaaS URL here to reach it explicitly even when a
+    different host is otherwise configured, e.g. via `wandb login`.""",
+)
+@click.option(
+    "--org",
+    default=None,
+    help="""Log in to a named organization on multi-tenant SaaS. Required
+    together with --issuer and --client-id, which are checked against the
+    identity provider the organization has registered.""",
+)
+@click.option(
+    "--issuer",
+    default=None,
+    help="""The OIDC issuer URL of the organization's identity provider.
+    Used with --org and --client-id.""",
+)
+@click.option(
+    "--client-id",
+    "client_id",
+    default=None,
+    help="""The OAuth client ID the organization registered for CLI login.
+    Used with --org and --issuer.""",
+)
+@click.option(
+    "--identity-token-file",
+    "token_file",
+    default=None,
+    help="""Where to save the credentials obtained from the login.
+    Defaults to identity_token.json in the W&B config directory.""",
+)
+@display_error
+def _login_sso(host, org, issuer, client_id, token_file):
+    """Log in via your organization's identity provider (SSO).
+
+    For W&B SaaS, name your organization and its identity provider, so W&B
+    can check that against what the organization actually registered:
+
+        $ wandb login sso --org ORG --issuer URL --client-id ID
+
+    For a dedicated or self-hosted instance, pass its URL:
+
+        $ wandb login sso --host https://my-wandb-server.example.com
+    """
+    settings = wandb_setup.singleton().settings
+    host_url = (
+        wbauth.HostUrl(host)
+        if host
+        else wbauth.HostUrl(settings.base_url, app_url=settings.app_url)
+    )
+    # Whether --host was passed is irrelevant once resolved: a bare
+    # invocation and `--host https://api.wandb.ai` describe the same
+    # instance, and both need an organization the same way. --host only
+    # matters for overriding an otherwise-configured dedicated instance.
+    is_saas = saas.is_wandb_domain(host_url.url)
+
+    if not is_saas and (org or issuer or client_id):
+        raise click.UsageError(
+            f"{host_url} is a dedicated or self-hosted instance, which serves"
+            " a single organization and resolves its own identity provider."
+            " Drop --org, --issuer and --client-id."
+        )
+    if is_saas and not (org and issuer and client_id):
+        missing = ", ".join(
+            name
+            for name, value in (
+                ("--org", org),
+                ("--issuer", issuer),
+                ("--client-id", client_id),
+            )
+            if not value
+        )
+        raise click.UsageError(
+            f"{host_url} is multi-tenant SaaS. Naming an organization means"
+            " naming its identity provider too, so that W&B can check it"
+            f" against what the organization registered. Pass {missing}."
+        )
+
+    token_path = pathlib.Path(
+        token_file or identity_token_file.default_path()
+    ).expanduser()
+
+    wandb.termlog(f"Logging in to {host_url} via SSO...")
+
+    expected = (
+        sso_login.ExpectedIdp(issuer=issuer, client_id=client_id) if org else None
+    )
+    account = sso_login.login_with_pkce(host_url, org=org, expected=expected)
+
+    # Verify using a staging file holding only the new account, so that a
+    # login that turns out to be unusable leaves saved accounts in place.
+    staged_path = token_path.with_name(f".{token_path.name}.new")
+    staged = identity_token_file.Accounts()
+    staged.add(account)
+    try:
+        staged.save(staged_path)
+        wbauth.AuthIdentityTokenFile(
+            host=host_url,
+            path=str(staged_path),
+            credentials_file=settings.credentials_file,
+        ).verify()
+    finally:
+        staged_path.unlink(missing_ok=True)
+
+    accounts = identity_token_file.load_or_empty(token_path)
+    accounts.add(account)
+    accounts.save(token_path)
+
+    auth = wbauth.AuthIdentityTokenFile(
+        host=host_url,
+        path=str(token_path),
+        credentials_file=settings.credentials_file,
+    )
+    _save_sso_settings(settings, auth)
+    wbauth.use_explicit_auth(auth, source="wandb login sso")
+    wandb.termlog(
+        f"Logged in to {host_url} via SSO. Credentials saved to {token_path}."
+    )
+
+
+def _save_sso_settings(
+    settings: wandb.Settings,
+    auth: wbauth.AuthIdentityTokenFile,
+) -> None:
+    system_settings = settings.read_system_settings()
+    system_settings.clear("api_key", globally=True)
+    system_settings.set("identity_token_file", str(auth.path), globally=True)
+    if auth.host.is_same_url("https://api.wandb.ai"):
+        system_settings.clear("base_url", globally=True)
+    else:
+        system_settings.set("base_url", auth.host.url, globally=True)
+    try:
+        system_settings.save()
+    except settings_file.SaveSettingsError as e:
+        raise Error(f"Failed to save SSO settings: {e}") from e
 
 
 @cli.command(context_settings=CONTEXT)
@@ -2620,7 +2780,7 @@ def start(ctx, port, env, daemon, upgrade, edge):
             if not api_key:
                 # Let the server start before potentially launching a browser
                 time.sleep(2)
-                ctx.invoke(login, host=host)
+                ctx.invoke(_login_with_key, host=host)
 
 
 @server.command(context_settings=RUN_CONTEXT)

--- a/wandb/cli/leet.py
+++ b/wandb/cli/leet.py
@@ -12,7 +12,6 @@ import pathlib
 import subprocess
 import sys
 import urllib.parse
-from typing import Any
 
 import click
 from typing_extensions import Never
@@ -24,34 +23,13 @@ from wandb.sdk import wandb_setup
 from wandb.sdk.lib import wbauth
 from wandb.util import get_core_path
 
-
-class DefaultCommandGroup(click.Group):
-    """A click Group that falls through to a default command.
-
-    If the first argument isn't a recognized subcommand or a help flag,
-    the default command is invoked with all arguments passed through.
-    This allows backward-compatible CLIs where `cmd [path]` and
-    `cmd run [path]` are equivalent.
-    """
-
-    def __init__(self, *args: Any, default_cmd: str = "run", **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self.default_cmd = default_cmd
-
-    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        if args and args[0] in ctx.help_option_names:
-            return super().parse_args(ctx, args)
-        if not args or args[0].startswith("-") or args[0] not in self.commands:
-            args = [self.default_cmd, *args]
-        return super().parse_args(ctx, args)
-
-    def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        formatter.write_usage(ctx.command_path, "[PATH] | COMMAND [ARGS]...")
+from ._click_utils import DefaultCommandGroup
 
 
 @click.group(
     cls=DefaultCommandGroup,
     default_cmd="run",
+    usage="[PATH] | COMMAND [ARGS]...",
     invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )

--- a/wandb/sdk/lib/wbauth/sso_login.py
+++ b/wandb/sdk/lib/wbauth/sso_login.py
@@ -1,0 +1,685 @@
+"""Browser-based OIDC login for `wandb login sso`."""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import hashlib
+import http.server
+import ipaddress
+import json
+import secrets
+import time
+import urllib.parse
+import webbrowser
+from collections.abc import Sequence
+
+import requests
+
+from wandb import env
+from wandb.errors import AuthenticationError, term
+
+from .host_url import HostUrl
+from .identity_token_file import Account
+
+_DEFAULT_SCOPES = ("openid", "profile", "email", "offline_access")
+_LOGIN_TIMEOUT_SECONDS = 300.0
+
+
+@dataclasses.dataclass(frozen=True)
+class IdpConfig:
+    """IdP connection details returned by `GET /oidc/cli_config`."""
+
+    issuer: str
+    client_id: str
+    scopes: tuple[str, ...]
+
+    auth_methods: tuple[str, ...] | None = None
+    """The login flows the W&B server says the client supports.
+
+    None if the server did not say, in which case the CLI attempts whichever
+    flow the user asked for and lets the IdP reject it.
+    """
+
+
+@dataclasses.dataclass(frozen=True)
+class ExpectedIdp:
+    """The identity provider a user named on the command line."""
+
+    issuer: str
+    client_id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class OidcDiscovery:
+    """OIDC endpoints used by the login flows."""
+
+    authorization_endpoint: str
+    token_endpoint: str
+
+    iss_parameter_supported: bool = False
+    """Whether the IdP promises to identify itself in authorization responses.
+
+    When true, a response without an `iss` parameter is rejected (RFC 9207
+    section 2.4). When false the parameter is still checked if it arrives,
+    since an IdP may send it without advertising it.
+    """
+
+
+def _parse_idp_config(body: object) -> IdpConfig:
+    if not isinstance(body, dict):
+        raise TypeError("response must be an object")
+
+    issuer = _secure_url(body["issuer"], name="issuer", allow_query=False)
+    client_id = body["client_id"]
+    scopes = body.get("scopes") or _DEFAULT_SCOPES
+    if not isinstance(client_id, str) or not client_id:
+        raise TypeError("client_id must be a non-empty string")
+    if (
+        not isinstance(scopes, (list, tuple))
+        or not scopes
+        or not all(isinstance(scope, str) and scope for scope in scopes)
+    ):
+        raise TypeError("scopes must be a non-empty list of strings")
+    if "openid" not in scopes:
+        raise ValueError("scopes must include 'openid'")
+
+    return IdpConfig(
+        issuer=issuer,
+        client_id=client_id,
+        scopes=tuple(scopes),
+        auth_methods=_parse_auth_methods(body),
+    )
+
+
+def _parse_auth_methods(body: dict) -> tuple[str, ...] | None:
+    """Reads the advertised login flows, or None if the server omitted them."""
+    methods = body.get("auth_methods")
+    if methods is None:
+        # Older servers advertised a single method under a singular key.
+        if (method := body.get("auth_method")) is None:
+            return None
+        methods = [method]
+
+    if (
+        not isinstance(methods, (list, tuple))
+        or not methods
+        or not all(isinstance(method, str) and method for method in methods)
+    ):
+        raise TypeError("auth_methods must be a non-empty list of strings")
+
+    return tuple(methods)
+
+
+def _parse_discovery(body: object, *, issuer: str) -> OidcDiscovery:
+    if not isinstance(body, dict):
+        raise TypeError("response must be an object")
+
+    discovered_issuer = _secure_url(
+        body["issuer"], name="discovery issuer", allow_query=False
+    )
+    if discovered_issuer.rstrip("/") != issuer:
+        raise ValueError(
+            f"discovery issuer {discovered_issuer!r} does not match {issuer!r}"
+        )
+
+    iss_supported = body.get("authorization_response_iss_parameter_supported", False)
+    if not isinstance(iss_supported, bool):
+        raise TypeError(
+            "authorization_response_iss_parameter_supported must be a boolean"
+        )
+
+    return OidcDiscovery(
+        authorization_endpoint=_secure_url(
+            body["authorization_endpoint"], name="authorization_endpoint"
+        ),
+        token_endpoint=_secure_url(body["token_endpoint"], name="token_endpoint"),
+        iss_parameter_supported=iss_supported,
+    )
+
+
+def fetch_idp_config(host: HostUrl, *, org: str | None = None) -> IdpConfig:
+    """Fetches the host's CLI SSO configuration."""
+    try:
+        _secure_url(host.url, name="W&B host")
+    except (TypeError, ValueError) as e:
+        raise AuthenticationError(str(e)) from None
+    url = f"{host.url}/oidc/cli_config"
+
+    try:
+        response = requests.get(
+            url,
+            params={"organization": org} if org else None,
+            timeout=env.get_http_timeout(10),
+            allow_redirects=False,
+        )
+    except requests.RequestException as e:
+        raise AuthenticationError(f"Failed to reach {host}: {e}") from None
+
+    if response.status_code == 404:
+        raise AuthenticationError(
+            f"{host} has no CLI SSO login configured"
+            + (f" for organization {org!r}" if org else "")
+            + ". Ask a W&B admin to configure it under Org Settings ->"
+            + " Authentication -> 'CLI login (SSO)', or pass --org if you"
+            + " belong to more than one organization."
+        )
+    if response.status_code != 200:
+        raise AuthenticationError(
+            f"Failed to fetch the SSO configuration from {host}:"
+            f" HTTP {response.status_code}: {response.text}"
+        )
+
+    try:
+        return _parse_idp_config(response.json())
+    except (ValueError, KeyError, TypeError) as e:
+        raise AuthenticationError(
+            f"{host} returned an invalid SSO configuration: {e}"
+        ) from None
+
+
+def discover_oidc(issuer: str) -> OidcDiscovery:
+    """Fetches and validates the IdP's OIDC discovery document."""
+    issuer = _secure_url(issuer, name="issuer", allow_query=False).rstrip("/")
+    url = f"{issuer}/.well-known/openid-configuration"
+
+    try:
+        response = requests.get(
+            url,
+            timeout=env.get_http_timeout(10),
+            allow_redirects=False,
+        )
+    except requests.RequestException as e:
+        raise AuthenticationError(
+            f"Failed to reach the identity provider at {issuer}: {e}"
+        ) from None
+
+    if response.status_code != 200:
+        raise AuthenticationError(
+            f"Failed to fetch the OIDC discovery document from {issuer}:"
+            f" HTTP {response.status_code}: {response.text}"
+        )
+
+    try:
+        return _parse_discovery(response.json(), issuer=issuer)
+    except (ValueError, KeyError, TypeError) as e:
+        raise AuthenticationError(
+            f"{issuer} returned an invalid OIDC discovery document: {e}"
+        ) from None
+
+
+def login_with_pkce(
+    host: HostUrl,
+    *,
+    org: str | None = None,
+    expected: ExpectedIdp | None = None,
+) -> Account:
+    """Runs discovery and an Authorization Code + PKCE login."""
+    idp_config = fetch_idp_config(host, org=org)
+    if expected:
+        check_expected_idp(idp_config, expected, org=org)
+    _check_auth_method(
+        idp_config,
+        "pkce",
+        f"{host} does not offer browser login.",
+    )
+
+    discovery = discover_oidc(idp_config.issuer)
+    return dataclasses.replace(
+        pkce_login(
+            idp_config,
+            discovery,
+            success_redirect_url=f"{host.url}/cli-login-success",
+        ),
+        host=host.url,
+        org=org,
+    )
+
+
+def _check_auth_method(idp_config: IdpConfig, method: str, message: str) -> None:
+    """Fails early if the server says it does not offer a login flow."""
+    if idp_config.auth_methods is not None and method not in idp_config.auth_methods:
+        raise AuthenticationError(message)
+
+
+def check_expected_idp(
+    idp_config: IdpConfig,
+    expected: ExpectedIdp,
+    *,
+    org: str | None,
+) -> None:
+    """Aborts unless the organization's registered IdP is the one named.
+
+    This runs before any browser opens or any device code is printed. It
+    catches the phish that keeps a real organization name and swaps in a
+    lookalike issuer, which is the half of a pasted command that a user
+    has no way to recognize as wrong.
+    """
+    mismatched = [
+        f"its {name} is {actual!r}, not {wanted!r}"
+        for name, actual, wanted in (
+            ("issuer", idp_config.issuer.rstrip("/"), expected.issuer.rstrip("/")),
+            ("client ID", idp_config.client_id, expected.client_id),
+        )
+        if actual != wanted
+    ]
+    if not mismatched:
+        return
+
+    raise AuthenticationError(
+        f"The identity provider registered for organization {org!r} is not the"
+        f" one you named: {'; '.join(mismatched)}. Nothing was sent to either"
+        " provider. If you did not write this command yourself, treat it as a"
+        " phishing attempt."
+    )
+
+
+def pkce_login(
+    idp_config: IdpConfig,
+    discovery: OidcDiscovery,
+    *,
+    timeout: float = _LOGIN_TIMEOUT_SECONDS,
+    success_redirect_url: str | None = None,
+) -> Account:
+    """Performs an Authorization Code + PKCE login on a loopback server.
+
+    If `success_redirect_url` is set, a successful callback redirects the
+    browser there (the W&B app's CLI-login landing page); otherwise, and on
+    error callbacks, a minimal inline notice page is served.
+    """
+    code_verifier, code_challenge = _new_pkce_pair()
+    state = secrets.token_urlsafe(24)
+    nonce = secrets.token_urlsafe(24)
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+    server.callback_params = None  # type: ignore[attr-defined]
+    server.success_redirect_url = success_redirect_url  # type: ignore[attr-defined]
+    server.expected_state = state  # type: ignore[attr-defined]
+    try:
+        port = server.server_address[1]
+        # The server binds to the IP literal, but the redirect URI sent to
+        # the IdP says "localhost". RFC 8252 section 7.3 requires IdPs to
+        # ignore the port of a loopback redirect URI, so that a client can
+        # register once and pick an ephemeral port per login, and section
+        # 8.3 recommends the IP literal over "localhost". Entra ID (Azure
+        # AD) only ignores the port for the literal "localhost" host, though,
+        # so an ephemeral-port flow cannot work there with "127.0.0.1".
+        # Every other mainstream IdP accepts "localhost" too, and browsers
+        # resolve it to the loopback interface we just bound. This matches
+        # what gcloud and the Azure CLI send.
+        redirect_uri = f"http://localhost:{port}/callback"
+
+        auth_url = _authorization_url(
+            discovery.authorization_endpoint,
+            client_id=idp_config.client_id,
+            redirect_uri=redirect_uri,
+            scopes=idp_config.scopes,
+            state=state,
+            nonce=nonce,
+            code_challenge=code_challenge,
+        )
+
+        if _try_open_browser(auth_url):
+            term.termlog(f"Opened {auth_url} in your browser.")
+        else:
+            term.termlog(f"Open this URL to log in:\n{auth_url}")
+
+        params = _wait_for_callback(server, timeout=timeout)
+    finally:
+        server.server_close()
+
+    code = _authorization_code(
+        params,
+        expected_state=state,
+        expected_issuer=idp_config.issuer,
+        require_issuer=discovery.iss_parameter_supported,
+    )
+
+    return _exchange_code(
+        discovery.token_endpoint,
+        client_id=idp_config.client_id,
+        code=code,
+        redirect_uri=redirect_uri,
+        code_verifier=code_verifier,
+        nonce=nonce,
+    )
+
+
+def _try_open_browser(url: str) -> bool:
+    """Tries to open a URL in a local browser."""
+    try:
+        return webbrowser.open(url)
+    except webbrowser.Error:
+        return False
+
+
+def _new_pkce_pair() -> tuple[str, str]:
+    """Returns a (code_verifier, code_challenge) pair, per RFC 7636 section 4."""
+    code_verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return code_verifier, code_challenge
+
+
+def _authorization_url(
+    endpoint: str,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    scopes: Sequence[str],
+    state: str,
+    nonce: str,
+    code_challenge: str,
+) -> str:
+    """Builds the IdP authorization URL for the loopback PKCE flow."""
+    parsed = urllib.parse.urlsplit(endpoint)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.extend(
+        {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(scopes),
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }.items()
+    )
+    return urllib.parse.urlunsplit(parsed._replace(query=urllib.parse.urlencode(query)))
+
+
+_CALLBACK_HTML = """\
+<!DOCTYPE html>
+<title>W&B SSO login</title>
+<body style="font-family: sans-serif; text-align: center; margin-top: 15%">
+<h2>Authentication response received.</h2>
+<p>Return to the terminal to finish logging in.</p>
+</body>
+"""
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Handles the IdP's redirect to the PKCE loopback server."""
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+
+        if parsed.path != "/callback":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        params = urllib.parse.parse_qs(parsed.query)
+        self.server.callback_params = params  # type: ignore[attr-defined]
+
+        redirect_url = getattr(self.server, "success_redirect_url", None)
+        looks_successful = (
+            "error" not in params
+            and params.get("code")
+            and params.get("state") == [getattr(self.server, "expected_state", None)]
+        )
+        if redirect_url and looks_successful:
+            self.send_response(302)
+            self.send_header("Location", redirect_url)
+            self.send_header("Cache-Control", "no-store")
+            # The URL being redirected away from carries the authorization
+            # code, so it must not travel to the W&B app as a referrer.
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.end_headers()
+            return
+
+        body = _CALLBACK_HTML.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def _wait_for_callback(
+    server: http.server.HTTPServer,
+    *,
+    timeout: float,
+) -> dict[str, list[str]]:
+    """Blocks until the loopback server receives the IdP's redirect."""
+    deadline = time.monotonic() + timeout
+
+    while getattr(server, "callback_params", None) is None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                "Timed out waiting for the SSO login to complete in the browser."
+            )
+        server.timeout = remaining
+        server.handle_request()
+
+    return server.callback_params  # type: ignore[attr-defined]
+
+
+def _authorization_code(
+    params: dict[str, list[str]],
+    *,
+    expected_state: str,
+    expected_issuer: str | None = None,
+    require_issuer: bool = False,
+) -> str:
+    """Extracts and validates the authorization code."""
+    # Checked before the state and the issuer so that an IdP that rejects
+    # the login says why, rather than being reported as a state mismatch:
+    # RFC 6749 asks the IdP to echo the state on errors, but not every one
+    # does, and an error response carries no code to be confused about.
+    if error := params.get("error", [None])[0]:
+        description = params.get("error_description", [error])[0]
+        raise AuthenticationError(f"SSO login failed: {description}")
+
+    if (state := params.get("state", [None])[0]) != expected_state:
+        raise AuthenticationError(
+            "SSO login failed: the redirect's state did not match the"
+            " request. Please try again." + (f" (got {state!r})" if state else "")
+        )
+
+    if expected_issuer:
+        _check_response_issuer(
+            params,
+            expected=expected_issuer,
+            required=require_issuer,
+        )
+
+    if not (code := params.get("code", [None])[0]):
+        raise AuthenticationError(
+            "SSO login failed: the identity provider's redirect did not"
+            " include an authorization code."
+        )
+
+    return code
+
+
+def _check_response_issuer(
+    params: dict[str, list[str]],
+    *,
+    expected: str,
+    required: bool,
+) -> None:
+    """Rejects an authorization response from an unexpected IdP (RFC 9207).
+
+    Every organization brings its own authorization server, so this client
+    talks to many of them. Without this check, a code minted by one of them
+    could be redeemed at another's token endpoint -- the mix-up attack the
+    `iss` parameter exists to stop.
+    """
+    if (issuer := params.get("iss", [None])[0]) is None:
+        if required:
+            raise AuthenticationError(
+                "SSO login failed: the identity provider says it identifies"
+                " itself in authorization responses, but this one did not."
+                " Please try again."
+            )
+        return
+
+    if issuer.rstrip("/") != expected.rstrip("/"):
+        raise AuthenticationError(
+            f"SSO login failed: the redirect came from {issuer!r}, but the"
+            f" login was sent to {expected!r}."
+        )
+
+
+def _parse_token_response(body: object) -> tuple[str, str]:
+    if not isinstance(body, dict):
+        raise TypeError("response must be an object")
+
+    id_token = body["id_token"]
+    refresh_token = body["refresh_token"]
+    if not isinstance(id_token, str) or not id_token:
+        raise TypeError("id_token must be a non-empty string")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        raise TypeError("refresh_token must be a non-empty string")
+    return id_token, refresh_token
+
+
+def _exchange_code(
+    token_endpoint: str,
+    *,
+    client_id: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    nonce: str,
+) -> Account:
+    """Exchanges an authorization code for tokens (RFC 6749 section 4.1.3)."""
+    try:
+        response = requests.post(
+            token_endpoint,
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "code_verifier": code_verifier,
+            },
+            timeout=env.get_http_timeout(10),
+            allow_redirects=False,
+        )
+    except requests.RequestException as e:
+        raise AuthenticationError(
+            f"Failed to reach the identity provider at {token_endpoint}: {e}"
+        ) from None
+
+    if response.status_code != 200:
+        raise AuthenticationError(
+            f"The identity provider rejected the login: {_token_error_detail(response)}"
+        )
+
+    account = _token_set(response, token_endpoint=token_endpoint, client_id=client_id)
+    _check_nonce(account.id_token, expected=nonce)
+    return account
+
+
+def _token_set(
+    response: requests.Response,
+    *,
+    token_endpoint: str,
+    client_id: str,
+) -> Account:
+    """Reads a successful token response into an account."""
+    try:
+        id_token, refresh_token = _parse_token_response(response.json())
+    except (ValueError, KeyError, TypeError) as e:
+        raise AuthenticationError(
+            "The identity provider did not return both an ID token and a refresh"
+            f" token. Ensure the client allows offline access. ({e})"
+        ) from None
+
+    return Account(
+        id_token=id_token,
+        refresh_token=refresh_token,
+        token_endpoint=token_endpoint,
+        client_id=client_id,
+    )
+
+
+def _check_nonce(id_token: str, *, expected: str) -> None:
+    """Rejects an ID token minted for a different authorization request.
+
+    Only a mismatch is an error. An IdP that omits the claim despite being
+    sent a nonce is out of spec (OpenID Connect Core section 3.1.3.7) but
+    common enough that failing the login over it would do more harm than
+    the replay this guards against, which TLS to the token endpoint and
+    the PKCE verifier already make impractical.
+    """
+    found = _jwt_claims(id_token).get("nonce")
+    if found is not None and not secrets.compare_digest(
+        str(found).encode(), expected.encode()
+    ):
+        raise AuthenticationError(
+            "SSO login failed: the identity provider returned an ID token"
+            " for a different login request. Please try again."
+        )
+
+
+def _jwt_claims(token: str) -> dict[str, object]:
+    """Decodes a JWT's payload, with no signature verification.
+
+    The token arrives over TLS from the token endpoint in response to this
+    process's own code and verifier, so its authenticity comes from the
+    transport; this only reads back what was asked for.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    try:
+        payload = base64.urlsafe_b64decode(parts[1] + "=" * (-len(parts[1]) % 4))
+        claims = json.loads(payload)
+    except (ValueError, TypeError):
+        return {}
+    return claims if isinstance(claims, dict) else {}
+
+
+def _token_error_detail(response: requests.Response) -> str:
+    """Summarizes a failed OAuth token response for an error message."""
+    detail = f"HTTP {response.status_code}"
+    try:
+        body = response.json()
+        description = body.get("error_description") or body.get("error")
+    except (ValueError, TypeError, AttributeError):
+        return detail
+    if isinstance(description, str):
+        detail += f": {description}"
+    return detail
+
+
+def _secure_url(value: object, *, name: str, allow_query: bool = True) -> str:
+    """Validates an OAuth endpoint, allowing HTTP only for local development."""
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"{name} must be a non-empty string")
+
+    parsed = urllib.parse.urlsplit(value)
+    if not parsed.netloc or parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"{name} must be an absolute HTTP(S) URL")
+    if parsed.scheme != "https" and not _is_loopback(parsed.hostname):
+        raise ValueError(f"{name} must use HTTPS")
+    if parsed.username or parsed.password or parsed.fragment:
+        raise ValueError(f"{name} must not include credentials or a fragment")
+    if not allow_query and parsed.query:
+        raise ValueError(f"{name} must not include a query")
+    return value
+
+
+def _is_loopback(hostname: str | None) -> bool:
+    """Returns whether a URL's host never leaves this machine.
+
+    This matches wandb-core's check, so that an endpoint the CLI accepts
+    during local development is one wandb-core will accept too.
+    """
+    if not hostname:
+        return False
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False


### PR DESCRIPTION
## Summary
- add OIDC discovery and Authorization Code flow with PKCE
- expose `wandb login sso` for SaaS organizations and dedicated or self-hosted instances
- preserve the existing `wandb login` API-key interface through a default subcommand group

An organization name alone never selects an identity provider, so a pasted command can't send a user to an attacker's IdP under a name they recognize. There are two ways to name an organization:

**Click it.** Bare `wandb login sso` on multi-tenant SaaS opens a W&B page listing the organizations the signed-in user actually belongs to, and the CLI uses whichever one they click, so the name comes back from the server. The callback is bound to the attempt that opened it: the state carries the loopback port, the page derives `http://127.0.0.1:<port>/callback` from the state rather than from a redirect target in its query string, and a state mismatch is rejected.

**Spell it out.** `--org` requires `--issuer` and `--client-id`. The CLI fetches `GET /oidc/cli_config?organization=<org>` and compares both against what was supplied, aborting with a message naming the mismatched field before any browser opens.

`--host` is the dedicated discriminator and resolves its own organization server-side; a bare invocation against a configured dedicated `base_url` behaves the same way rather than opening a pointless one-item picker.

The authorization response is also checked against RFC 9207's `iss` parameter. That is a separate question from the pre-flight comparison above: the comparison asks whether this is the issuer the organization registered, `iss` asks whether the server that answered is the one the CLI dialed. Both matter for a client that talks to a different authorization server per organization.

The picker page and its membership query are the matching `wandb/core` work; this PR is the CLI half of that contract.

## Test plan
- [x] `./.venv/bin/python -m pytest tests/unit_tests/test_cli_login_sso.py tests/unit_tests/test_lib/test_auth_sso_login.py -q`
- [ ] End to end against the picker page once the `wandb/core` side lands

## Stack
1. [Core refresh foundation](https://github.com/wandb/wandb/pull/12777)
2. [Python identity account management](https://github.com/wandb/wandb/pull/12778)
3. **PKCE SSO login (this PR)**
4. [Device-code SSO login](https://github.com/wandb/wandb/pull/12780)