### PR TITLE
Add device-code SSO login to the CLI

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Added
 
-- `wandb login sso` logs in through your organization's identity provider in a browser, instead of an API key. On multi-tenant SaaS, pass `--org` together with `--issuer` and `--client-id`, which are checked against the identity provider that organization registered before anything is sent to it. Pass `--host` for a dedicated or self-hosted instance, which serves a single organization and resolves it automatically. The resulting credentials are saved to `identity_token.json` in the W&B config directory, one entry per account, and wandb-core refreshes them as they expire.
+- `wandb login sso` logs in through your organization's identity provider in a browser, instead of an API key. On multi-tenant SaaS, pass `--org` together with `--issuer` and `--client-id`, which are checked against the identity provider that organization registered before anything is sent to it. Pass `--host` for a dedicated or self-hosted instance, which serves a single organization and resolves it automatically. On a machine with no browser, `--use-device-code` prints a URL and a code to approve from a phone or another computer. The resulting credentials are saved to `identity_token.json` in the W&B config directory, one entry per account, and wandb-core refreshes them as they expire.
 
 ### Changed
 

--- a/tests/unit_tests/test_cli_login_sso.py
+++ b/tests/unit_tests/test_cli_login_sso.py
@@ -35,6 +35,34 @@ def fake_pkce_login(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
 
 
 @pytest.fixture
+def fake_device_code_login(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    calls: list[dict] = []
+
+    def fake_login_with_device_code(host, *, org=None, expected=None):
+        calls.append({"host": host, "org": org, "expected": expected})
+        return identity_token_file.Account(
+            id_token="fake-device-id-token",
+            refresh_token="fake-device-refresh-token",
+            token_endpoint="https://idp.example.com/token",
+            client_id="wandb-cli",
+            host=host.url,
+            org=org,
+        )
+
+    monkeypatch.setattr(
+        cli.sso_login,
+        "login_with_device_code",
+        fake_login_with_device_code,
+    )
+    monkeypatch.setattr(
+        ServiceApi,
+        "authenticate",
+        lambda self: AuthenticateResponse(),
+    )
+    return calls
+
+
+@pytest.fixture
 def saas_base_url(local_settings):
     """Points the CLI at multi-tenant SaaS, as a fresh install would be."""
     system_settings = cli.wandb_setup.singleton().settings.read_system_settings()
@@ -58,6 +86,7 @@ def test_sso_login_help(runner):
     assert "--org" in result.output
     assert "--issuer" in result.output
     assert "--client-id" in result.output
+    assert "--use-device-code" in result.output
 
 
 def test_login_help_keeps_api_key_options(runner):
@@ -119,6 +148,34 @@ def test_sso_login_writes_identity_token_file(
     assert "api_key" not in settings
     assert settings["identity_token_file"] == str(token_path)
     assert settings["base_url"] == "https://my-wandb.example.com"
+
+
+def test_sso_login_uses_device_code(
+    runner,
+    local_settings,
+    tmp_path: pathlib.Path,
+    fake_device_code_login: list[dict],
+    fake_pkce_login: list[dict],
+):
+    token_path = tmp_path / "identity_token.json"
+
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--host",
+            "https://my-wandb.example.com",
+            "--use-device-code",
+            "--identity-token-file",
+            str(token_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_pkce_login == []
+    assert len(fake_device_code_login) == 1
+    assert fake_device_code_login[0]["host"].is_same_url("https://my-wandb.example.com")
 
 
 def test_sso_login_host_names_saas_explicitly(
@@ -267,6 +324,36 @@ def test_sso_login_without_flags_skips_org_checks_on_a_dedicated_instance(
     assert result.exit_code == 0, result.output
     assert len(fake_pkce_login) == 1
     assert fake_pkce_login[0]["org"] is None
+
+
+def test_sso_login_uses_device_code_with_an_explicit_org(
+    runner,
+    saas_base_url,
+    tmp_path: pathlib.Path,
+    fake_device_code_login: list[dict],
+    fake_pkce_login: list[dict],
+):
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--org",
+            "acme",
+            "--issuer",
+            "https://idp.example.com",
+            "--client-id",
+            "wandb-cli",
+            "--use-device-code",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_pkce_login == []
+    assert len(fake_device_code_login) == 1
+    assert fake_device_code_login[0]["org"] == "acme"
 
 
 def test_sso_login_replaces_unreadable_credentials(

--- a/tests/unit_tests/test_lib/test_auth_sso_login.py
+++ b/tests/unit_tests/test_lib/test_auth_sso_login.py
@@ -45,7 +45,7 @@ def test_fetch_idp_config(mock_responses: RequestsMock):
             "issuer": "https://idp.example.com/realms/acme",
             "client_id": "wandb-cli",
             "scopes": ["openid", "offline_access"],
-            "auth_methods": ["pkce"],
+            "auth_methods": ["pkce", "device_code"],
         },
     )
 
@@ -55,7 +55,7 @@ def test_fetch_idp_config(mock_responses: RequestsMock):
         issuer="https://idp.example.com/realms/acme",
         client_id="wandb-cli",
         scopes=("openid", "offline_access"),
-        auth_methods=("pkce",),
+        auth_methods=("pkce", "device_code"),
     )
 
 
@@ -204,7 +204,7 @@ def test_login_with_pkce_requires_server_support(mock_responses: RequestsMock):
         json={
             "issuer": "https://idp.example.com",
             "client_id": "wandb-cli",
-            "auth_methods": ["unsupported"],
+            "auth_methods": ["device_code"],
         },
     )
 
@@ -261,6 +261,24 @@ def test_login_with_pkce_aborts_on_a_provider_the_org_did_not_register(
     assert len(mock_responses.calls) == 1
 
 
+def test_login_with_device_code_aborts_on_an_unregistered_provider(
+    mock_responses: RequestsMock,
+):
+    _add_cli_config(mock_responses)
+
+    with pytest.raises(AuthenticationError, match="phishing"):
+        sso_login.login_with_device_code(
+            HostUrl("https://api.wandb.ai"),
+            org="acme",
+            expected=sso_login.ExpectedIdp(
+                issuer="https://acme-login.example",
+                client_id="wandb-cli",
+            ),
+        )
+
+    assert len(mock_responses.calls) == 1
+
+
 def test_check_expected_idp_ignores_a_trailing_slash():
     sso_login.check_expected_idp(
         sso_login.IdpConfig(
@@ -312,6 +330,22 @@ def test_discover_oidc(mock_responses: RequestsMock):
         authorization_endpoint="https://idp.example.com/authorize",
         token_endpoint="https://idp.example.com/token",
     )
+
+
+def test_discover_oidc_rejects_insecure_device_endpoint(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "device_authorization_endpoint": "http://idp.example.com/device",
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="must use HTTPS"):
+        sso_login.discover_oidc("https://idp.example.com")
 
 
 def test_discover_oidc_missing_endpoint(mock_responses: RequestsMock):
@@ -804,3 +838,304 @@ def test_pkce_login_times_out_without_a_callback():
 
     with pytest.raises(TimeoutError):
         sso_login.pkce_login(idp_config, discovery, timeout=0.2)
+
+
+@pytest.fixture
+def device_idp_config() -> sso_login.IdpConfig:
+    return sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid", "offline_access"),
+        auth_methods=("pkce", "device_code"),
+    )
+
+
+@pytest.fixture
+def device_discovery() -> sso_login.OidcDiscovery:
+    return sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+        device_authorization_endpoint="https://idp.example.com/device",
+    )
+
+
+@pytest.fixture
+def slept(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Records poll waits instead of actually sleeping through them."""
+    waits: list[float] = []
+    monkeypatch.setattr(sso_login.time, "sleep", waits.append)
+    return waits
+
+
+def _add_device_authorization(
+    mock_responses: RequestsMock,
+    **overrides: object,
+) -> None:
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/device",
+        json={
+            "device_code": "fake-device-code",
+            "user_code": "WDBX-1234",
+            "verification_uri": "https://idp.example.com/activate",
+            "expires_in": 600,
+            "interval": 5,
+            **overrides,
+        },
+    )
+
+
+def test_device_code_login_full_flow(
+    mock_responses: RequestsMock,
+    device_idp_config: sso_login.IdpConfig,
+    device_discovery: sso_login.OidcDiscovery,
+    slept: list[float],
+    capsys: pytest.CaptureFixture,
+):
+    _add_device_authorization(mock_responses)
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"error": "authorization_pending"},
+        status=400,
+    )
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    result = sso_login.device_code_login(device_idp_config, device_discovery)
+
+    assert result == Account(
+        id_token="fake-id-token",
+        refresh_token="fake-refresh-token",
+        token_endpoint="https://idp.example.com/token",
+        client_id="wandb-cli",
+    )
+    assert slept == [5.0, 5.0]
+
+    output = capsys.readouterr().err
+    assert "https://idp.example.com/activate" in output
+    assert "WDBX-1234" in output
+
+    device_request = urllib.parse.parse_qs(mock_responses.calls[0].request.body)
+    assert device_request["client_id"] == ["wandb-cli"]
+    assert device_request["scope"] == ["openid offline_access"]
+
+    poll_request = urllib.parse.parse_qs(mock_responses.calls[1].request.body)
+    assert poll_request["grant_type"] == [
+        "urn:ietf:params:oauth:grant-type:device_code"
+    ]
+    assert poll_request["device_code"] == ["fake-device-code"]
+    assert poll_request["client_id"] == ["wandb-cli"]
+
+
+def test_device_code_login_opens_browser_to_complete_uri(
+    mock_responses: RequestsMock,
+    device_idp_config: sso_login.IdpConfig,
+    device_discovery: sso_login.OidcDiscovery,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+):
+    _add_device_authorization(
+        mock_responses,
+        verification_uri_complete="https://idp.example.com/activate?user_code=WDBX-1234",
+    )
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    opened_urls: list[str] = []
+    monkeypatch.setattr(
+        sso_login.webbrowser, "open", lambda url: opened_urls.append(url) or True
+    )
+
+    sso_login.device_code_login(device_idp_config, device_discovery)
+
+    assert opened_urls == ["https://idp.example.com/activate?user_code=WDBX-1234"]
+    output = capsys.readouterr().err
+    assert "Opened https://idp.example.com/activate?user_code=WDBX-1234" in output
+    assert "WDBX-1234" in output
+
+
+def test_device_code_login_falls_back_when_browser_fails_to_open(
+    mock_responses: RequestsMock,
+    device_idp_config: sso_login.IdpConfig,
+    device_discovery: sso_login.OidcDiscovery,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+):
+    _add_device_authorization(mock_responses)
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    def fake_open(url: str) -> bool:
+        raise sso_login.webbrowser.Error("no browser found")
+
+    monkeypatch.setattr(sso_login.webbrowser, "open", fake_open)
+
+    sso_login.device_code_login(device_idp_config, device_discovery)
+
+    output = capsys.readouterr().err
+    assert "Open this URL to log in:" in output
+    assert "https://idp.example.com/activate" in output
+    assert "WDBX-1234" in output
+
+
+def test_device_code_login_backs_off_on_slow_down(
+    mock_responses: RequestsMock,
+    device_idp_config: sso_login.IdpConfig,
+    device_discovery: sso_login.OidcDiscovery,
+    slept: list[float],
+):
+    _add_device_authorization(mock_responses)
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"error": "slow_down"},
+        status=400,
+    )
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    sso_login.device_code_login(device_idp_config, device_discovery)
+
+    assert slept == [5.0, 10.0]
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        ("access_denied", "the request was denied"),
+        ("expired_token", "the code expired"),
+        ("invalid_client", "HTTP 400"),
+    ],
+)
+def test_device_code_login_surfaces_idp_errors(
+    mock_responses: RequestsMock,
+    device_idp_config: sso_login.IdpConfig,
+    device_discovery: sso_login.OidcDiscovery,
+    slept: list[float],
+    error: str,
+    message: str,
+):
+    _add_device_authorization(mock_responses)
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"error": error},
+        status=400,
+    )
+
+    with pytest.raises(AuthenticationError, match=message):
+        sso_login.device_code_login(device_idp_config, device_discovery)
+
+
+def test_device_code_login_times_out(
+    mock_responses: RequestsMock,
+    device_idp_config: sso_login.IdpConfig,
+    device_discovery: sso_login.OidcDiscovery,
+    slept: list[float],
+):
+    _add_device_authorization(mock_responses, expires_in=0)
+
+    with pytest.raises(AuthenticationError, match="Timed out"):
+        sso_login.device_code_login(device_idp_config, device_discovery)
+
+    # The code was already expired, so it never polled.
+    assert len(mock_responses.calls) == 1
+
+
+def test_device_code_login_requires_a_device_endpoint(
+    device_idp_config: sso_login.IdpConfig,
+):
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+    with pytest.raises(AuthenticationError, match="does not support device code"):
+        sso_login.device_code_login(device_idp_config, discovery)
+
+
+def test_device_code_login_rejects_malformed_authorization(
+    mock_responses: RequestsMock,
+    device_idp_config: sso_login.IdpConfig,
+    device_discovery: sso_login.OidcDiscovery,
+):
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/device",
+        json={"device_code": "fake-device-code"},  # missing user_code
+    )
+
+    with pytest.raises(
+        AuthenticationError, match="invalid device authorization response"
+    ):
+        sso_login.device_code_login(device_idp_config, device_discovery)
+
+
+def test_login_with_device_code_requires_server_support(
+    mock_responses: RequestsMock,
+):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com",
+            "client_id": "wandb-cli",
+            "auth_methods": ["pkce"],
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="does not offer device code login"):
+        sso_login.login_with_device_code(HostUrl("https://my-wandb.example.com"))
+
+
+def test_login_with_device_code_records_host_and_org(
+    mock_responses: RequestsMock,
+    slept: list[float],
+):
+    mock_responses.add(
+        "GET",
+        "https://my-wandb.example.com/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com",
+            "client_id": "wandb-cli",
+            "auth_methods": ["pkce", "device_code"],
+        },
+    )
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "device_authorization_endpoint": "https://idp.example.com/device",
+        },
+    )
+    _add_device_authorization(mock_responses)
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    result = sso_login.login_with_device_code(
+        HostUrl("https://my-wandb.example.com"),
+        org="acme",
+    )
+
+    assert result.host == "https://my-wandb.example.com"
+    assert result.org == "acme"
+    assert result.id_token == "fake-id-token"

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -446,8 +446,17 @@ def _login_with_key(key, host, cloud, relogin, anonymously, verify, no_offline=F
     help="""Where to save the credentials obtained from the login.
     Defaults to identity_token.json in the W&B config directory.""",
 )
+@click.option(
+    "--use-device-code",
+    "use_device_code",
+    is_flag=True,
+    default=False,
+    help="""Use device authorization. Choose this over SSH, in a container,
+    or anywhere else without a browser; W&B prints a URL and code that can
+    be opened on another device.""",
+)
 @display_error
-def _login_sso(host, org, issuer, client_id, token_file):
+def _login_sso(host, org, issuer, client_id, token_file, use_device_code):
     """Log in via your organization's identity provider (SSO).
 
     For W&B SaaS, name your organization and its identity provider, so W&B
@@ -458,6 +467,10 @@ def _login_sso(host, org, issuer, client_id, token_file):
     For a dedicated or self-hosted instance, pass its URL:
 
         $ wandb login sso --host https://my-wandb-server.example.com
+
+    On a machine without a browser, approve the login on another device:
+
+        $ wandb login sso --use-device-code
     """
     settings = wandb_setup.singleton().settings
     host_url = (
@@ -502,7 +515,11 @@ def _login_sso(host, org, issuer, client_id, token_file):
     expected = (
         sso_login.ExpectedIdp(issuer=issuer, client_id=client_id) if org else None
     )
-    account = sso_login.login_with_pkce(host_url, org=org, expected=expected)
+    account = (
+        sso_login.login_with_device_code(host_url, org=org, expected=expected)
+        if use_device_code
+        else sso_login.login_with_pkce(host_url, org=org, expected=expected)
+    )
 
     # Verify using a staging file holding only the new account, so that a
     # login that turns out to be unusable leaves saved accounts in place.

--- a/wandb/sdk/lib/wbauth/sso_login.py
+++ b/wandb/sdk/lib/wbauth/sso_login.py
@@ -25,6 +25,14 @@ from .identity_token_file import Account
 _DEFAULT_SCOPES = ("openid", "profile", "email", "offline_access")
 _LOGIN_TIMEOUT_SECONDS = 300.0
 
+# The device flow gets longer than the PKCE flow because the user may be
+# walking over to another device to approve it.
+_DEVICE_LOGIN_TIMEOUT_SECONDS = 900.0
+_DEVICE_POLL_INTERVAL_SECONDS = 5.0
+_MIN_DEVICE_POLL_INTERVAL_SECONDS = 1.0
+_DEVICE_SLOW_DOWN_INCREMENT_SECONDS = 5.0
+_DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
+
 
 @dataclasses.dataclass(frozen=True)
 class IdpConfig:
@@ -56,6 +64,7 @@ class OidcDiscovery:
 
     authorization_endpoint: str
     token_endpoint: str
+    device_authorization_endpoint: str | None = None
 
     iss_parameter_supported: bool = False
     """Whether the IdP promises to identify itself in authorization responses.
@@ -122,6 +131,13 @@ def _parse_discovery(body: object, *, issuer: str) -> OidcDiscovery:
         raise ValueError(
             f"discovery issuer {discovered_issuer!r} does not match {issuer!r}"
         )
+    # Only IdPs that enable the device grant publish this endpoint, so its
+    # absence is not an error until a device-code login asks for it.
+    device_endpoint = body.get("device_authorization_endpoint")
+    if device_endpoint is not None:
+        device_endpoint = _secure_url(
+            device_endpoint, name="device_authorization_endpoint"
+        )
 
     iss_supported = body.get("authorization_response_iss_parameter_supported", False)
     if not isinstance(iss_supported, bool):
@@ -134,6 +150,7 @@ def _parse_discovery(body: object, *, issuer: str) -> OidcDiscovery:
             body["authorization_endpoint"], name="authorization_endpoint"
         ),
         token_endpoint=_secure_url(body["token_endpoint"], name="token_endpoint"),
+        device_authorization_endpoint=device_endpoint,
         iss_parameter_supported=iss_supported,
     )
 
@@ -221,7 +238,7 @@ def login_with_pkce(
     _check_auth_method(
         idp_config,
         "pkce",
-        f"{host} does not offer browser login.",
+        f"{host} does not offer browser login. Add --use-device-code to your command.",
     )
 
     discovery = discover_oidc(idp_config.issuer)
@@ -231,6 +248,31 @@ def login_with_pkce(
             discovery,
             success_redirect_url=f"{host.url}/cli-login-success",
         ),
+        host=host.url,
+        org=org,
+    )
+
+
+def login_with_device_code(
+    host: HostUrl,
+    *,
+    org: str | None = None,
+    expected: ExpectedIdp | None = None,
+) -> Account:
+    """Runs discovery and a device authorization login."""
+    idp_config = fetch_idp_config(host, org=org)
+    if expected:
+        check_expected_idp(idp_config, expected, org=org)
+    _check_auth_method(
+        idp_config,
+        "device_code",
+        f"{host} does not offer device code login. Remove --use-device-code"
+        " and try again.",
+    )
+
+    discovery = discover_oidc(idp_config.issuer)
+    return dataclasses.replace(
+        device_code_login(idp_config, discovery),
         host=host.url,
         org=org,
     )
@@ -343,6 +385,226 @@ def pkce_login(
         code_verifier=code_verifier,
         nonce=nonce,
     )
+
+
+def device_code_login(
+    idp_config: IdpConfig,
+    discovery: OidcDiscovery,
+    *,
+    timeout: float = _DEVICE_LOGIN_TIMEOUT_SECONDS,
+) -> Account:
+    """Performs a device authorization login, per RFC 8628.
+
+    This prints the IdP's verification URL and user code, and opens the URL
+    in a local browser if there is one. The flow works headless either way:
+    it exists for machines with no browser at all, and for users who prefer
+    to approve the login from a phone or another computer.
+    """
+    if not discovery.device_authorization_endpoint:
+        raise AuthenticationError(
+            f"The identity provider at {idp_config.issuer} does not support"
+            " device code login. Ask a W&B admin to enable the device"
+            " authorization grant on the CLI's OAuth client, or remove"
+            " --use-device-code and try again."
+        )
+
+    # Keycloak (and possibly other IdPs) requires PKCE on the device
+    # authorization request whenever the client has PKCE enforced, even
+    # though RFC 8628 itself doesn't mention PKCE.
+    code_verifier, code_challenge = _new_pkce_pair()
+
+    authorization = _request_device_code(
+        discovery.device_authorization_endpoint,
+        client_id=idp_config.client_id,
+        scopes=idp_config.scopes,
+        code_challenge=code_challenge,
+    )
+
+    prefilled = authorization.verification_uri_complete
+    url = prefilled or authorization.verification_uri
+
+    term.termlog(
+        (
+            f"Opened {url} in your browser."
+            if _try_open_browser(url)
+            else f"Open this URL to log in:\n{url}"
+        )
+        + f"\nThen enter the code: {authorization.user_code}"
+    )
+
+    return _poll_for_device_token(
+        discovery.token_endpoint,
+        client_id=idp_config.client_id,
+        authorization=authorization,
+        code_verifier=code_verifier,
+        timeout=timeout,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class _DeviceAuthorization:
+    """A device authorization response, per RFC 8628 section 3.2."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str | None
+    expires_in: float
+    interval: float
+
+
+def _parse_device_authorization(body: object) -> _DeviceAuthorization:
+    if not isinstance(body, dict):
+        raise TypeError("response must be an object")
+
+    device_code = body["device_code"]
+    user_code = body["user_code"]
+    if not isinstance(device_code, str) or not device_code:
+        raise TypeError("device_code must be a non-empty string")
+    if not isinstance(user_code, str) or not user_code:
+        raise TypeError("user_code must be a non-empty string")
+
+    complete = body.get("verification_uri_complete")
+    if complete is not None:
+        complete = _secure_url(complete, name="verification_uri_complete")
+
+    return _DeviceAuthorization(
+        device_code=device_code,
+        user_code=user_code,
+        verification_uri=_secure_url(
+            body["verification_uri"],
+            name="verification_uri",
+        ),
+        verification_uri_complete=complete,
+        expires_in=_seconds(
+            body.get("expires_in"),
+            name="expires_in",
+            default=_DEVICE_LOGIN_TIMEOUT_SECONDS,
+        ),
+        # Floored so that an IdP reporting 0 doesn't turn the poll loop
+        # into a hot loop against its own token endpoint.
+        interval=max(
+            _seconds(
+                body.get("interval"),
+                name="interval",
+                default=_DEVICE_POLL_INTERVAL_SECONDS,
+            ),
+            _MIN_DEVICE_POLL_INTERVAL_SECONDS,
+        ),
+    )
+
+
+def _seconds(value: object, *, name: str, default: float) -> float:
+    """Reads an optional duration in seconds from a device-flow response."""
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise TypeError(f"{name} must be a non-negative number")
+    return float(value)
+
+
+def _request_device_code(
+    endpoint: str,
+    *,
+    client_id: str,
+    scopes: Sequence[str],
+    code_challenge: str,
+) -> _DeviceAuthorization:
+    """Requests a device code and user code (RFC 8628 section 3.1)."""
+    try:
+        response = requests.post(
+            endpoint,
+            data={
+                "client_id": client_id,
+                "scope": " ".join(scopes),
+                "code_challenge": code_challenge,
+                "code_challenge_method": "S256",
+            },
+            timeout=env.get_http_timeout(10),
+            allow_redirects=False,
+        )
+    except requests.RequestException as e:
+        raise AuthenticationError(
+            f"Failed to reach the identity provider at {endpoint}: {e}"
+        ) from None
+
+    if response.status_code != 200:
+        raise AuthenticationError(
+            "The identity provider rejected the device login request:"
+            f" {_token_error_detail(response)}"
+        )
+
+    try:
+        return _parse_device_authorization(response.json())
+    except (ValueError, KeyError, TypeError) as e:
+        raise AuthenticationError(
+            f"{endpoint} returned an invalid device authorization response: {e}"
+        ) from None
+
+
+def _poll_for_device_token(
+    token_endpoint: str,
+    *,
+    client_id: str,
+    authorization: _DeviceAuthorization,
+    code_verifier: str,
+    timeout: float,
+) -> Account:
+    """Polls for the user's approval (RFC 8628 sections 3.4 and 3.5)."""
+    interval = authorization.interval
+    deadline = time.monotonic() + min(authorization.expires_in, timeout)
+
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AuthenticationError(
+                "Timed out waiting for the SSO login to be approved. Run the"
+                " command again to start over."
+            )
+        # Sleeping before the first poll avoids a request that is certain to
+        # be pending, since the user has not opened the URL yet.
+        time.sleep(min(interval, remaining))
+
+        try:
+            response = requests.post(
+                token_endpoint,
+                data={
+                    "grant_type": _DEVICE_CODE_GRANT,
+                    "client_id": client_id,
+                    "device_code": authorization.device_code,
+                    "code_verifier": code_verifier,
+                },
+                timeout=env.get_http_timeout(10),
+                allow_redirects=False,
+            )
+        except requests.RequestException as e:
+            raise AuthenticationError(
+                f"Failed to reach the identity provider at {token_endpoint}: {e}"
+            ) from None
+
+        if response.status_code == 200:
+            return _token_set(
+                response,
+                token_endpoint=token_endpoint,
+                client_id=client_id,
+            )
+
+        error = _oauth_error_code(response)
+        if error == "authorization_pending":
+            continue
+        if error == "slow_down":
+            interval += _DEVICE_SLOW_DOWN_INCREMENT_SECONDS
+            continue
+        if error == "access_denied":
+            raise AuthenticationError("SSO login failed: the request was denied.")
+        if error == "expired_token":
+            raise AuthenticationError(
+                "SSO login failed: the code expired before the login was"
+                " approved. Run the command again to start over."
+            )
+        raise AuthenticationError(
+            f"The identity provider rejected the login: {_token_error_detail(response)}"
+        )
 
 
 def _try_open_browser(url: str) -> bool:
@@ -637,6 +899,15 @@ def _jwt_claims(token: str) -> dict[str, object]:
     except (ValueError, TypeError):
         return {}
     return claims if isinstance(claims, dict) else {}
+
+
+def _oauth_error_code(response: requests.Response) -> str | None:
+    """Returns the OAuth `error` code from a failed token response."""
+    try:
+        error = response.json().get("error")
+    except (ValueError, TypeError, AttributeError):
+        return None
+    return error if isinstance(error, str) else None
 
 
 def _token_error_detail(response: requests.Response) -> str:


### PR DESCRIPTION
## Summary
- add OAuth device authorization for headless and remote environments
- open the verification URI when possible and print the approval code otherwise
- handle polling intervals, backoff, denial, expiration, and malformed IdP responses

## Test plan
- [x] `./.venv/bin/python -m pytest tests/unit_tests/test_cli_login_sso.py tests/unit_tests/test_lib/test_auth_sso_login.py -q`
- [x] combined stack: 115 focused Python tests and `cd core && go test ./internal/api`

## Stack
1. [Core refresh foundation](https://github.com/wandb/wandb/pull/12777)
2. [Python identity account management](https://github.com/wandb/wandb/pull/12778)
3. [PKCE SSO login](https://github.com/wandb/wandb/pull/12779)
4. **Device-code SSO login (this PR)**

Made with [Cursor](https://cursor.com)