### PR TITLE
feat: warn when syncing run generated with newer SDK version

### DIFF
--- a/core/internal/runsync/runinfo.go
+++ b/core/internal/runsync/runinfo.go
@@ -8,6 +8,9 @@ import (
 // RunInfo is basic information about a run that can be extracted from
 // its transaction log.
 type RunInfo struct {
+	// SDKVersion is the version of the SDK that produced the run.
+	SDKVersion string
+
 	// Components of the run's path.
 	//
 	// Entity and Project may be empty to indicate that the user's defaults

--- a/core/internal/runsync/runreader.go
+++ b/core/internal/runsync/runreader.go
@@ -76,6 +76,8 @@ func (r *RunReader) ExtractRunInfo(ctx context.Context) (*RunInfo, error) {
 	}
 	defer reader.Close()
 
+	runInfo := &RunInfo{}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -97,13 +99,16 @@ func (r *RunReader) ExtractRunInfo(ctx context.Context) (*RunInfo, error) {
 			}
 		}
 
-		if run := record.GetRun(); run != nil {
-			return &RunInfo{
-				Entity:    run.Entity,
-				Project:   run.Project,
-				RunID:     run.RunId,
-				StartTime: run.StartTime.AsTime(),
-			}, nil
+		// The Header always appears before the RunRecord.
+		// When we've found the first RunRecord, we are done.
+		if header := record.GetHeader(); header != nil {
+			runInfo.SDKVersion = header.GetVersionInfo().GetProducer()
+		} else if run := record.GetRun(); run != nil {
+			runInfo.Entity = run.Entity
+			runInfo.Project = run.Project
+			runInfo.RunID = run.RunId
+			runInfo.StartTime = run.StartTime.AsTime()
+			return runInfo, nil
 		}
 	}
 }

--- a/core/internal/runsync/runreader_test.go
+++ b/core/internal/runsync/runreader_test.go
@@ -138,11 +138,18 @@ func isExitRecord(code int32) gomock.Matcher {
 	)
 }
 
-func Test_Extract_FindsRunRecord(t *testing.T) {
+func Test_Extract_FindsInformation(t *testing.T) {
 	x := setup(t)
 	startTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	wandbFileWithRecords(t,
 		x.TransactionLog,
+		&spb.Record{RecordType: &spb.Record_Header{
+			Header: &spb.HeaderRecord{
+				VersionInfo: &spb.VersionInfo{
+					Producer: "1.2.3dev+deadbeef",
+				},
+			},
+		}},
 		&spb.Record{RecordType: &spb.Record_Run{
 			Run: &spb.RunRecord{
 				Entity:    "test entity",
@@ -156,10 +163,11 @@ func Test_Extract_FindsRunRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, &runsync.RunInfo{
-		Entity:    "test entity",
-		Project:   "test project",
-		RunID:     "test run ID",
-		StartTime: startTime,
+		SDKVersion: "1.2.3dev+deadbeef",
+		Entity:     "test entity",
+		Project:    "test project",
+		RunID:      "test run ID",
+		StartTime:  startTime,
 	}, runInfo)
 }
 

--- a/core/internal/runsync/runsyncer.go
+++ b/core/internal/runsync/runsyncer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wandb/wandb/core/internal/settings"
 	"github.com/wandb/wandb/core/internal/stream"
 	"github.com/wandb/wandb/core/internal/tensorboard"
+	"github.com/wandb/wandb/core/internal/version"
 	"github.com/wandb/wandb/core/internal/wboperation"
 	spb "github.com/wandb/wandb/core/pkg/service_go_proto"
 )
@@ -113,6 +114,15 @@ func (rs *RunSyncer) Init(ctx context.Context) (*RunInfo, error) {
 	rs.mu.Lock()
 	rs.runInfo = runInfo
 	rs.mu.Unlock()
+
+	// NOTE: Print after setting runInfo for a useful message prefix.
+	if version.Compare(runInfo.SDKVersion, version.Version) > 0 {
+		rs.printer.Warnf(
+			"Syncing a run generated with a newer SDK version (%s) may"+
+				" not work as expected.",
+			version.PyPI(runInfo.SDKVersion),
+		)
+	}
 
 	return runInfo, nil
 }


### PR DESCRIPTION
Adds a vague warning to `wandb sync` when syncing a run made with a newer SDK version.

```
❯ wandb sync wandb/latest-run --no-skip-synced                 
wandb: Syncing 1 run(s):
wandb:   wandb/latest-run/run-w3mjoeuv.wandb
wandb: [wandb sync] Loaded credentials for https://api.wandb.ai from /Users/timoffex/.netrc.
wandb: WARNING [uncategorized/w3mjoeuv] Syncing a run generated with a newer SDK version (v0.30.2) may not work as expected.
wandb: [uncategorized/w3mjoeuv] View run super-wildflower-4791 at https://wandb.ai/wandb/uncategorized/runs/w3mjoeuv
wandb: [uncategorized/w3mjoeuv] Finished syncing wandb/latest-run/run-w3mjoeuv.wandb
```

This will show up if someone logs a run, then downgrades `wandb` before syncing. Or if someone logs on a machine with a newer `wandb` but syncs on a machine with an older `wandb`.

Although we try to be backward and forward compatible, this gives us some wiggle room for making changes that older SDKs might not sync the same way. For instance, I'd like to stop storing generated summary records in the transaction log. Older SDKs can still sync such runs mostly successfully, but their summaries will be incomplete. I think warning the user is nicer than bumping the transaction log version and refusing to sync.

## Testing

I tested by changing the `Version` constant and syncing a run. Unfortunately, this feature is hard to test in any other way. A system test would be ideal, but it would use a hard-coded transaction log and would need an update each time the transaction log version changes.