### PR TITLE
refactor: emit post-Handler records from the TensorBoard integration

### DIFF
--- a/core/internal/runsync/wire_gen.go
+++ b/core/internal/runsync/wire_gen.go
@@ -92,8 +92,9 @@ func InjectRunSyncerFactory(settings2 *settings.Settings, logger *observability.
 		HistoryStepTracker:      historyStepTracker,
 	}
 	tbHandlerFactory := &tensorboard.TBHandlerFactory{
-		Logger:   logger,
-		Settings: settings2,
+		Logger:    logger,
+		RunHandle: runHandle,
+		Settings:  settings2,
 	}
 	runSyncerFactory := &RunSyncerFactory{
 		Logger:              logger,

--- a/core/internal/stream/wire_gen.go
+++ b/core/internal/stream/wire_gen.go
@@ -116,8 +116,9 @@ func InjectStream(commit GitCommitHash, xpuResourceManager *monitor.XPUResourceM
 		HistoryStepTracker:      historyStepTracker,
 	}
 	tbHandlerFactory := &tensorboard.TBHandlerFactory{
-		Logger:   coreLogger,
-		Settings: settings2,
+		Logger:    coreLogger,
+		RunHandle: runHandle,
+		Settings:  settings2,
 	}
 	writerFactory := &WriterFactory{
 		Logger:   coreLogger,

--- a/core/internal/tensorboard/emitter.go
+++ b/core/internal/tensorboard/emitter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wandb/wandb/core/internal/paths"
 	"github.com/wandb/wandb/core/internal/pathtree"
 	"github.com/wandb/wandb/core/internal/randomid"
+	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/wbvalue"
@@ -59,11 +60,15 @@ type tfEmitter struct {
 	hasWallTime bool
 	tfWallTime  float64
 
-	settings *settings.Settings
+	runHandle *runhandle.RunHandle
+	settings  *settings.Settings
 }
 
-func NewTFEmitter(s *settings.Settings) *tfEmitter {
-	return &tfEmitter{settings: s}
+func NewTFEmitter(
+	runHandle *runhandle.RunHandle,
+	s *settings.Settings,
+) *tfEmitter {
+	return &tfEmitter{runHandle: runHandle, settings: s}
 }
 
 // Emit sends accumulated data to the run.
@@ -97,7 +102,6 @@ func (e *tfEmitter) filesRecord() *spb.Record {
 	}
 
 	return &spb.Record{
-		Control: &spb.Control{Local: true},
 		RecordType: &spb.Record_Files{
 			Files: &spb.FilesRecord{
 				Files: files,
@@ -121,7 +125,6 @@ func (e *tfEmitter) configRecord() *spb.Record {
 	}
 
 	return &spb.Record{
-		Control: &spb.Control{Local: true},
 		RecordType: &spb.Record_Config{
 			Config: &spb.ConfigRecord{
 				Update: items,
@@ -135,7 +138,13 @@ func (e *tfEmitter) historyRecord() *spb.Record {
 		return nil
 	}
 
-	var items []*spb.HistoryItem
+	items := []*spb.HistoryItem{
+		{
+			Key:       "_runtime",
+			ValueJson: fmt.Sprintf("%f", e.runHandle.Runtime().Seconds()),
+		},
+	}
+
 	for _, value := range e.historyStep {
 		items = append(items,
 			&spb.HistoryItem{
@@ -161,19 +170,9 @@ func (e *tfEmitter) historyRecord() *spb.Record {
 	}
 
 	return &spb.Record{
-		Control: &spb.Control{Local: true},
-		RecordType: &spb.Record_Request{
-			Request: &spb.Request{
-				RequestType: &spb.Request_PartialHistory{
-					PartialHistory: &spb.PartialHistoryRequest{
-						Item: items,
-
-						// Setting "Flush" indicates that the event should be uploaded as
-						// its own history row, rather than combined with future events.
-						// Future events may contain new values for the same keys.
-						Action: &spb.HistoryAction{Flush: true},
-					},
-				},
+		RecordType: &spb.Record_History{
+			History: &spb.HistoryRecord{
+				Item: items,
 			},
 		},
 	}

--- a/core/internal/tensorboard/emitter_test.go
+++ b/core/internal/tensorboard/emitter_test.go
@@ -3,6 +3,8 @@ package tensorboard_test
 import (
 	"path/filepath"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,6 +12,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/wandb/wandb/core/internal/pathtree"
+	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runworktest"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/tensorboard"
@@ -17,27 +20,18 @@ import (
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
 
-func localFlushPartialHistory(items []*spb.HistoryItem) *spb.Record {
+func historyRecord(items []*spb.HistoryItem) *spb.Record {
 	return &spb.Record{
-		Control: &spb.Control{Local: true},
-		RecordType: &spb.Record_Request{
-			Request: &spb.Request{
-				RequestType: &spb.Request_PartialHistory{
-					PartialHistory: &spb.PartialHistoryRequest{
-						Item: items,
-						Action: &spb.HistoryAction{
-							Flush: true,
-						},
-					},
-				},
+		RecordType: &spb.Record_History{
+			History: &spb.HistoryRecord{
+				Item: items,
 			},
 		},
 	}
 }
 
-func localConfigUpdate(items []*spb.ConfigItem) *spb.Record {
+func configRecord(items []*spb.ConfigItem) *spb.Record {
 	return &spb.Record{
-		Control: &spb.Control{Local: true},
 		RecordType: &spb.Record_Config{
 			Config: &spb.ConfigRecord{
 				Update: items,
@@ -53,7 +47,10 @@ func assertProtoEqual(t *testing.T, expected, actual proto.Message) {
 }
 
 func TestAccumulatesHistory(t *testing.T) {
-	emitter := tensorboard.NewTFEmitter(settings.From(&spb.Settings{}))
+	emitter := tensorboard.NewTFEmitter(
+		runhandle.New(),
+		settings.From(&spb.Settings{}),
+	)
 
 	emitter.EmitHistory(pathtree.PathOf("x", "y"), "0.5")
 	emitter.EmitHistory(pathtree.PathOf("z"), `"abc"`)
@@ -63,35 +60,50 @@ func TestAccumulatesHistory(t *testing.T) {
 	records := fakeRunWork.AllRecords()
 	assert.Len(t, records, 1)
 	assertProtoEqual(t,
-		localFlushPartialHistory([]*spb.HistoryItem{
+		historyRecord([]*spb.HistoryItem{
+			{Key: "_runtime", ValueJson: "0.000000"},
 			{NestedKey: []string{"x", "y"}, ValueJson: "0.5"},
 			{NestedKey: []string{"z"}, ValueJson: `"abc"`},
 		}),
 		records[0])
 }
 
-func TestStepAndWallTime(t *testing.T) {
-	emitter := tensorboard.NewTFEmitter(settings.From(&spb.Settings{}))
+func TestRequiredKeys(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		runHandle := runhandle.New()
+		runHandle.ResumeRunTimer()
+		synctest.Sleep(time.Minute + time.Second)
 
-	emitter.SetTFStep(9)
-	emitter.SetTFWallTime(2.5)
-	emitter.EmitHistory(pathtree.PathOf("x"), "4")
-	fakeRunWork := runworktest.New()
-	emitter.Emit(fakeRunWork)
+		emitter := tensorboard.NewTFEmitter(
+			runHandle,
+			settings.From(&spb.Settings{}),
+		)
 
-	records := fakeRunWork.AllRecords()
-	assert.Len(t, records, 1)
-	assertProtoEqual(t,
-		localFlushPartialHistory([]*spb.HistoryItem{
-			{NestedKey: []string{"x"}, ValueJson: "4"},
-			{Key: "global_step", ValueJson: "9"},
-			{Key: "_timestamp", ValueJson: "2.5"},
-		}),
-		records[0])
+		emitter.SetTFStep(9)
+		emitter.SetTFWallTime(2.5)
+		emitter.EmitHistory(pathtree.PathOf("x"), "4")
+		fakeRunWork := runworktest.New()
+		emitter.Emit(fakeRunWork)
+		fakeRunWork.Close()
+
+		records := fakeRunWork.AllRecords()
+		assert.Len(t, records, 1)
+		assertProtoEqual(t,
+			historyRecord([]*spb.HistoryItem{
+				{Key: "_runtime", ValueJson: "61.000000"},
+				{NestedKey: []string{"x"}, ValueJson: "4"},
+				{Key: "global_step", ValueJson: "9"},
+				{Key: "_timestamp", ValueJson: "2.5"},
+			}),
+			records[0])
+	})
 }
 
 func TestChartModifiesConfig(t *testing.T) {
-	emitter := tensorboard.NewTFEmitter(settings.From(&spb.Settings{}))
+	emitter := tensorboard.NewTFEmitter(
+		runhandle.New(),
+		settings.From(&spb.Settings{}),
+	)
 	chart := wbvalue.Chart{Title: "test-title"}
 	expectedConfigJSON, err := chart.ConfigValueJSON()
 	require.NoError(t, err)
@@ -100,11 +112,12 @@ func TestChartModifiesConfig(t *testing.T) {
 		emitter.EmitChart("mychart", chart))
 	fakeRunWork := runworktest.New()
 	emitter.Emit(fakeRunWork)
+	fakeRunWork.Close()
 
 	records := fakeRunWork.AllRecords()
 	assert.Len(t, records, 1)
 	assertProtoEqual(t,
-		localConfigUpdate([]*spb.ConfigItem{
+		configRecord([]*spb.ConfigItem{
 			{
 				NestedKey: chart.ConfigKey("mychart").Labels(),
 				ValueJson: expectedConfigJSON},
@@ -116,7 +129,7 @@ func TestTableWritesToFile(t *testing.T) {
 	s := settings.From(&spb.Settings{
 		SyncDir: wrapperspb.String(t.TempDir()),
 	})
-	emitter := tensorboard.NewTFEmitter(s)
+	emitter := tensorboard.NewTFEmitter(runhandle.New(), s)
 	table := wbvalue.Table{
 		ColumnLabels: []string{"a", "b"},
 		Rows:         [][]any{{1, 2}, {3, 4}},
@@ -126,6 +139,7 @@ func TestTableWritesToFile(t *testing.T) {
 		emitter.EmitTable(pathtree.PathOf("my", "table"), table))
 	fakeRunWork := runworktest.New()
 	emitter.Emit(fakeRunWork)
+	fakeRunWork.Close()
 
 	records := fakeRunWork.AllRecords()
 	require.Len(t, records, 2) // file upload & history
@@ -141,10 +155,12 @@ func TestTableWritesToFile(t *testing.T) {
 
 func TestTableUpdatesHistory(t *testing.T) {
 	emitter := tensorboard.NewTFEmitter(
+		runhandle.New(),
 		settings.From(&spb.Settings{
 			SyncDir: wrapperspb.String(t.TempDir()),
 		}),
 	)
+
 	table := wbvalue.Table{
 		ColumnLabels: []string{"a", "b"},
 		Rows:         [][]any{{1, 2}, {3, 4}},
@@ -154,20 +170,21 @@ func TestTableUpdatesHistory(t *testing.T) {
 		emitter.EmitTable(pathtree.PathOf("my", "table"), table))
 	fakeRunWork := runworktest.New()
 	emitter.Emit(fakeRunWork)
+	fakeRunWork.Close()
 
 	records := fakeRunWork.AllRecords()
 	require.Len(t, records, 2)
-	partialHistory := records[1].GetRequest().GetPartialHistory()
-	require.NotNil(t, partialHistory)
-	require.Len(t, partialHistory.Item, 1)
-	assert.Equal(t, partialHistory.Item[0].NestedKey, []string{"my", "table"})
+	history := records[1].GetHistory()
+	require.NotNil(t, history)
+	require.Len(t, history.Item, 2)
+	assert.Equal(t, history.Item[1].NestedKey, []string{"my", "table"})
 }
 
 func TestEmitImages(t *testing.T) {
 	s := settings.From(&spb.Settings{
 		SyncDir: wrapperspb.String(t.TempDir()),
 	})
-	emitter := tensorboard.NewTFEmitter(s)
+	emitter := tensorboard.NewTFEmitter(runhandle.New(), s)
 	require.NoError(t,
 		emitter.EmitImages(
 			pathtree.PathOf("my", "image"),
@@ -188,6 +205,7 @@ func TestEmitImages(t *testing.T) {
 		))
 	fakeRunWork := runworktest.New()
 	emitter.Emit(fakeRunWork)
+	fakeRunWork.Close()
 
 	records := fakeRunWork.AllRecords()
 	require.Len(t, records, 2) // file upload & history

--- a/core/internal/tensorboard/tbwork.go
+++ b/core/internal/tensorboard/tbwork.go
@@ -42,7 +42,18 @@ func (w *TBWork) Schedule(wg *sync.WaitGroup, proceed func()) {
 }
 
 // ToRecord implements WorkImpl.ToRecord.
-func (w *TBWork) ToRecord() *spb.Record { return w.Record }
+func (w *TBWork) ToRecord() *spb.Record {
+	// TBRecord used to be written to the transaction log, but now we write
+	// the generated records instead. This simplifies syncing logic.
+	//
+	// TODO: Replace TBRecord by a TBRequest.
+	if w.Record.GetControl() == nil {
+		w.Record.Control = &spb.Control{}
+	}
+	w.Record.Control.Local = true
+
+	return w.Record
+}
 
 // DebugInfo implements WorkImpl.DebugInfo
 func (w *TBWork) DebugInfo() string {

--- a/core/internal/tensorboard/tensorboard.go
+++ b/core/internal/tensorboard/tensorboard.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/wandb/wandb/core/internal/observability"
 	"github.com/wandb/wandb/core/internal/paths"
+	"github.com/wandb/wandb/core/internal/runhandle"
 	"github.com/wandb/wandb/core/internal/runwork"
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/tensorboard/tbproto"
@@ -51,6 +52,7 @@ type TBHandler struct {
 	rootDirGuesser *RootDirGuesser
 	extraWork      runwork.ExtraWork
 	logger         *observability.CoreLogger
+	runHandle      *runhandle.RunHandle
 	settings       *settings.Settings
 	fileReadDelay  time.Duration
 
@@ -60,8 +62,9 @@ type TBHandler struct {
 
 // TBHandlerFactory constructs a TBHandler.
 type TBHandlerFactory struct {
-	Logger   *observability.CoreLogger
-	Settings *settings.Settings
+	Logger    *observability.CoreLogger
+	RunHandle *runhandle.RunHandle
+	Settings  *settings.Settings
 }
 
 func (f *TBHandlerFactory) New(
@@ -72,6 +75,7 @@ func (f *TBHandlerFactory) New(
 		rootDirGuesser: NewRootDirGuesser(f.Logger),
 		extraWork:      extraWork,
 		logger:         f.Logger,
+		runHandle:      f.RunHandle,
 		settings:       f.Settings,
 		fileReadDelay:  fileReadDelay,
 
@@ -298,11 +302,11 @@ func (tb *TBHandler) convertToRunHistory(
 		)
 
 		if emitter == nil {
-			emitter = NewTFEmitter(tb.settings)
+			emitter = NewTFEmitter(tb.runHandle, tb.settings)
 			emitterStep = event.Step
 		} else if emitterStep != event.Step {
 			emitter.Emit(tb.extraWork)
-			emitter = NewTFEmitter(tb.settings)
+			emitter = NewTFEmitter(tb.runHandle, tb.settings)
 			emitterStep = event.Step
 		}
 

--- a/core/internal/transactionlog/transactionlog.go
+++ b/core/internal/transactionlog/transactionlog.go
@@ -9,7 +9,7 @@ import "errors"
 // files in a new format. It may also prevent the next SDK version from reading
 // old .wandb files, depending on the implementation of ensureSupportedVersion.
 // Update the error messages below.
-const wandbStoreVersion = 0
+const wandbStoreVersion = 1
 
 // ensureSupportedVersion returns an error for an unsupported version.
 //
@@ -18,6 +18,9 @@ const wandbStoreVersion = 0
 // the user when using `wandb sync`.
 func ensureSupportedVersion(version uint8) error {
 	switch {
+	case version < 1:
+		return errors.New("wandb<=0.30.0 is required to read this file")
+
 	case version > wandbStoreVersion:
 		// In this case, we can't provide any more useful info unless we
 		// attempt to read the SDK version from the file.
@@ -26,10 +29,9 @@ func ensureSupportedVersion(version uint8) error {
 		return errors.New("a newer wandb version is required to read this file")
 
 	case version < wandbStoreVersion:
-		// This is not currently possible, but it's here as a safe default.
+		// This is a fallback that should never be reached.
 		//
-		// When we do bump `wandbStoreVersion`, we should ensure this message
-		// includes the required wandb Python version.
+		// Add cases above for specific old versions.
 		return errors.New("an older wandb version is required to read this file")
 
 	default:

--- a/core/internal/transactionlog/transactionlog_test.go
+++ b/core/internal/transactionlog/transactionlog_test.go
@@ -273,8 +273,8 @@ func Test_Read_VerifiesHeader(t *testing.T) {
 
 func Test_Read_UnsupportedNewVersion(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "run.wandb")
-	// The file version is the 0x01 byte at the end.
-	require.NoError(t, os.WriteFile(path, []byte(":W&B\xE1\xBE\x01"), 0o644))
+	// The file version is the 0x99 byte at the end.
+	require.NoError(t, os.WriteFile(path, []byte(":W&B\xE1\xBE\x99"), 0o644))
 
 	reader, err := transactionlog.OpenReader(path, observabilitytest.NewTestLogger(t))
 	require.NoError(t, err)
@@ -283,6 +283,20 @@ func Test_Read_UnsupportedNewVersion(t *testing.T) {
 
 	assert.ErrorContains(t, err,
 		"a newer wandb version is required to read this file")
+}
+
+func Test_Read_UnsupportedOldVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.wandb")
+	// The file version is the 0x01 byte at the end.
+	require.NoError(t, os.WriteFile(path, []byte(":W&B\xE1\xBE\x00"), 0o644))
+
+	reader, err := transactionlog.OpenReader(path, observabilitytest.NewTestLogger(t))
+	require.NoError(t, err)
+	_, err = reader.Read()
+	reader.Close()
+
+	assert.ErrorContains(t, err,
+		"wandb<=0.30.0 is required to read this file")
 }
 
 func Test_ReadAfterSeek_SkipsVerifyingHeader(t *testing.T) {


### PR DESCRIPTION
Changes our TensorBoard integration to emit complete records, specifically `HistoryRecord` instead of `PartialHistoryRequest`. This is necessary to merge the `Schedule` and `Accept` methods of `runwork.Work`, which is itself necessary to get rid of the `RunStartRequest`, which is necessary for making `wandb.init()` async.

This is only possible now that #12666 is merged, because the TensorBoard integration has no way of assigning `_step` itself.

TODO: We also need to make the Sender compute summaries.

The records created by the integration are now saved to the transaction log instead of TBRecord. Since these records don't contain `_step` (relying on the Sender), the resulting transaction log cannot be synced by older SDKs. For this reason, I bumped `wandbStoreVersion` in `transactionlog.go`.