### PR TITLE
Stop trusting a typed organization name in SSO login

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -16,7 +16,7 @@ Section headings should be at level 3 (e.g. `### Added`).
 
 ### Added
 
-- `wandb login sso` logs in through your organization's identity provider in a browser, instead of an API key. Pass `--org` for a multi-tenant SaaS organization or `--host` for a dedicated or self-hosted instance. On a machine with no browser, `--use-device-code` prints a URL and a code to approve from a phone or another computer. The resulting credentials are saved to `identity_token.json` in the W&B config directory, one entry per account, and wandb-core refreshes them as they expire.
+- `wandb login sso` logs in through your organization's identity provider in a browser, instead of an API key. On multi-tenant SaaS, run it with no flags and pick your organization from a list of the ones you belong to; to name one on the command line instead, pass `--org` together with `--issuer` and `--client-id`, which are checked against the identity provider that organization registered before anything is sent to it. Pass `--host` for a dedicated or self-hosted instance, which serves a single organization and resolves it automatically. On a machine with no browser, `--use-device-code` prints a URL and a code to approve from a phone or another computer. The resulting credentials are saved to `identity_token.json` in the W&B config directory, one entry per account, and wandb-core refreshes them as they expire.
 
 ### Changed
 

--- a/tests/unit_tests/test_cli_login_sso.py
+++ b/tests/unit_tests/test_cli_login_sso.py
@@ -14,8 +14,8 @@ from wandb.sdk.lib.wbauth import identity_token_file
 def fake_pkce_login(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
     calls: list[dict] = []
 
-    def fake_login_with_pkce(host, *, org=None):
-        calls.append({"host": host, "org": org})
+    def fake_login_with_pkce(host, *, org=None, expected=None):
+        calls.append({"host": host, "org": org, "expected": expected})
         return identity_token_file.Account(
             id_token="fake-id-token",
             refresh_token="fake-refresh-token",
@@ -38,8 +38,8 @@ def fake_pkce_login(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
 def fake_device_code_login(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
     calls: list[dict] = []
 
-    def fake_login_with_device_code(host, *, org=None):
-        calls.append({"host": host, "org": org})
+    def fake_login_with_device_code(host, *, org=None, expected=None):
+        calls.append({"host": host, "org": org, "expected": expected})
         return identity_token_file.Account(
             id_token="fake-device-id-token",
             refresh_token="fake-device-refresh-token",
@@ -62,6 +62,28 @@ def fake_device_code_login(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
     return calls
 
 
+@pytest.fixture
+def fake_org_picker(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Stands in for the W&B page that lists the user's organizations."""
+    calls = []
+
+    def fake_select_organization(host):
+        calls.append(host)
+        return "picked-org"
+
+    monkeypatch.setattr(cli.sso_login, "select_organization", fake_select_organization)
+    return calls
+
+
+@pytest.fixture
+def saas_base_url(local_settings):
+    """Points the CLI at multi-tenant SaaS, as a fresh install would be."""
+    system_settings = cli.wandb_setup.singleton().settings.read_system_settings()
+    system_settings.set("base_url", "https://api.wandb.ai", globally=True)
+    system_settings.save()
+    cli.wandb_setup.singleton().settings.update_from_system_settings()
+
+
 def _read_system_settings(path: pathlib.Path) -> dict[str, str]:
     parser = configparser.ConfigParser()
     parser.read(path)
@@ -75,6 +97,8 @@ def test_sso_login_help(runner):
     assert "identity provider" in result.output
     assert "--host" in result.output
     assert "--org" in result.output
+    assert "--issuer" in result.output
+    assert "--client-id" in result.output
     assert "--use-device-code" in result.output
 
 
@@ -167,42 +191,133 @@ def test_sso_login_uses_device_code(
     assert fake_device_code_login[0]["host"].is_same_url("https://my-wandb.example.com")
 
 
-def test_sso_login_requires_org_for_saas(runner, local_settings):
+def test_sso_login_rejects_saas_as_a_host(runner, local_settings):
     result = runner.invoke(
         cli.cli,
         ["login", "sso", "--host", "https://api.wandb.ai"],
     )
 
     assert result.exit_code == 2
-    assert "Pass --org instead of --host" in result.output
+    assert "serves many organizations" in result.output
 
 
-def test_sso_login_rejects_host_and_org_together(runner, local_settings):
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--org", "acme"],
+        ["--issuer", "https://idp.example.com"],
+        ["--client-id", "wandb-cli"],
+    ],
+)
+def test_sso_login_rejects_host_with_org_flags(runner, local_settings, extra):
     result = runner.invoke(
         cli.cli,
-        ["login", "sso", "--host", "https://my-wandb.example.com", "--org", "acme"],
+        ["login", "sso", "--host", "https://my-wandb.example.com", *extra],
     )
 
     assert result.exit_code == 2
-    assert "but not both" in result.output
+    assert "resolves its own identity provider" in result.output
 
 
-def test_sso_login_requires_org_or_host(runner, local_settings):
-    result = runner.invoke(cli.cli, ["login", "sso"])
+@pytest.mark.parametrize(
+    ("flags", "missing"),
+    [
+        (["--org", "acme"], "--issuer, --client-id"),
+        (["--org", "acme", "--issuer", "https://idp.example.com"], "--client-id"),
+        (["--org", "acme", "--client-id", "wandb-cli"], "--issuer"),
+        (["--issuer", "https://idp.example.com", "--client-id", "wandb-cli"], "--org"),
+    ],
+)
+def test_sso_login_org_requires_its_identity_provider(
+    runner,
+    saas_base_url,
+    fake_pkce_login: list[dict],
+    fake_org_picker: list,
+    flags,
+    missing,
+):
+    result = runner.invoke(cli.cli, ["login", "sso", *flags])
 
     assert result.exit_code == 2
-    assert "--org" in result.output
-    assert "--host" in result.output
+    assert f"Add {missing}" in result.output
+    assert fake_pkce_login == []
+    assert fake_org_picker == []
 
 
-def test_sso_login_org_only_uses_configured_base_url(
+def test_sso_login_with_explicit_org_checks_the_named_provider(
+    runner,
+    saas_base_url,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+    fake_org_picker: list,
+):
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--org",
+            "acme",
+            "--issuer",
+            "https://idp.example.com",
+            "--client-id",
+            "wandb-cli",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_org_picker == []
+    assert len(fake_pkce_login) == 1
+    assert fake_pkce_login[0]["host"].is_same_url("https://api.wandb.ai")
+    assert fake_pkce_login[0]["org"] == "acme"
+    assert fake_pkce_login[0]["expected"] == cli.sso_login.ExpectedIdp(
+        issuer="https://idp.example.com",
+        client_id="wandb-cli",
+    )
+
+    # The default host is left implicit rather than pinned in the settings.
+    system_settings_path = pathlib.Path(
+        cli.wandb_setup.singleton().settings.settings_system
+    )
+    assert "base_url" not in _read_system_settings(system_settings_path)
+
+
+def test_sso_login_without_flags_picks_an_org_on_saas(
+    runner,
+    saas_base_url,
+    tmp_path: pathlib.Path,
+    fake_pkce_login: list[dict],
+    fake_org_picker: list,
+):
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(fake_org_picker) == 1
+    assert fake_org_picker[0].is_same_url("https://api.wandb.ai")
+    assert len(fake_pkce_login) == 1
+    assert fake_pkce_login[0]["org"] == "picked-org"
+    assert fake_pkce_login[0]["expected"] is None
+
+
+def test_sso_login_without_flags_skips_the_picker_on_a_dedicated_instance(
     runner,
     local_settings,
     tmp_path: pathlib.Path,
     fake_pkce_login: list[dict],
+    fake_org_picker: list,
 ):
     system_settings = cli.wandb_setup.singleton().settings.read_system_settings()
-    system_settings.set("base_url", "https://api.wandb.ai", globally=True)
+    system_settings.set("base_url", "https://my-wandb.example.com", globally=True)
     system_settings.save()
     cli.wandb_setup.singleton().settings.update_from_system_settings()
 
@@ -211,23 +326,41 @@ def test_sso_login_org_only_uses_configured_base_url(
         [
             "login",
             "sso",
-            "--org",
-            "acme",
             "--identity-token-file",
             str(tmp_path / "identity_token.json"),
         ],
     )
 
     assert result.exit_code == 0, result.output
+    assert fake_org_picker == []
     assert len(fake_pkce_login) == 1
-    assert fake_pkce_login[0]["host"].is_same_url("https://api.wandb.ai")
-    assert fake_pkce_login[0]["org"] == "acme"
+    assert fake_pkce_login[0]["org"] is None
 
-    # The default host is left implicit rather than pinned in the settings.
-    system_settings_path = pathlib.Path(
-        cli.wandb_setup.singleton().settings.settings_system
+
+def test_sso_login_uses_device_code_after_the_picker(
+    runner,
+    saas_base_url,
+    tmp_path: pathlib.Path,
+    fake_device_code_login: list[dict],
+    fake_pkce_login: list[dict],
+    fake_org_picker: list,
+):
+    result = runner.invoke(
+        cli.cli,
+        [
+            "login",
+            "sso",
+            "--use-device-code",
+            "--identity-token-file",
+            str(tmp_path / "identity_token.json"),
+        ],
     )
-    assert "base_url" not in _read_system_settings(system_settings_path)
+
+    assert result.exit_code == 0, result.output
+    assert fake_pkce_login == []
+    assert len(fake_org_picker) == 1
+    assert len(fake_device_code_login) == 1
+    assert fake_device_code_login[0]["org"] == "picked-org"
 
 
 def test_sso_login_replaces_unreadable_credentials(

--- a/tests/unit_tests/test_lib/test_auth_sso_login.py
+++ b/tests/unit_tests/test_lib/test_auth_sso_login.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import http.client
 import json
+import re
 import threading
 import urllib.parse
 import urllib.request
@@ -209,6 +210,107 @@ def test_login_with_pkce_requires_server_support(mock_responses: RequestsMock):
 
     with pytest.raises(AuthenticationError, match="does not offer browser login"):
         sso_login.login_with_pkce(HostUrl("https://my-wandb.example.com"))
+
+
+def _add_cli_config(mock_responses: RequestsMock, **overrides: object) -> None:
+    mock_responses.add(
+        "GET",
+        "https://api.wandb.ai/oidc/cli_config",
+        json={
+            "issuer": "https://idp.example.com",
+            "client_id": "wandb-cli",
+            **overrides,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("registered", "named", "message"),
+    [
+        (
+            {"issuer": "https://idp.example.com"},
+            {"issuer": "https://acme-login.example"},
+            "its issuer is 'https://idp.example.com'",
+        ),
+        (
+            {"client_id": "wandb-cli"},
+            {"client_id": "attacker-cli"},
+            "its client ID is 'wandb-cli'",
+        ),
+    ],
+)
+def test_login_with_pkce_aborts_on_a_provider_the_org_did_not_register(
+    mock_responses: RequestsMock,
+    registered: dict,
+    named: dict,
+    message: str,
+):
+    _add_cli_config(mock_responses, **registered)
+    expected = sso_login.ExpectedIdp(
+        **{"issuer": "https://idp.example.com", "client_id": "wandb-cli", **named}
+    )
+
+    with pytest.raises(AuthenticationError, match=re.escape(message)):
+        sso_login.login_with_pkce(
+            HostUrl("https://api.wandb.ai"),
+            org="acme",
+            expected=expected,
+        )
+
+    # Nothing beyond the W&B discovery call was attempted.
+    assert len(mock_responses.calls) == 1
+
+
+def test_login_with_device_code_aborts_on_an_unregistered_provider(
+    mock_responses: RequestsMock,
+):
+    _add_cli_config(mock_responses)
+
+    with pytest.raises(AuthenticationError, match="phishing"):
+        sso_login.login_with_device_code(
+            HostUrl("https://api.wandb.ai"),
+            org="acme",
+            expected=sso_login.ExpectedIdp(
+                issuer="https://acme-login.example",
+                client_id="wandb-cli",
+            ),
+        )
+
+    assert len(mock_responses.calls) == 1
+
+
+def test_check_expected_idp_ignores_a_trailing_slash():
+    sso_login.check_expected_idp(
+        sso_login.IdpConfig(
+            issuer="https://idp.example.com/",
+            client_id="wandb-cli",
+            scopes=("openid",),
+        ),
+        sso_login.ExpectedIdp(
+            issuer="https://idp.example.com",
+            client_id="wandb-cli",
+        ),
+        org="acme",
+    )
+
+
+def test_check_expected_idp_names_both_mismatched_fields():
+    with pytest.raises(AuthenticationError) as excinfo:
+        sso_login.check_expected_idp(
+            sso_login.IdpConfig(
+                issuer="https://idp.example.com",
+                client_id="wandb-cli",
+                scopes=("openid",),
+            ),
+            sso_login.ExpectedIdp(
+                issuer="https://acme-login.example",
+                client_id="attacker-cli",
+            ),
+            org="acme",
+        )
+
+    assert "issuer" in str(excinfo.value)
+    assert "client ID" in str(excinfo.value)
 
 
 def test_discover_oidc(mock_responses: RequestsMock):
@@ -763,6 +865,94 @@ def slept(monkeypatch: pytest.MonkeyPatch) -> list[float]:
     waits: list[float] = []
     monkeypatch.setattr(sso_login.time, "sleep", waits.append)
     return waits
+
+
+def _simulate_browser_picking_an_org(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    organization: str | None = "acme",
+    state: str | None = None,
+    error: str | None = None,
+) -> list[str]:
+    """Makes webbrowser.open() answer the picker from the loopback port."""
+    opened_urls: list[str] = []
+
+    def fake_open(picker_url: str) -> bool:
+        opened_urls.append(picker_url)
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(picker_url).query)
+        # The page derives the callback from the state, not from a
+        # redirect URL handed to it in the query string.
+        port = query["state"][0].split(".")[0]
+
+        params = {"state": state if state is not None else query["state"][0]}
+        if organization is not None:
+            params["organization"] = organization
+        if error is not None:
+            params["error"] = error
+
+        def hit_callback() -> None:
+            url = f"http://127.0.0.1:{port}/callback?{urllib.parse.urlencode(params)}"
+            urllib.request.urlopen(url, timeout=5)
+
+        threading.Thread(target=hit_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(sso_login.webbrowser, "open", fake_open)
+    return opened_urls
+
+
+def test_select_organization_returns_the_clicked_org(monkeypatch: pytest.MonkeyPatch):
+    opened_urls = _simulate_browser_picking_an_org(monkeypatch, organization="acme")
+
+    org = sso_login.select_organization(HostUrl("https://api.wandb.ai"), timeout=10)
+
+    assert org == "acme"
+    parsed = urllib.parse.urlparse(opened_urls[0])
+    assert parsed.netloc == "wandb.ai"
+    assert parsed.path == "/cli-login"
+    state = urllib.parse.parse_qs(parsed.query)["state"][0]
+    port, _, nonce = state.partition(".")
+    assert 0 < int(port) < 65536
+    assert nonce
+
+
+def test_select_organization_rejects_a_foreign_state(monkeypatch: pytest.MonkeyPatch):
+    _simulate_browser_picking_an_org(monkeypatch, state="12345.not-our-nonce")
+
+    with pytest.raises(AuthenticationError, match="a different login"):
+        sso_login.select_organization(HostUrl("https://api.wandb.ai"), timeout=10)
+
+
+def test_select_organization_requires_an_organization(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _simulate_browser_picking_an_org(monkeypatch, organization=None)
+
+    with pytest.raises(AuthenticationError, match="which organization"):
+        sso_login.select_organization(HostUrl("https://api.wandb.ai"), timeout=10)
+
+
+def test_select_organization_rejects_a_malformed_name(monkeypatch: pytest.MonkeyPatch):
+    _simulate_browser_picking_an_org(monkeypatch, organization="acme corp")
+
+    with pytest.raises(AuthenticationError, match="not a valid organization name"):
+        sso_login.select_organization(HostUrl("https://api.wandb.ai"), timeout=10)
+
+
+def test_select_organization_surfaces_a_page_error(monkeypatch: pytest.MonkeyPatch):
+    _simulate_browser_picking_an_org(
+        monkeypatch,
+        organization=None,
+        error="no_organizations",
+    )
+
+    with pytest.raises(AuthenticationError, match="no_organizations"):
+        sso_login.select_organization(HostUrl("https://api.wandb.ai"), timeout=10)
+
+
+def test_select_organization_times_out_without_a_choice():
+    with pytest.raises(TimeoutError):
+        sso_login.select_organization(HostUrl("https://api.wandb.ai"), timeout=0.2)
 
 
 def _add_device_authorization(

--- a/wandb/cli/cli.py
+++ b/wandb/cli/cli.py
@@ -414,14 +414,29 @@ def _login_with_key(key, host, cloud, relogin, anonymously, verify, no_offline=F
     default=None,
     help="""Log in to a dedicated or self-hosted W&B instance by URL
     (e.g. https://my-wandb.example.com). Such an instance serves a single
-    organization and resolves it automatically. Mutually exclusive
-    with --org.""",
+    organization and resolves its own identity provider, so it cannot be
+    combined with --org, --issuer or --client-id.""",
 )
 @click.option(
     "--org",
     default=None,
-    help="""Log in to an organization on multi-tenant SaaS, whose identity
-    provider is used for the login. Mutually exclusive with --host.""",
+    help="""Log in to a named organization on multi-tenant SaaS. Requires
+    --issuer and --client-id, which are checked against the identity
+    provider the organization has registered. Omit all three to choose
+    your organization from a list instead.""",
+)
+@click.option(
+    "--issuer",
+    default=None,
+    help="""The OIDC issuer URL of the organization's identity provider.
+    Used with --org and --client-id.""",
+)
+@click.option(
+    "--client-id",
+    "client_id",
+    default=None,
+    help="""The OAuth client ID the organization registered for CLI login.
+    Used with --org and --issuer.""",
 )
 @click.option(
     "--identity-token-file",
@@ -440,12 +455,18 @@ def _login_with_key(key, host, cloud, relogin, anonymously, verify, no_offline=F
     be opened on another device.""",
 )
 @display_error
-def _login_sso(host, org, token_file, use_device_code):
+def _login_sso(host, org, issuer, client_id, token_file, use_device_code):
     """Log in via your organization's identity provider (SSO).
 
-    For W&B SaaS, select your organization:
+    For W&B SaaS, pick your organization from a list in the browser:
 
-        $ wandb login sso --org my-org
+        $ wandb login sso
+
+    To name it on the command line instead, say which identity provider it
+    should be, so W&B can check that against the one your organization
+    registered:
+
+        $ wandb login sso --org ORG --issuer URL --client-id ID
 
     For a dedicated or self-hosted instance, pass its URL:
 
@@ -453,19 +474,37 @@ def _login_sso(host, org, token_file, use_device_code):
 
     On a machine without a browser, approve the login on another device:
 
-        $ wandb login sso --org my-org --use-device-code
+        $ wandb login sso --use-device-code
     """
     settings = wandb_setup.singleton().settings
-    if bool(host) == bool(org):
+    if host and (org or issuer or client_id):
         raise click.UsageError(
-            "Pass --host for a dedicated or self-hosted instance, or --org"
-            " for a multi-tenant SaaS organization, but not both."
+            "--host names a dedicated or self-hosted instance, which serves a"
+            " single organization and resolves its own identity provider."
+            " Drop --org, --issuer and --client-id."
         )
     if host and saas.is_wandb_domain(host):
         raise click.UsageError(
             f"{host} is multi-tenant SaaS, which serves many organizations."
-            " Pass --org instead of --host to choose one."
+            " Run `wandb login sso` with no flags to choose one."
         )
+    if (org or issuer or client_id) and not (org and issuer and client_id):
+        missing = ", ".join(
+            name
+            for name, value in (
+                ("--org", org),
+                ("--issuer", issuer),
+                ("--client-id", client_id),
+            )
+            if not value
+        )
+        raise click.UsageError(
+            "Naming an organization means naming its identity provider too,"
+            " so that W&B can check it against the one the organization"
+            f" registered. Add {missing}, or run `wandb login sso` with no"
+            " flags to choose your organization from a list."
+        )
+
     host_url = (
         wbauth.HostUrl(host)
         if host
@@ -476,10 +515,19 @@ def _login_sso(host, org, token_file, use_device_code):
     ).expanduser()
 
     wandb.termlog(f"Logging in to {host_url} via SSO...")
+
+    expected = (
+        sso_login.ExpectedIdp(issuer=issuer, client_id=client_id) if org else None
+    )
+    if not org and saas.is_wandb_domain(host_url.url):
+        # Only multi-tenant SaaS needs an organization; a single-tenant
+        # instance has exactly one and resolves it server-side.
+        org = sso_login.select_organization(host_url)
+
     account = (
-        sso_login.login_with_device_code(host_url, org=org)
+        sso_login.login_with_device_code(host_url, org=org, expected=expected)
         if use_device_code
-        else sso_login.login_with_pkce(host_url, org=org)
+        else sso_login.login_with_pkce(host_url, org=org, expected=expected)
     )
 
     # Verify using a staging file holding only the new account, so that a

--- a/wandb/sdk/lib/wbauth/sso_login.py
+++ b/wandb/sdk/lib/wbauth/sso_login.py
@@ -25,6 +25,9 @@ from .identity_token_file import Account
 _DEFAULT_SCOPES = ("openid", "profile", "email", "offline_access")
 _LOGIN_TIMEOUT_SECONDS = 300.0
 
+# The W&B app page that lists the signed-in user's organizations.
+_PICKER_PATH = "/cli-login"
+
 # The device flow gets longer than the PKCE flow because the user may be
 # walking over to another device to approve it.
 _DEVICE_LOGIN_TIMEOUT_SECONDS = 900.0
@@ -48,6 +51,14 @@ class IdpConfig:
     None if the server did not say, in which case the CLI attempts whichever
     flow the user asked for and lets the IdP reject it.
     """
+
+
+@dataclasses.dataclass(frozen=True)
+class ExpectedIdp:
+    """The identity provider a user named on the command line."""
+
+    issuer: str
+    client_id: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -217,9 +228,90 @@ def discover_oidc(issuer: str) -> OidcDiscovery:
         ) from None
 
 
-def login_with_pkce(host: HostUrl, *, org: str | None = None) -> Account:
+def select_organization(
+    host: HostUrl,
+    *,
+    timeout: float = _LOGIN_TIMEOUT_SECONDS,
+) -> str:
+    """Asks the W&B app which organization to log in to.
+
+    Opens a page that lists the organizations the signed-in user actually
+    belongs to, and returns the one they click. The name therefore comes
+    back from the server instead of from something the user was told to
+    type, which is what makes it safe to hand to discovery.
+    """
+    server = _callback_server(response_html=_PICKER_HTML)
+    try:
+        state = _picker_state(server.server_address[1])
+        server.expected_state = state  # type: ignore[attr-defined]
+
+        url = f"{host.app_url}{_PICKER_PATH}?" + urllib.parse.urlencode(
+            {"state": state}
+        )
+        if _try_open_browser(url):
+            term.termlog(f"Opened {url} in your browser.")
+        else:
+            term.termlog(f"Open this URL to choose your organization:\n{url}")
+
+        params = _wait_for_callback(server, timeout=timeout)
+    finally:
+        server.server_close()
+
+    return _selected_organization(params, expected_state=state)
+
+
+def _picker_state(port: int) -> str:
+    """Builds the picker's state, which also carries the callback's port.
+
+    The page derives `http://127.0.0.1:<port>/callback` from the state
+    rather than reading a redirect target out of its query string, so the
+    only thing a crafted link can steer is which port on the user's own
+    machine hears the answer (RFC 9700 section 4.11).
+    """
+    return f"{port}.{secrets.token_urlsafe(24)}"
+
+
+def _selected_organization(
+    params: dict[str, list[str]],
+    *,
+    expected_state: str,
+) -> str:
+    """Reads the organization the user clicked out of the page's callback."""
+    if error := params.get("error", [None])[0]:
+        description = params.get("error_description", [error])[0]
+        raise AuthenticationError(f"SSO login failed: {description}")
+
+    state = params.get("state", [""])[0]
+    if not secrets.compare_digest(state, expected_state):
+        raise AuthenticationError(
+            "SSO login failed: the organization was chosen for a different"
+            " login. Please run the command again."
+        )
+
+    org = params.get("organization", [""])[0]
+    if not org:
+        raise AuthenticationError(
+            "SSO login failed: the page did not say which organization was"
+            " chosen. Please run the command again."
+        )
+    if any(char.isspace() or not char.isprintable() for char in org):
+        raise AuthenticationError(
+            f"SSO login failed: {org!r} is not a valid organization name."
+        )
+
+    return org
+
+
+def login_with_pkce(
+    host: HostUrl,
+    *,
+    org: str | None = None,
+    expected: ExpectedIdp | None = None,
+) -> Account:
     """Runs discovery and an Authorization Code + PKCE login."""
     idp_config = fetch_idp_config(host, org=org)
+    if expected:
+        check_expected_idp(idp_config, expected, org=org)
     _check_auth_method(
         idp_config,
         "pkce",
@@ -238,9 +330,16 @@ def login_with_pkce(host: HostUrl, *, org: str | None = None) -> Account:
     )
 
 
-def login_with_device_code(host: HostUrl, *, org: str | None = None) -> Account:
+def login_with_device_code(
+    host: HostUrl,
+    *,
+    org: str | None = None,
+    expected: ExpectedIdp | None = None,
+) -> Account:
     """Runs discovery and a device authorization login."""
     idp_config = fetch_idp_config(host, org=org)
+    if expected:
+        check_expected_idp(idp_config, expected, org=org)
     _check_auth_method(
         idp_config,
         "device_code",
@@ -262,6 +361,38 @@ def _check_auth_method(idp_config: IdpConfig, method: str, message: str) -> None
         raise AuthenticationError(message)
 
 
+def check_expected_idp(
+    idp_config: IdpConfig,
+    expected: ExpectedIdp,
+    *,
+    org: str | None,
+) -> None:
+    """Aborts unless the organization's registered IdP is the one named.
+
+    This runs before any browser opens or any device code is printed. It
+    catches the phish that keeps a real organization name and swaps in a
+    lookalike issuer, which is the half of a pasted command that a user
+    has no way to recognize as wrong.
+    """
+    mismatched = [
+        f"its {name} is {actual!r}, not {wanted!r}"
+        for name, actual, wanted in (
+            ("issuer", idp_config.issuer.rstrip("/"), expected.issuer.rstrip("/")),
+            ("client ID", idp_config.client_id, expected.client_id),
+        )
+        if actual != wanted
+    ]
+    if not mismatched:
+        return
+
+    raise AuthenticationError(
+        f"The identity provider registered for organization {org!r} is not the"
+        f" one you named: {'; '.join(mismatched)}. Nothing was sent to either"
+        " provider. If you did not write this command yourself, treat it as a"
+        " phishing attempt."
+    )
+
+
 def pkce_login(
     idp_config: IdpConfig,
     discovery: OidcDiscovery,
@@ -279,10 +410,10 @@ def pkce_login(
     state = secrets.token_urlsafe(24)
     nonce = secrets.token_urlsafe(24)
 
-    server = http.server.HTTPServer(("127.0.0.1", 0), _CallbackHandler)
-    server.callback_params = None  # type: ignore[attr-defined]
-    server.success_redirect_url = success_redirect_url  # type: ignore[attr-defined]
-    server.expected_state = state  # type: ignore[attr-defined]
+    server = _callback_server(
+        expected_state=state,
+        success_redirect_url=success_redirect_url,
+    )
     try:
         port = server.server_address[1]
         redirect_uri = f"http://127.0.0.1:{port}/callback"
@@ -600,6 +731,30 @@ _CALLBACK_HTML = """\
 </body>
 """
 
+_PICKER_HTML = """\
+<!DOCTYPE html>
+<title>W&B SSO login</title>
+<body style="font-family: sans-serif; text-align: center; margin-top: 15%">
+<h2>Organization selected.</h2>
+<p>Return to the terminal to finish logging in.</p>
+</body>
+"""
+
+
+def _callback_server(
+    *,
+    expected_state: str | None = None,
+    success_redirect_url: str | None = None,
+    response_html: str = _CALLBACK_HTML,
+) -> http.server.HTTPServer:
+    """Binds a loopback server to receive one callback from the browser."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+    server.callback_params = None  # type: ignore[attr-defined]
+    server.expected_state = expected_state  # type: ignore[attr-defined]
+    server.success_redirect_url = success_redirect_url  # type: ignore[attr-defined]
+    server.response_html = response_html  # type: ignore[attr-defined]
+    return server
+
 
 class _CallbackHandler(http.server.BaseHTTPRequestHandler):
     """Handles the IdP's redirect to the PKCE loopback server."""
@@ -631,7 +786,7 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             return
 
-        body = _CALLBACK_HTML.encode()
+        body = getattr(self.server, "response_html", _CALLBACK_HTML).encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Cache-Control", "no-store")


### PR DESCRIPTION
Stacked on #12803.

## Summary

`wandb login sso --org acme` used to let a typed organization name select an identity provider, so a pasted command could send a user to an attacker's IdP under a name they recognized. There are now exactly two ways to name an organization, and neither takes the name on faith.

**Click it.** Bare `wandb login sso` on multi-tenant SaaS opens a W&B page listing the organizations the signed-in user actually belongs to, and the CLI uses whichever one they click. The name comes back from the server, so feeding it to discovery is safe. The CLI binds the callback to the attempt that opened it: the state carries the loopback port, the page derives `http://127.0.0.1:<port>/callback` from the state rather than from a redirect target in its query string, and a state mismatch is rejected.

**Spell it out.** `--org` now requires `--issuer` and `--client-id`. The CLI fetches `GET /oidc/cli_config?organization=<org>` and compares both against what was supplied, aborting with a message naming the mismatched field before any browser opens or any device code is printed.

`--host` is unchanged, and so is a bare invocation against a configured dedicated instance — a single-tenant instance serves one organization and resolves it server-side. `--use-device-code` remains a pure flow selector, valid in any quadrant, with no automatic fallback.

The picker page and its membership query are the matching `wandb/core` work; this PR is the CLI half of that contract.

## Test plan

- [ ] `pytest tests/unit_tests/test_lib/test_auth_sso_login.py tests/unit_tests/test_cli_login_sso.py`
- [ ] End to end against the picker page once the `wandb/core` side lands

Made with [Cursor](https://cursor.com)