### PR TITLE
feat(sdk): batch Evaluations EvalTable row uploads

### DIFF
--- a/tests/unit_tests/test_eval_table.py
+++ b/tests/unit_tests/test_eval_table.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ import pytest
 import wandb
 import wandb.data_types as wandb_data_types
 from wandb.errors import UsageError
+from wandb.sdk.data_types import _eval_table_writer
 from wandb.sdk.data_types import eval_table as eval_table_module
 
 
@@ -200,6 +202,131 @@ def test_coreweave_eval_table_writes_columns_rows_and_version(
     assert "evaluate_call_id" not in marker
 
 
+def test_coreweave_eval_table_batches_rows_by_encoded_bytes(
+    mock_coreweave_client,
+    run,
+    monkeypatch,
+):
+    row = {
+        "input": {"prompt": "é" * 40},
+        "output": {"answer": "yes"},
+        "scores": {},
+    }
+    single_row_body_size = len(
+        json.dumps(
+            {"rows": [row]},
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+    )
+    monkeypatch.setattr(
+        _eval_table_writer,
+        "_TARGET_ROW_BATCH_BODY_BYTES",
+        single_row_body_size - 1,
+    )
+    et = wandb.EvalTable(
+        columns=["prompt", "answer"],
+        data=[["é" * 40, "yes"], ["é" * 40, "yes"]],
+        input_columns=["prompt"],
+        output_columns=["answer"],
+        backend="coreweave",
+    )
+
+    run.log({"eval": et})
+
+    calls = mock_coreweave_client.eval_tables.add_rows.call_args_list
+    assert [call.kwargs["rows"] for call in calls] == [[row], [row]]
+    keys = [call.kwargs["idempotency_key"] for call in calls]
+    assert len(set(keys)) == 2
+    assert keys[0].endswith("-rows-0")
+    assert keys[1].endswith("-rows-1")
+
+
+def test_coreweave_eval_table_batches_rows_by_count(
+    mock_coreweave_client,
+    run,
+    monkeypatch,
+):
+    monkeypatch.setattr(_eval_table_writer, "_MAX_ROWS_PER_BATCH", 2)
+    et = wandb.EvalTable(
+        columns=["value"],
+        data=[[index] for index in range(5)],
+        output_columns=["value"],
+        backend="coreweave",
+    )
+
+    run.log({"eval": et})
+
+    calls = mock_coreweave_client.eval_tables.add_rows.call_args_list
+    assert [len(call.kwargs["rows"]) for call in calls] == [2, 2, 1]
+    assert [call[0] for call in mock_coreweave_client.eval_tables.method_calls] == [
+        "create",
+        "create_columns",
+        "add_rows",
+        "add_rows",
+        "add_rows",
+        "create_version",
+    ]
+
+
+def test_coreweave_eval_table_rejects_oversized_row_before_network(
+    mock_coreweave_client,
+    run,
+    monkeypatch,
+):
+    value = "large" * 100
+    row = {
+        "input": {"row": 0},
+        "output": {"value": value},
+        "scores": {},
+    }
+    body_size = len(
+        json.dumps(
+            {"rows": [row]},
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+    )
+    monkeypatch.setattr(_eval_table_writer, "_MAX_BATCH_BODY_BYTES", body_size)
+    et = wandb.EvalTable(
+        columns=["value"],
+        data=[[value]],
+        output_columns=["value"],
+        backend="coreweave",
+    )
+
+    with pytest.raises(UsageError, match="contains a row"):
+        run.log({"eval": et})
+
+    mock_coreweave_client.eval_tables.create.assert_not_called()
+
+
+def test_coreweave_eval_table_does_not_cut_version_after_batch_failure(
+    mock_coreweave_client,
+    run,
+    monkeypatch,
+):
+    monkeypatch.setattr(_eval_table_writer, "_MAX_ROWS_PER_BATCH", 1)
+    mock_coreweave_client.eval_tables.add_rows.side_effect = [
+        None,
+        RuntimeError("batch failed"),
+    ]
+    et = wandb.EvalTable(
+        columns=["value"],
+        data=[[1], [2]],
+        output_columns=["value"],
+        backend="coreweave",
+    )
+
+    with pytest.raises(RuntimeError, match="batch failed"):
+        run.log({"eval": et})
+
+    mock_coreweave_client.eval_tables.create_version.assert_not_called()
+    mock_coreweave_client.close.assert_called_once_with()
+
+
 def test_coreweave_eval_table_infers_python_and_numpy_integers(
     mock_coreweave_client,
     run,
@@ -287,7 +414,9 @@ def test_coreweave_eval_table_requires_base_url(monkeypatch, mock_run):
 def test_coreweave_eval_table_retries_with_stable_idempotency_keys(
     mock_coreweave_client,
     run,
+    monkeypatch,
 ):
+    monkeypatch.setattr(_eval_table_writer, "_MAX_ROWS_PER_BATCH", 1)
     version = SimpleNamespace(
         dataset_version_id="dataset-version-1",
         evaluation_version_id="evaluation-version-1",
@@ -298,7 +427,8 @@ def test_coreweave_eval_table_retries_with_stable_idempotency_keys(
     ]
     et = wandb.EvalTable(
         columns=["value"],
-        data=[[1]],
+        data=[[1], [2]],
+        output_columns=["value"],
         backend="coreweave",
     )
     et.bind_to_run(run, "eval", 0)
@@ -310,13 +440,19 @@ def test_coreweave_eval_table_retries_with_stable_idempotency_keys(
     methods = (
         mock_coreweave_client.eval_tables.create,
         mock_coreweave_client.eval_tables.create_columns,
-        mock_coreweave_client.eval_tables.add_rows,
         mock_coreweave_client.eval_tables.create_version,
     )
     for method in methods:
         calls = method.call_args_list
         assert len(calls) == 2
         assert calls[0].kwargs["idempotency_key"] == calls[1].kwargs["idempotency_key"]
+
+    row_calls = mock_coreweave_client.eval_tables.add_rows.call_args_list
+    assert len(row_calls) == 4
+    first_attempt_keys = [call.kwargs["idempotency_key"] for call in row_calls[:2]]
+    retry_keys = [call.kwargs["idempotency_key"] for call in row_calls[2:]]
+    assert first_attempt_keys == retry_keys
+    assert len(set(first_attempt_keys)) == 2
 
 
 def test_coreweave_eval_table_run_location_stabilizes_idempotency_keys(

--- a/wandb/sdk/data_types/_eval_table_writer.py
+++ b/wandb/sdk/data_types/_eval_table_writer.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import os
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
@@ -26,9 +27,14 @@ EVAL_TABLE_MARKER = {"wandb_eval_table": True}
 _MIN_WEAVE_VERSION = "0.52.41"
 _COREWEAVE_BASE_URL_ENV = "COREWEAVE_EVALUATIONS_BASE_URL"
 _MAX_BATCH_BODY_BYTES = 16 << 20
+# Leave headroom below the server limit and keep failed retries bounded.
+_TARGET_ROW_BATCH_BODY_BYTES = 8 << 20
 _MAX_DATASET_FIELDS = 10_000
-_MAX_ROWS = 10_000
+_MAX_ROWS_PER_BATCH = 10_000
 _MAX_SCORERS = 256
+
+_ROW_BATCH_PREFIX_BYTES = len(b'{"rows":[')
+_ROW_BATCH_SUFFIX_BYTES = len(b"]}")
 
 EvalTableBackend = Literal["weave", "coreweave"]
 PrimitiveValueType = Literal["boolean", "integer", "number", "string"]
@@ -215,7 +221,7 @@ class WeaveEvalTableWriter:
 class _PreparedCoreWeaveWrite:
     dataset_fields: list[dict[str, str]]
     scorers: list[dict[str, str]]
-    rows: list[dict[str, Any]]
+    row_batches: list[list[dict[str, Any]]]
 
 
 class CoreWeaveEvalTableWriter:
@@ -271,12 +277,13 @@ class CoreWeaveEvalTableWriter:
                 scorers=prepared.scorers,
                 idempotency_key=self._idempotency_key("columns"),
             )
-            client.eval_tables.add_rows(
-                created.evaluation_id,
-                project_id=self._project_id,
-                rows=prepared.rows,
-                idempotency_key=self._idempotency_key("rows"),
-            )
+            for batch_index, rows in enumerate(prepared.row_batches):
+                client.eval_tables.add_rows(
+                    created.evaluation_id,
+                    project_id=self._project_id,
+                    rows=rows,
+                    idempotency_key=self._idempotency_key(f"rows-{batch_index}"),
+                )
             version = client.eval_tables.create_version(
                 created.evaluation_id,
                 project_id=self._project_id,
@@ -310,11 +317,6 @@ class CoreWeaveEvalTableWriter:
     def _prepare(self, value: EvalTableWriteInput) -> _PreparedCoreWeaveWrite:
         if not value.rows:
             raise UsageError("CoreWeave EvalTable logging requires at least one row.")
-        if len(value.rows) > _MAX_ROWS:
-            raise UsageError(
-                f"CoreWeave EvalTable logging currently supports at most {_MAX_ROWS} "
-                "rows per table."
-            )
 
         dataset_field_types: dict[tuple[str, str], PrimitiveValueType] = {}
         dataset_field_order: list[tuple[str, str]] = []
@@ -384,12 +386,45 @@ class CoreWeaveEvalTableWriter:
         self._validate_body_size(
             "columns", {"dataset_fields": dataset_fields, "scorers": scorers}
         )
-        self._validate_body_size("rows", {"rows": rows})
         return _PreparedCoreWeaveWrite(
             dataset_fields=dataset_fields,
             scorers=scorers,
-            rows=rows,
+            row_batches=list(self._iter_row_batches(rows)),
         )
+
+    def _iter_row_batches(
+        self,
+        rows: list[dict[str, Any]],
+    ) -> Iterator[list[dict[str, Any]]]:
+        batch: list[dict[str, Any]] = []
+        batch_size = _ROW_BATCH_PREFIX_BYTES + _ROW_BATCH_SUFFIX_BYTES
+
+        for row in rows:
+            row_size = len(self._encode_json(row))
+            single_row_body_size = (
+                _ROW_BATCH_PREFIX_BYTES + row_size + _ROW_BATCH_SUFFIX_BYTES
+            )
+            if single_row_body_size >= _MAX_BATCH_BODY_BYTES:
+                raise UsageError(
+                    "CoreWeave EvalTable rows payload contains a row whose encoded "
+                    "request must be smaller than 16 MiB."
+                )
+
+            separator_size = 1 if batch else 0
+            if batch and (
+                len(batch) >= _MAX_ROWS_PER_BATCH
+                or batch_size + separator_size + row_size > _TARGET_ROW_BATCH_BODY_BYTES
+            ):
+                yield batch
+                batch = []
+                batch_size = _ROW_BATCH_PREFIX_BYTES + _ROW_BATCH_SUFFIX_BYTES
+                separator_size = 0
+
+            batch.append(row)
+            batch_size += separator_size + row_size
+
+        if batch:
+            yield batch
 
     def _prepare_mapping(
         self,
@@ -475,16 +510,18 @@ class CoreWeaveEvalTableWriter:
         )
 
     def _validate_body_size(self, operation: str, body: dict[str, Any]) -> None:
-        encoded = json.dumps(
-            body,
+        if len(self._encode_json(body)) >= _MAX_BATCH_BODY_BYTES:
+            raise UsageError(
+                f"CoreWeave EvalTable {operation} payload must be smaller than 16 MiB."
+            )
+
+    def _encode_json(self, value: Any) -> bytes:
+        return json.dumps(
+            value,
             allow_nan=False,
             ensure_ascii=False,
             separators=(",", ":"),
         ).encode()
-        if len(encoded) >= _MAX_BATCH_BODY_BYTES:
-            raise UsageError(
-                f"CoreWeave EvalTable {operation} payload must be smaller than 16 MiB."
-            )
 
     def _idempotency_key(self, operation: str) -> str:
         if self._idempotency_scope is None:


### PR DESCRIPTION
<!-- git-deck-stack-position:start -->
This PR is 5 of 5 in a Pull Request Stack (see below).
<!-- git-deck-stack-position:end -->

Description
-----------

- https://coreweave.atlassian.net/browse/WB-40378

CES-backed `EvalTable` logging now uploads rows in multiple requests instead of rejecting a table that exceeds one request's limits.

- Batches rows at the smaller of an 8 MiB UTF-8 JSON body or 10,000 rows.
- Sends a row larger than the 8 MiB target by itself when it still fits below the server's 16 MiB request limit.
- Rejects an individual row that cannot fit in a valid request before making any network calls and reports its index.
- Gives each batch a deterministic idempotency key and cuts the `EvaluationVersion` only after every batch succeeds.
- Raises the per-table ceiling from 10,000 to 100,000 rows
- Keeps the batch target internal. This PR does not change the Evaluations API or its server limits.

- [x]  I updated CHANGELOG.unreleased.md, or it's not applicable
  - Not applicable because the CES `EvalTable` backend remains private testing functionality.

Testing
-------

- `.venv/bin/python -m pytest -q tests/unit_tests/test_eval_table.py tests/unit_tests/test_eval_table_weave.py tests/unit_tests/test_eval_table_ces.py tests/unit_tests/test_weave_media_adapters.py tests/unit_tests/test_library_public.py`

<!-- git-deck-stack-section:start -->
---

## Pull Request Stack
> [!WARNING]
> You may not want to merge this PR yet, because it is still stacked on another PR.

Stack root: `main`

1. #12894 `kelu/stabilize-debounced-writer-test`
2. #12812 `kelu/eval-table-writer-backends`
3. #12895 `kelu/eval-table-backend-test-split`
4. #12813 `kelu/eval-table-coreweave-writes`
5. #12816 `kelu/eval-table-coreweave-row-batching` 👈 *YOU ARE HERE*

This PR stack is managed by [git-deck](http://github.com/wandb/git-deck)
<!-- git-deck-stack-section:end -->
