### PR TITLE
Validate the authorization response issuer in SSO login

### DIFF
--- a/tests/unit_tests/test_lib/test_auth_sso_login.py
+++ b/tests/unit_tests/test_lib/test_auth_sso_login.py
@@ -275,6 +275,172 @@ def test_discover_oidc_rejects_issuer_mismatch(mock_responses: RequestsMock):
         sso_login.discover_oidc("https://idp.example.com")
 
 
+def test_discover_oidc_reads_iss_parameter_support(mock_responses: RequestsMock):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "authorization_response_iss_parameter_supported": True,
+        },
+    )
+
+    result = sso_login.discover_oidc("https://idp.example.com")
+
+    assert result.iss_parameter_supported
+
+
+def test_discover_oidc_rejects_malformed_iss_parameter_support(
+    mock_responses: RequestsMock,
+):
+    mock_responses.add(
+        "GET",
+        "https://idp.example.com/.well-known/openid-configuration",
+        json={
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "authorization_response_iss_parameter_supported": "yes",
+        },
+    )
+
+    with pytest.raises(AuthenticationError, match="must be a boolean"):
+        sso_login.discover_oidc("https://idp.example.com")
+
+
+def test_authorization_code_accepts_matching_iss():
+    code = sso_login._authorization_code(
+        {"state": ["s"], "code": ["c"], "iss": ["https://idp.example.com/"]},
+        expected_state="s",
+        expected_issuer="https://idp.example.com",
+    )
+
+    assert code == "c"
+
+
+def test_authorization_code_rejects_foreign_iss():
+    with pytest.raises(AuthenticationError, match="attacker.example.com"):
+        sso_login._authorization_code(
+            {"state": ["s"], "code": ["c"], "iss": ["https://attacker.example.com"]},
+            expected_state="s",
+            expected_issuer="https://idp.example.com",
+        )
+
+
+def test_authorization_code_tolerates_missing_iss():
+    code = sso_login._authorization_code(
+        {"state": ["s"], "code": ["c"]},
+        expected_state="s",
+        expected_issuer="https://idp.example.com",
+    )
+
+    assert code == "c"
+
+
+def test_authorization_code_requires_iss_when_advertised():
+    with pytest.raises(AuthenticationError, match="did not"):
+        sso_login._authorization_code(
+            {"state": ["s"], "code": ["c"]},
+            expected_state="s",
+            expected_issuer="https://idp.example.com",
+            require_issuer=True,
+        )
+
+
+def test_authorization_code_surfaces_idp_error_before_checking_iss():
+    with pytest.raises(AuthenticationError, match="Consent required"):
+        sso_login._authorization_code(
+            {
+                "error": ["access_denied"],
+                "error_description": ["Consent required"],
+                "iss": ["https://attacker.example.com"],
+            },
+            expected_state="s",
+            expected_issuer="https://idp.example.com",
+        )
+
+
+def test_pkce_login_rejects_response_from_another_issuer(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_hitting_callback(
+        monkeypatch,
+        extra_params={"iss": "https://attacker.example.com"},
+    )
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+    )
+
+    with pytest.raises(AuthenticationError, match="attacker.example.com"):
+        sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    # The code never reached the token endpoint.
+    assert len(mock_responses.calls) == 0
+
+
+def test_pkce_login_accepts_response_carrying_its_own_issuer(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_hitting_callback(
+        monkeypatch,
+        extra_params={"iss": "https://idp.example.com"},
+    )
+    mock_responses.add(
+        "POST",
+        "https://idp.example.com/token",
+        json={"id_token": "fake-id-token", "refresh_token": "fake-refresh-token"},
+    )
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+        iss_parameter_supported=True,
+    )
+
+    result = sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    assert result.id_token == "fake-id-token"
+
+
+def test_pkce_login_requires_iss_from_an_idp_that_advertises_it(
+    mock_responses: RequestsMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_hitting_callback(monkeypatch)
+
+    idp_config = sso_login.IdpConfig(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+        scopes=("openid",),
+    )
+    discovery = sso_login.OidcDiscovery(
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+        iss_parameter_supported=True,
+    )
+
+    with pytest.raises(AuthenticationError, match="identifies itself"):
+        sso_login.pkce_login(idp_config, discovery, timeout=10)
+
+    assert len(mock_responses.calls) == 0
+
+
 def test_exchange_code_requires_refresh_token(mock_responses: RequestsMock):
     mock_responses.add(
         "POST",
@@ -412,6 +578,7 @@ def _simulate_browser_hitting_callback(
     *,
     code: str = "fake-auth-code",
     omit_state: bool = False,
+    extra_params: dict[str, str] | None = None,
 ) -> list[str]:
     """Makes webbrowser.open() redirect to the loopback callback."""
     opened_urls: list[str] = []
@@ -420,7 +587,7 @@ def _simulate_browser_hitting_callback(
         opened_urls.append(auth_url)
         query = urllib.parse.parse_qs(urllib.parse.urlparse(auth_url).query)
         redirect_uri = query["redirect_uri"][0]
-        params = {"code": code}
+        params = {"code": code, **(extra_params or {})}
         if not omit_state:
             params["state"] = query["state"][0]
 

--- a/wandb/sdk/lib/wbauth/sso_login.py
+++ b/wandb/sdk/lib/wbauth/sso_login.py
@@ -58,6 +58,14 @@ class OidcDiscovery:
     token_endpoint: str
     device_authorization_endpoint: str | None = None
 
+    iss_parameter_supported: bool = False
+    """Whether the IdP promises to identify itself in authorization responses.
+
+    When true, a response without an `iss` parameter is rejected (RFC 9207
+    section 2.4). When false the parameter is still checked if it arrives,
+    since an IdP may send it without advertising it.
+    """
+
 
 def _parse_idp_config(body: object) -> IdpConfig:
     if not isinstance(body, dict):
@@ -123,12 +131,19 @@ def _parse_discovery(body: object, *, issuer: str) -> OidcDiscovery:
             device_endpoint, name="device_authorization_endpoint"
         )
 
+    iss_supported = body.get("authorization_response_iss_parameter_supported", False)
+    if not isinstance(iss_supported, bool):
+        raise TypeError(
+            "authorization_response_iss_parameter_supported must be a boolean"
+        )
+
     return OidcDiscovery(
         authorization_endpoint=_secure_url(
             body["authorization_endpoint"], name="authorization_endpoint"
         ),
         token_endpoint=_secure_url(body["token_endpoint"], name="token_endpoint"),
         device_authorization_endpoint=device_endpoint,
+        iss_parameter_supported=iss_supported,
     )
 
 
@@ -291,7 +306,12 @@ def pkce_login(
     finally:
         server.server_close()
 
-    code = _authorization_code(params, expected_state=state)
+    code = _authorization_code(
+        params,
+        expected_state=state,
+        expected_issuer=idp_config.issuer,
+        require_issuer=discovery.iss_parameter_supported,
+    )
 
     return _exchange_code(
         discovery.token_endpoint,
@@ -643,11 +663,18 @@ def _wait_for_callback(
     return server.callback_params  # type: ignore[attr-defined]
 
 
-def _authorization_code(params: dict[str, list[str]], *, expected_state: str) -> str:
+def _authorization_code(
+    params: dict[str, list[str]],
+    *,
+    expected_state: str,
+    expected_issuer: str | None = None,
+    require_issuer: bool = False,
+) -> str:
     """Extracts and validates the authorization code."""
-    # Checked before the state so that an IdP that rejects the login says
-    # why, rather than being reported as a state mismatch: RFC 6749 asks
-    # the IdP to echo the state on errors, but not every one does.
+    # Checked before the state and the issuer so that an IdP that rejects
+    # the login says why, rather than being reported as a state mismatch:
+    # RFC 6749 asks the IdP to echo the state on errors, but not every one
+    # does, and an error response carries no code to be confused about.
     if error := params.get("error", [None])[0]:
         description = params.get("error_description", [error])[0]
         raise AuthenticationError(f"SSO login failed: {description}")
@@ -658,6 +685,13 @@ def _authorization_code(params: dict[str, list[str]], *, expected_state: str) ->
             " request. Please try again." + (f" (got {state!r})" if state else "")
         )
 
+    if expected_issuer:
+        _check_response_issuer(
+            params,
+            expected=expected_issuer,
+            required=require_issuer,
+        )
+
     if not (code := params.get("code", [None])[0]):
         raise AuthenticationError(
             "SSO login failed: the identity provider's redirect did not"
@@ -665,6 +699,35 @@ def _authorization_code(params: dict[str, list[str]], *, expected_state: str) ->
         )
 
     return code
+
+
+def _check_response_issuer(
+    params: dict[str, list[str]],
+    *,
+    expected: str,
+    required: bool,
+) -> None:
+    """Rejects an authorization response from an unexpected IdP (RFC 9207).
+
+    Every organization brings its own authorization server, so this client
+    talks to many of them. Without this check, a code minted by one of them
+    could be redeemed at another's token endpoint -- the mix-up attack the
+    `iss` parameter exists to stop.
+    """
+    if (issuer := params.get("iss", [None])[0]) is None:
+        if required:
+            raise AuthenticationError(
+                "SSO login failed: the identity provider says it identifies"
+                " itself in authorization responses, but this one did not."
+                " Please try again."
+            )
+        return
+
+    if issuer.rstrip("/") != expected.rstrip("/"):
+        raise AuthenticationError(
+            f"SSO login failed: the redirect came from {issuer!r}, but the"
+            f" login was sent to {expected!r}."
+        )
 
 
 def _parse_token_response(body: object) -> tuple[str, str]:


### PR DESCRIPTION
Stacked on #12780.

## Summary

Every organization brings its own authorization server, so `wandb login sso` talks to many of them. Without an `iss` check, an authorization code minted by one could be redeemed at another's token endpoint — the mix-up attack RFC 9207 exists to stop.

- `discover_oidc` now reads `authorization_response_iss_parameter_supported` from the IdP's discovery document.
- The PKCE callback validates `iss` against the issuer the login was sent to whenever the parameter arrives, and requires it from an IdP that advertises support.
- IdP error responses still surface their own message first, since an error carries no code to be confused about.

This is distinct from the pre-flight config comparison in the follow-up PR: that one asks "is this the issuer the org registered", this one asks "did the server that answered match the one I dialed".

## Test plan

- [ ] `pytest tests/unit_tests/test_lib/test_auth_sso_login.py`

Made with [Cursor](https://cursor.com)