### PR TITLE
fix(sdk): preserve parent directory for Molecule pathlib.Path input

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -26,3 +26,4 @@ Section headings should be at level 3 (e.g. `### Added`).
 ### Fixed
 
 - Changing system metrics grid rows or columns in LEET, including `wandb leet symon`, no longer crashes and takes effect immediately without waiting for new data (@dmitryduev in https://github.com/wandb/wandb/pull/12763)
+- `wandb.Molecule` no longer drops the parent directory of a `pathlib.Path` input, which previously raised `FileNotFoundError` for files outside the working directory (@pujitha24)

--- a/tests/unit_tests/test_data_types.py
+++ b/tests/unit_tests/test_data_types.py
@@ -876,6 +876,21 @@ def test_molecule_file(mock_run):
     assert os.path.exists(mol._path)
 
 
+def test_molecule_pathlib_path(mock_run):
+    """Ensure that a pathlib.Path with a parent directory is preserved."""
+    run = mock_run()
+    subdir = Path("subdir")
+    subdir.mkdir()
+    path = subdir / "test.pdb"
+    path.write_text("00000")
+
+    mol = wandb.Molecule(path)
+    mol.bind_to_run(run, "rad", "summary")
+    wandb.Molecule.seq_to_json([mol], run, "rad", "summary")
+
+    assert os.path.exists(mol._path)
+
+
 def test_molecule_from_smiles(mock_run):
     """Ensure that wandb.Molecule.from_smiles supports valid SMILES molecule string representations."""
     run = mock_run()

--- a/wandb/sdk/data_types/molecule.py
+++ b/wandb/sdk/data_types/molecule.py
@@ -57,8 +57,10 @@ class Molecule(BatchableMedia):
         """
         super().__init__(caption=caption)
 
-        if hasattr(data_or_path, "name"):
-            # if the file has a path, we just detect the type and copy it from there
+        if hasattr(data_or_path, "name") and not isinstance(data_or_path, pathlib.Path):
+            # if the file has a path, we just detect the type and copy it from there.
+            # this does not work for pathlib.Path objects,
+            # where `.name` returns the last directory in the path.
             data_or_path = data_or_path.name
 
         if hasattr(data_or_path, "read"):


### PR DESCRIPTION
Description
-----------

- Fixes WB-NNNNN
- Fixes #12791

`wandb.Molecule` advertises `pathlib.Path` as a supported constructor input, but
its constructor treats any object with a `.name` attribute as a file handle and
replaces `data_or_path` with `data_or_path.name`. Since `pathlib.Path` objects
also have a `.name` attribute (the basename), a `Path` input was silently
truncated to its basename, dropping the parent directory. The equivalent string
path worked correctly. This PR adds an `isinstance` check to skip the `.name`
shortcut for `pathlib.Path` inputs, mirroring the identical fix already present
in `wandb/sdk/data_types/object_3d.py` for the same root cause.

- [x] I updated CHANGELOG.unreleased.md, or it's not applicable


Testing
-------
How was this PR tested?

Added `test_molecule_pathlib_path` in `tests/unit_tests/test_data_types.py`,
which constructs `wandb.Molecule` from a `pathlib.Path` pointing at a file in a
subdirectory. Confirmed the test fails with `FileNotFoundError` on the
pre-fix code and passes after the fix:

    pytest tests/unit_tests/test_data_types.py -k molecule -q

All 8 molecule tests and the full `tests/unit_tests/test_data_types.py` suite
(131 passed, 1 skipped) pass after the change. Also ran `ruff check`, `ruff
format --check`, and `ty check` on the changed files with no issues.